### PR TITLE
Wrap tooltips in the intro window

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -488,6 +488,9 @@ int GuiMain(int argc, char* argv[])
         return EXIT_SUCCESS;
     }
 
+    // Install global event filter that makes sure that long tooltips can be word-wrapped
+    app.installEventFilter(new GUIUtil::ToolTipToRichTextFilter(TOOLTIP_WRAP_THRESHOLD, &app));
+
     /// 5. Now that settings and translations are available, ask user for data directory
     // User language is set up: pick a data directory
     bool did_show_intro = false;
@@ -559,8 +562,6 @@ int GuiMain(int argc, char* argv[])
 #endif // ENABLE_WALLET
 
     /// 9. Main GUI initialization
-    // Install global event filter that makes sure that long tooltips can be word-wrapped
-    app.installEventFilter(new GUIUtil::ToolTipToRichTextFilter(TOOLTIP_WRAP_THRESHOLD, &app));
     // Install global event filter that makes sure that out-of-focus labels do not contain text cursor.
     app.installEventFilter(new GUIUtil::LabelOutOfFocusEventFilter(&app));
 #if defined(Q_OS_WIN)


### PR DESCRIPTION
On master (d6fe5b28dff4c512bad7c9576232d6def10608d4):

![DeepinScreenshot_select-area_20200702082514](https://user-images.githubusercontent.com/32963518/86319852-18e6e200-bc3e-11ea-902c-1b868540f4cf.png)

With this PR:

![Screenshot from 2020-07-02 08-22-44](https://user-images.githubusercontent.com/32963518/86319881-28fec180-bc3e-11ea-9d76-522a5e71c32d.png)

---

This is a move-only change.

This was done while reviewing #15.