### PR TITLE
Do not truncate node flag strings in debugwindow peers details tab

### DIFF
--- a/src/qt/forms/debugwindow.ui
+++ b/src/qt/forms/debugwindow.ui
@@ -1078,12 +1078,6 @@
                 <height>426</height>
                </rect>
               </property>
-              <property name="minimumSize">
-               <size>
-                <width>300</width>
-                <height>0</height>
-               </size>
-              </property>
               <layout class="QGridLayout" name="gridLayout_2" columnstretch="0,1">
                <item row="0" column="0">
                 <widget class="QLabel" name="label_30">


### PR DESCRIPTION
Fix: When fiddling around with new node flags other than the usual.

I saw that not all possible node flag strings i.e. the UNKNOWN[..] where
visible in peers details tab.
Since v18.2 fixed size was set to 300 and sliding is thereby limited.

A fix on my old linux cruft and small screen was to set minimumSize width to -1 or 0.
Qt will then autosize the slider to the max string length.

Thereby i had full display of all flags inclusive sliding without to fullscreen the window.

Not sure if this is even an issue for those who can afford big screens or high res macs?
Feedback welcome.

BTW: nice side effect now again easy to scroll trough long version names of the node.
can't wait to see strings like /Satoshi:0.23.99/NOX2NOX4NOX32  or what ever fits in the version string.