### PR TITLE
Update pruning tooltip, original author BitcoinErrorLog

### DIFF
--- a/src/qt/forms/optionsdialog.ui
+++ b/src/qt/forms/optionsdialog.ui
@@ -55,7 +55,7 @@
         <item>
          <widget class="QCheckBox" name="prune">
           <property name="toolTip">
-           <string>Disables some advanced features but all blocks will still be fully validated. Reverting this setting requires re-downloading the entire blockchain. Actual disk usage may be somewhat higher.</string>
+           <string>Enabling pruning significantly reduces the disk space required to store transactions. All blocks are still fully validated. Reverting this setting requires re-downloading the entire blockchain.</string>
           </property>
           <property name="text">
            <string>Prune &amp;block storage to</string>


### PR DESCRIPTION
Squashed commits from BitcoinErrorLog at his request, per the original discussion on #15: this tooltip has been adjusted to be more user-friendly and reflect what the net effect of pruning is for the user.