### PR TITLE
indicate explicit to the user that the wallet balances shown is watch only.

### DIFF
--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -201,7 +201,10 @@ void OverviewPage::setBalance(const interfaces::WalletBalances& balances)
     m_balances = balances;
     if (walletModel->wallet().isLegacy()) {
         if (walletModel->wallet().privateKeysDisabled()) {
+            ui->labelSpendable->setText(tr("OverviewPage", "Watch-only:"));
+            ui->labelSpendable->setVisible(true);
             ui->labelBalance->setText(BitcoinUnits::formatWithPrivacy(unit, balances.watch_only_balance, BitcoinUnits::SeparatorStyle::ALWAYS, m_privacy));
+            ui->labelBalance->setToolTip(tr("OverviewPage", "Your current balance in watch-only addresses"));
             ui->labelUnconfirmed->setText(BitcoinUnits::formatWithPrivacy(unit, balances.unconfirmed_watch_only_balance, BitcoinUnits::SeparatorStyle::ALWAYS, m_privacy));
             ui->labelImmature->setText(BitcoinUnits::formatWithPrivacy(unit, balances.immature_watch_only_balance, BitcoinUnits::SeparatorStyle::ALWAYS, m_privacy));
             ui->labelTotal->setText(BitcoinUnits::formatWithPrivacy(unit, balances.watch_only_balance + balances.unconfirmed_watch_only_balance + balances.immature_watch_only_balance, BitcoinUnits::SeparatorStyle::ALWAYS, m_privacy));


### PR DESCRIPTION
This little change got me back to earth when i realized that the
balance hint *Your current spendable balance* was just a label and
not the result of of some random pubkey addresses i imported with
importaddress warping into keys for those addresses,

At least for some short moment i felt mainnet btc rich, but this change
in hint wording should be done.

edit@saibato Todo: before merge run translation Makefile after we agree in wording.
