### PR TITLE
Remove needless headers from qt/walletview.cpp

### DIFF
--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -4,9 +4,6 @@
 
 #include <qt/walletview.h>
 
-#include <node/psbt.h>
-#include <node/transaction.h>
-#include <policy/policy.h>
 #include <qt/addressbookpage.h>
 #include <qt/askpassphrasedialog.h>
 #include <qt/clientmodel.h>
@@ -23,6 +20,7 @@
 #include <qt/walletmodel.h>
 
 #include <interfaces/node.h>
+#include <psbt.h>
 #include <ui_interface.h>
 #include <util/strencodings.h>
 


### PR DESCRIPTION
No symbols from the removed headers are used in the `qt/walletview.cpp`.

This is a small followup of https://github.com/bitcoin/bitcoin/pull/18027.