### PR TITLE
Add ability to integrate the client with desktop environment on Linux

### DIFF
--- a/build_msvc/libbitcoin_qt/libbitcoin_qt.vcxproj
+++ b/build_msvc/libbitcoin_qt/libbitcoin_qt.vcxproj
@@ -23,6 +23,7 @@
     <ClCompile Include="..\..\src\qt\createwalletdialog.cpp" />
     <ClCompile Include="..\..\src\qt\csvmodelwriter.cpp" />
     <ClCompile Include="..\..\src\qt\editaddressdialog.cpp" />
+    <ClCompile Include="..\..\src\qt\guifileutil.cpp" />
     <ClCompile Include="..\..\src\qt\guiutil.cpp" />
     <ClCompile Include="..\..\src\qt\intro.cpp" />
     <ClCompile Include="..\..\src\qt\modaloverlay.cpp" />

--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -119,6 +119,7 @@ BITCOIN_QT_H = \
   qt/csvmodelwriter.h \
   qt/editaddressdialog.h \
   qt/guiconstants.h \
+  qt/guifileutil.h \
   qt/guiutil.h \
   qt/intro.h \
   qt/macdockiconhandler.h \
@@ -219,6 +220,7 @@ BITCOIN_QT_BASE_CPP = \
   qt/bitcoinunits.cpp \
   qt/clientmodel.cpp \
   qt/csvmodelwriter.cpp \
+  qt/guifileutil.cpp \
   qt/guiutil.cpp \
   qt/intro.cpp \
   qt/modaloverlay.cpp \

--- a/src/qt/addressbookpage.cpp
+++ b/src/qt/addressbookpage.cpp
@@ -12,6 +12,7 @@
 #include <qt/addresstablemodel.h>
 #include <qt/csvmodelwriter.h>
 #include <qt/editaddressdialog.h>
+#include <qt/guifileutil.h>
 #include <qt/guiutil.h>
 #include <qt/platformstyle.h>
 

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -8,6 +8,7 @@
 #include <qt/clientmodel.h>
 #include <qt/createwalletdialog.h>
 #include <qt/guiconstants.h>
+#include <qt/guifileutil.h>
 #include <qt/guiutil.h>
 #include <qt/modaloverlay.h>
 #include <qt/networkstyle.h>
@@ -479,6 +480,21 @@ void BitcoinGUI::createMenuBar()
         settings->addSeparator();
     }
     settings->addAction(optionsAction);
+#ifdef Q_OS_LINUX
+    if (gArgs.GetChainName() != CBaseChainParams::REGTEST) {
+        settings->addSeparator();
+        QAction* integrate_with_DE = settings->addAction(tr("&Integrate with desktop environment"));
+        connect(integrate_with_DE, &QAction::triggered, [this] {
+            if (GUIUtil::IntegrateWithDesktopEnvironment(m_network_style->getTrayAndWindowIcon())) {
+                QMessageBox::information(this, tr("Application registered"),
+                                         tr("Now you are able to launch " PACKAGE_NAME " from the desktop menu."));
+            } else {
+                QMessageBox::warning(this, tr("Application registration failed"),
+                                     tr("" PACKAGE_NAME " failed integration with your desktop environment."));
+            }
+        });
+    }
+#endif // Q_OS_LINUX
 
     QMenu* window_menu = appMenuBar->addMenu(tr("&Window"));
 

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -6,7 +6,7 @@
 
 #include <qt/bantablemodel.h>
 #include <qt/guiconstants.h>
-#include <qt/guiutil.h>
+#include <qt/guifileutil.h>
 #include <qt/peertablemodel.h>
 
 #include <clientversion.h>

--- a/src/qt/guifileutil.cpp
+++ b/src/qt/guifileutil.cpp
@@ -1,0 +1,313 @@
+// Copyright (c) 2011-2020 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <qt/guifileutil.h>
+
+#include <chainparams.h>
+#include <util/system.h>
+
+#ifdef WIN32
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <shellapi.h>
+#include <shlobj.h>
+#include <shlwapi.h>
+#endif // WIN32
+
+#ifdef Q_OS_LINUX
+#include <stdlib.h>
+#include <unistd.h>
+#endif // Q_OS_LINUX
+
+#include <QDesktopServices>
+#include <QDir>
+#include <QFileDialog>
+#include <QFileInfo>
+#include <QRegExp>
+#include <QStandardPaths>
+#include <QString>
+#ifdef Q_OS_MAC
+#include <QProcess>
+#endif // Q_OS_MAC
+
+namespace GUIUtil {
+
+QString getDefaultDataDirectory()
+{
+    return boostPathToQString(GetDefaultDataDir());
+}
+
+QString getSaveFileName(QWidget *parent, const QString &caption, const QString &dir,
+    const QString &filter,
+    QString *selectedSuffixOut)
+{
+    QString selectedFilter;
+    QString myDir;
+    if(dir.isEmpty()) // Default to user documents location
+    {
+        myDir = QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation);
+    }
+    else
+    {
+        myDir = dir;
+    }
+    /* Directly convert path to native OS path separators */
+    QString result = QDir::toNativeSeparators(QFileDialog::getSaveFileName(parent, caption, myDir, filter, &selectedFilter));
+
+    /* Extract first suffix from filter pattern "Description (*.foo)" or "Description (*.foo *.bar ...) */
+    QRegExp filter_re(".* \\(\\*\\.(.*)[ \\)]");
+    QString selectedSuffix;
+    if(filter_re.exactMatch(selectedFilter))
+    {
+        selectedSuffix = filter_re.cap(1);
+    }
+
+    /* Add suffix if needed */
+    QFileInfo info(result);
+    if(!result.isEmpty())
+    {
+        if(info.suffix().isEmpty() && !selectedSuffix.isEmpty())
+        {
+            /* No suffix specified, add selected suffix */
+            if(!result.endsWith("."))
+                result.append(".");
+            result.append(selectedSuffix);
+        }
+    }
+
+    /* Return selected suffix if asked to */
+    if(selectedSuffixOut)
+    {
+        *selectedSuffixOut = selectedSuffix;
+    }
+    return result;
+}
+
+QString getOpenFileName(QWidget *parent, const QString &caption, const QString &dir,
+    const QString &filter,
+    QString *selectedSuffixOut)
+{
+    QString selectedFilter;
+    QString myDir;
+    if(dir.isEmpty()) // Default to user documents location
+    {
+        myDir = QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation);
+    }
+    else
+    {
+        myDir = dir;
+    }
+    /* Directly convert path to native OS path separators */
+    QString result = QDir::toNativeSeparators(QFileDialog::getOpenFileName(parent, caption, myDir, filter, &selectedFilter));
+
+    if(selectedSuffixOut)
+    {
+        /* Extract first suffix from filter pattern "Description (*.foo)" or "Description (*.foo *.bar ...) */
+        QRegExp filter_re(".* \\(\\*\\.(.*)[ \\)]");
+        QString selectedSuffix;
+        if(filter_re.exactMatch(selectedFilter))
+        {
+            selectedSuffix = filter_re.cap(1);
+        }
+        *selectedSuffixOut = selectedSuffix;
+    }
+    return result;
+}
+
+void openDebugLogfile()
+{
+    fs::path pathDebug = GetDataDir() / "debug.log";
+
+    /* Open debug.log with the associated application */
+    if (fs::exists(pathDebug))
+        QDesktopServices::openUrl(QUrl::fromLocalFile(boostPathToQString(pathDebug)));
+}
+
+bool openBitcoinConf()
+{
+    fs::path pathConfig = GetConfigFile(gArgs.GetArg("-conf", BITCOIN_CONF_FILENAME));
+
+    /* Create the file */
+    fsbridge::ofstream configFile(pathConfig, std::ios_base::app);
+
+    if (!configFile.good())
+        return false;
+
+    configFile.close();
+
+    /* Open bitcoin.conf with the associated application */
+    bool res = QDesktopServices::openUrl(QUrl::fromLocalFile(boostPathToQString(pathConfig)));
+#ifdef Q_OS_MAC
+    // Workaround for macOS-specific behavior; see #15409.
+    if (!res) {
+        res = QProcess::startDetached("/usr/bin/open", QStringList{"-t", boostPathToQString(pathConfig)});
+    }
+#endif
+
+    return res;
+}
+
+#ifdef WIN32
+fs::path static StartupShortcutPath()
+{
+    std::string chain = gArgs.GetChainName();
+    if (chain == CBaseChainParams::MAIN)
+        return GetSpecialFolderPath(CSIDL_STARTUP) / "Bitcoin.lnk";
+    if (chain == CBaseChainParams::TESTNET) // Remove this special case when CBaseChainParams::TESTNET = "testnet4"
+        return GetSpecialFolderPath(CSIDL_STARTUP) / "Bitcoin (testnet).lnk";
+    return GetSpecialFolderPath(CSIDL_STARTUP) / strprintf("Bitcoin (%s).lnk", chain);
+}
+
+bool GetStartOnSystemStartup()
+{
+    // check for Bitcoin*.lnk
+    return fs::exists(StartupShortcutPath());
+}
+
+bool SetStartOnSystemStartup(bool fAutoStart)
+{
+    // If the shortcut exists already, remove it for updating
+    fs::remove(StartupShortcutPath());
+
+    if (fAutoStart)
+    {
+        CoInitialize(nullptr);
+
+        // Get a pointer to the IShellLink interface.
+        IShellLinkW* psl = nullptr;
+        HRESULT hres = CoCreateInstance(CLSID_ShellLink, nullptr,
+            CLSCTX_INPROC_SERVER, IID_IShellLinkW,
+            reinterpret_cast<void**>(&psl));
+
+        if (SUCCEEDED(hres))
+        {
+            // Get the current executable path
+            WCHAR pszExePath[MAX_PATH];
+            GetModuleFileNameW(nullptr, pszExePath, ARRAYSIZE(pszExePath));
+
+            // Start client minimized
+            QString strArgs = "-min";
+            // Set -testnet /-regtest options
+            strArgs += QString::fromStdString(strprintf(" -chain=%s", gArgs.GetChainName()));
+
+            // Set the path to the shortcut target
+            psl->SetPath(pszExePath);
+            PathRemoveFileSpecW(pszExePath);
+            psl->SetWorkingDirectory(pszExePath);
+            psl->SetShowCmd(SW_SHOWMINNOACTIVE);
+            psl->SetArguments(strArgs.toStdWString().c_str());
+
+            // Query IShellLink for the IPersistFile interface for
+            // saving the shortcut in persistent storage.
+            IPersistFile* ppf = nullptr;
+            hres = psl->QueryInterface(IID_IPersistFile, reinterpret_cast<void**>(&ppf));
+            if (SUCCEEDED(hres))
+            {
+                // Save the link by calling IPersistFile::Save.
+                hres = ppf->Save(StartupShortcutPath().wstring().c_str(), TRUE);
+                ppf->Release();
+                psl->Release();
+                CoUninitialize();
+                return true;
+            }
+            psl->Release();
+        }
+        CoUninitialize();
+        return false;
+    }
+    return true;
+}
+#elif defined(Q_OS_LINUX)
+
+// Follow the Desktop Application Autostart Spec:
+// http://standards.freedesktop.org/autostart-spec/autostart-spec-latest.html
+
+fs::path static GetAutostartDir()
+{
+    char* pszConfigHome = getenv("XDG_CONFIG_HOME");
+    if (pszConfigHome) return fs::path(pszConfigHome) / "autostart";
+    char* pszHome = getenv("HOME");
+    if (pszHome) return fs::path(pszHome) / ".config" / "autostart";
+    return fs::path();
+}
+
+fs::path static GetAutostartFilePath()
+{
+    std::string chain = gArgs.GetChainName();
+    if (chain == CBaseChainParams::MAIN)
+        return GetAutostartDir() / "bitcoin.desktop";
+    return GetAutostartDir() / strprintf("bitcoin-%s.desktop", chain);
+}
+
+bool GetStartOnSystemStartup()
+{
+    fsbridge::ifstream optionFile(GetAutostartFilePath());
+    if (!optionFile.good())
+        return false;
+    // Scan through file for "Hidden=true":
+    std::string line;
+    while (!optionFile.eof())
+    {
+        getline(optionFile, line);
+        if (line.find("Hidden") != std::string::npos &&
+            line.find("true") != std::string::npos)
+            return false;
+    }
+    optionFile.close();
+
+    return true;
+}
+
+bool SetStartOnSystemStartup(bool fAutoStart)
+{
+    if (!fAutoStart)
+        fs::remove(GetAutostartFilePath());
+    else
+    {
+        char pszExePath[MAX_PATH+1];
+        ssize_t r = readlink("/proc/self/exe", pszExePath, sizeof(pszExePath) - 1);
+        if (r == -1)
+            return false;
+        pszExePath[r] = '\0';
+
+        fs::create_directories(GetAutostartDir());
+
+        fsbridge::ofstream optionFile(GetAutostartFilePath(), std::ios_base::out | std::ios_base::trunc);
+        if (!optionFile.good())
+            return false;
+        std::string chain = gArgs.GetChainName();
+        // Write a bitcoin.desktop file to the autostart directory:
+        optionFile << "[Desktop Entry]\n";
+        optionFile << "Type=Application\n";
+        if (chain == CBaseChainParams::MAIN)
+            optionFile << "Name=Bitcoin\n";
+        else
+            optionFile << strprintf("Name=Bitcoin (%s)\n", chain);
+        optionFile << "Exec=" << pszExePath << strprintf(" -min -chain=%s\n", chain);
+        optionFile << "Terminal=false\n";
+        optionFile << "Hidden=false\n";
+        optionFile.close();
+    }
+    return true;
+}
+
+#else
+
+bool GetStartOnSystemStartup() { return false; }
+bool SetStartOnSystemStartup(bool fAutoStart) { return false; }
+
+#endif
+
+fs::path qstringToBoostPath(const QString &path)
+{
+    return fs::path(path.toStdString());
+}
+
+QString boostPathToQString(const fs::path &path)
+{
+    return QString::fromStdString(path.string());
+}
+
+} // namespace GUIUtil

--- a/src/qt/guifileutil.h
+++ b/src/qt/guifileutil.h
@@ -1,0 +1,68 @@
+// Copyright (c) 2011-2020 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QT_GUIFILEUTIL_H
+#define BITCOIN_QT_GUIFILEUTIL_H
+
+#include <fs.h>
+
+#include <QString>
+
+QT_BEGIN_NAMESPACE
+class QWidget;
+QT_END_NAMESPACE
+
+/** Filesystem utility functions used by the GUI.
+ */
+namespace GUIUtil {
+/**
+ * Determine default data directory for operating system.
+ */
+QString getDefaultDataDirectory();
+
+/** Get save filename, mimics QFileDialog::getSaveFileName, except that it appends a default suffix
+    when no suffix is provided by the user.
+
+  @param[in] parent  Parent window (or 0)
+  @param[in] caption Window caption (or empty, for default)
+  @param[in] dir     Starting directory (or empty, to default to documents directory)
+  @param[in] filter  Filter specification such as "Comma Separated Files (*.csv)"
+  @param[out] selectedSuffixOut  Pointer to return the suffix (file type) that was selected (or 0).
+              Can be useful when choosing the save file format based on suffix.
+ */
+QString getSaveFileName(QWidget *parent, const QString &caption, const QString &dir,
+    const QString &filter,
+    QString *selectedSuffixOut);
+
+/** Get open filename, convenience wrapper for QFileDialog::getOpenFileName.
+
+  @param[in] parent  Parent window (or 0)
+  @param[in] caption Window caption (or empty, for default)
+  @param[in] dir     Starting directory (or empty, to default to documents directory)
+  @param[in] filter  Filter specification such as "Comma Separated Files (*.csv)"
+  @param[out] selectedSuffixOut  Pointer to return the suffix (file type) that was selected (or 0).
+              Can be useful when choosing the save file format based on suffix.
+ */
+QString getOpenFileName(QWidget *parent, const QString &caption, const QString &dir,
+    const QString &filter,
+    QString *selectedSuffixOut);
+
+// Open debug.log
+void openDebugLogfile();
+
+// Open the config file
+bool openBitcoinConf();
+
+bool GetStartOnSystemStartup();
+bool SetStartOnSystemStartup(bool fAutoStart);
+
+/* Convert QString to OS specific boost path through UTF-8 */
+fs::path qstringToBoostPath(const QString &path);
+
+/* Convert OS specific boost path to QString through UTF-8 */
+QString boostPathToQString(const fs::path &path);
+
+} // namespace GUIUtil
+
+#endif // BITCOIN_QT_GUIFILEUTIL_H

--- a/src/qt/guifileutil.h
+++ b/src/qt/guifileutil.h
@@ -7,7 +7,9 @@
 
 #include <fs.h>
 
+#include <QIcon>
 #include <QString>
+#include <QtGlobal>
 
 QT_BEGIN_NAMESPACE
 class QWidget;
@@ -16,6 +18,11 @@ QT_END_NAMESPACE
 /** Filesystem utility functions used by the GUI.
  */
 namespace GUIUtil {
+
+#ifdef Q_OS_LINUX
+bool IntegrateWithDesktopEnvironment(QIcon icon);
+#endif // Q_OS_LINUX
+
 /**
  * Determine default data directory for operating system.
  */

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -10,7 +10,6 @@
 #include <qt/sendcoinsrecipient.h>
 
 #include <base58.h>
-#include <chainparams.h>
 #include <interfaces/node.h>
 #include <key_io.h>
 #include <policy/policy.h>
@@ -18,24 +17,12 @@
 #include <protocol.h>
 #include <script/script.h>
 #include <script/standard.h>
-#include <util/system.h>
-
-#ifdef WIN32
-#ifndef NOMINMAX
-#define NOMINMAX
-#endif
-#include <shellapi.h>
-#include <shlobj.h>
-#include <shlwapi.h>
-#endif
 
 #include <QAbstractItemView>
 #include <QApplication>
 #include <QClipboard>
 #include <QDateTime>
-#include <QDesktopServices>
 #include <QDoubleValidator>
-#include <QFileDialog>
 #include <QFont>
 #include <QFontDatabase>
 #include <QFontMetrics>
@@ -57,9 +44,6 @@
 #include <QtGlobal>
 
 #if defined(Q_OS_MAC)
-
-#include <QProcess>
-
 void ForceActivation();
 #endif
 
@@ -254,88 +238,6 @@ bool hasEntryData(const QAbstractItemView *view, int column, int role)
     return !selection.at(0).data(role).toString().isEmpty();
 }
 
-QString getDefaultDataDirectory()
-{
-    return boostPathToQString(GetDefaultDataDir());
-}
-
-QString getSaveFileName(QWidget *parent, const QString &caption, const QString &dir,
-    const QString &filter,
-    QString *selectedSuffixOut)
-{
-    QString selectedFilter;
-    QString myDir;
-    if(dir.isEmpty()) // Default to user documents location
-    {
-        myDir = QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation);
-    }
-    else
-    {
-        myDir = dir;
-    }
-    /* Directly convert path to native OS path separators */
-    QString result = QDir::toNativeSeparators(QFileDialog::getSaveFileName(parent, caption, myDir, filter, &selectedFilter));
-
-    /* Extract first suffix from filter pattern "Description (*.foo)" or "Description (*.foo *.bar ...) */
-    QRegExp filter_re(".* \\(\\*\\.(.*)[ \\)]");
-    QString selectedSuffix;
-    if(filter_re.exactMatch(selectedFilter))
-    {
-        selectedSuffix = filter_re.cap(1);
-    }
-
-    /* Add suffix if needed */
-    QFileInfo info(result);
-    if(!result.isEmpty())
-    {
-        if(info.suffix().isEmpty() && !selectedSuffix.isEmpty())
-        {
-            /* No suffix specified, add selected suffix */
-            if(!result.endsWith("."))
-                result.append(".");
-            result.append(selectedSuffix);
-        }
-    }
-
-    /* Return selected suffix if asked to */
-    if(selectedSuffixOut)
-    {
-        *selectedSuffixOut = selectedSuffix;
-    }
-    return result;
-}
-
-QString getOpenFileName(QWidget *parent, const QString &caption, const QString &dir,
-    const QString &filter,
-    QString *selectedSuffixOut)
-{
-    QString selectedFilter;
-    QString myDir;
-    if(dir.isEmpty()) // Default to user documents location
-    {
-        myDir = QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation);
-    }
-    else
-    {
-        myDir = dir;
-    }
-    /* Directly convert path to native OS path separators */
-    QString result = QDir::toNativeSeparators(QFileDialog::getOpenFileName(parent, caption, myDir, filter, &selectedFilter));
-
-    if(selectedSuffixOut)
-    {
-        /* Extract first suffix from filter pattern "Description (*.foo)" or "Description (*.foo *.bar ...) */
-        QRegExp filter_re(".* \\(\\*\\.(.*)[ \\)]");
-        QString selectedSuffix;
-        if(filter_re.exactMatch(selectedFilter))
-        {
-            selectedSuffix = filter_re.cap(1);
-        }
-        *selectedSuffixOut = selectedSuffix;
-    }
-    return result;
-}
-
 Qt::ConnectionType blockingGUIThreadConnection()
 {
     if(QThread::currentThread() != qApp->thread())
@@ -385,39 +287,6 @@ void bringToFront(QWidget* w)
 void handleCloseWindowShortcut(QWidget* w)
 {
     QObject::connect(new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_W), w), &QShortcut::activated, w, &QWidget::close);
-}
-
-void openDebugLogfile()
-{
-    fs::path pathDebug = GetDataDir() / "debug.log";
-
-    /* Open debug.log with the associated application */
-    if (fs::exists(pathDebug))
-        QDesktopServices::openUrl(QUrl::fromLocalFile(boostPathToQString(pathDebug)));
-}
-
-bool openBitcoinConf()
-{
-    fs::path pathConfig = GetConfigFile(gArgs.GetArg("-conf", BITCOIN_CONF_FILENAME));
-
-    /* Create the file */
-    fsbridge::ofstream configFile(pathConfig, std::ios_base::app);
-
-    if (!configFile.good())
-        return false;
-
-    configFile.close();
-
-    /* Open bitcoin.conf with the associated application */
-    bool res = QDesktopServices::openUrl(QUrl::fromLocalFile(boostPathToQString(pathConfig)));
-#ifdef Q_OS_MAC
-    // Workaround for macOS-specific behavior; see #15409.
-    if (!res) {
-        res = QProcess::startDetached("/usr/bin/open", QStringList{"-t", boostPathToQString(pathConfig)});
-    }
-#endif
-
-    return res;
 }
 
 ToolTipToRichTextFilter::ToolTipToRichTextFilter(int _size_threshold, QObject *parent) :
@@ -581,171 +450,10 @@ TableViewLastColumnResizingFixer::TableViewLastColumnResizingFixer(QTableView* t
     setViewHeaderResizeMode(lastColumnIndex, QHeaderView::Interactive);
 }
 
-#ifdef WIN32
-fs::path static StartupShortcutPath()
-{
-    std::string chain = gArgs.GetChainName();
-    if (chain == CBaseChainParams::MAIN)
-        return GetSpecialFolderPath(CSIDL_STARTUP) / "Bitcoin.lnk";
-    if (chain == CBaseChainParams::TESTNET) // Remove this special case when CBaseChainParams::TESTNET = "testnet4"
-        return GetSpecialFolderPath(CSIDL_STARTUP) / "Bitcoin (testnet).lnk";
-    return GetSpecialFolderPath(CSIDL_STARTUP) / strprintf("Bitcoin (%s).lnk", chain);
-}
-
-bool GetStartOnSystemStartup()
-{
-    // check for Bitcoin*.lnk
-    return fs::exists(StartupShortcutPath());
-}
-
-bool SetStartOnSystemStartup(bool fAutoStart)
-{
-    // If the shortcut exists already, remove it for updating
-    fs::remove(StartupShortcutPath());
-
-    if (fAutoStart)
-    {
-        CoInitialize(nullptr);
-
-        // Get a pointer to the IShellLink interface.
-        IShellLinkW* psl = nullptr;
-        HRESULT hres = CoCreateInstance(CLSID_ShellLink, nullptr,
-            CLSCTX_INPROC_SERVER, IID_IShellLinkW,
-            reinterpret_cast<void**>(&psl));
-
-        if (SUCCEEDED(hres))
-        {
-            // Get the current executable path
-            WCHAR pszExePath[MAX_PATH];
-            GetModuleFileNameW(nullptr, pszExePath, ARRAYSIZE(pszExePath));
-
-            // Start client minimized
-            QString strArgs = "-min";
-            // Set -testnet /-regtest options
-            strArgs += QString::fromStdString(strprintf(" -chain=%s", gArgs.GetChainName()));
-
-            // Set the path to the shortcut target
-            psl->SetPath(pszExePath);
-            PathRemoveFileSpecW(pszExePath);
-            psl->SetWorkingDirectory(pszExePath);
-            psl->SetShowCmd(SW_SHOWMINNOACTIVE);
-            psl->SetArguments(strArgs.toStdWString().c_str());
-
-            // Query IShellLink for the IPersistFile interface for
-            // saving the shortcut in persistent storage.
-            IPersistFile* ppf = nullptr;
-            hres = psl->QueryInterface(IID_IPersistFile, reinterpret_cast<void**>(&ppf));
-            if (SUCCEEDED(hres))
-            {
-                // Save the link by calling IPersistFile::Save.
-                hres = ppf->Save(StartupShortcutPath().wstring().c_str(), TRUE);
-                ppf->Release();
-                psl->Release();
-                CoUninitialize();
-                return true;
-            }
-            psl->Release();
-        }
-        CoUninitialize();
-        return false;
-    }
-    return true;
-}
-#elif defined(Q_OS_LINUX)
-
-// Follow the Desktop Application Autostart Spec:
-// http://standards.freedesktop.org/autostart-spec/autostart-spec-latest.html
-
-fs::path static GetAutostartDir()
-{
-    char* pszConfigHome = getenv("XDG_CONFIG_HOME");
-    if (pszConfigHome) return fs::path(pszConfigHome) / "autostart";
-    char* pszHome = getenv("HOME");
-    if (pszHome) return fs::path(pszHome) / ".config" / "autostart";
-    return fs::path();
-}
-
-fs::path static GetAutostartFilePath()
-{
-    std::string chain = gArgs.GetChainName();
-    if (chain == CBaseChainParams::MAIN)
-        return GetAutostartDir() / "bitcoin.desktop";
-    return GetAutostartDir() / strprintf("bitcoin-%s.desktop", chain);
-}
-
-bool GetStartOnSystemStartup()
-{
-    fsbridge::ifstream optionFile(GetAutostartFilePath());
-    if (!optionFile.good())
-        return false;
-    // Scan through file for "Hidden=true":
-    std::string line;
-    while (!optionFile.eof())
-    {
-        getline(optionFile, line);
-        if (line.find("Hidden") != std::string::npos &&
-            line.find("true") != std::string::npos)
-            return false;
-    }
-    optionFile.close();
-
-    return true;
-}
-
-bool SetStartOnSystemStartup(bool fAutoStart)
-{
-    if (!fAutoStart)
-        fs::remove(GetAutostartFilePath());
-    else
-    {
-        char pszExePath[MAX_PATH+1];
-        ssize_t r = readlink("/proc/self/exe", pszExePath, sizeof(pszExePath) - 1);
-        if (r == -1)
-            return false;
-        pszExePath[r] = '\0';
-
-        fs::create_directories(GetAutostartDir());
-
-        fsbridge::ofstream optionFile(GetAutostartFilePath(), std::ios_base::out | std::ios_base::trunc);
-        if (!optionFile.good())
-            return false;
-        std::string chain = gArgs.GetChainName();
-        // Write a bitcoin.desktop file to the autostart directory:
-        optionFile << "[Desktop Entry]\n";
-        optionFile << "Type=Application\n";
-        if (chain == CBaseChainParams::MAIN)
-            optionFile << "Name=Bitcoin\n";
-        else
-            optionFile << strprintf("Name=Bitcoin (%s)\n", chain);
-        optionFile << "Exec=" << pszExePath << strprintf(" -min -chain=%s\n", chain);
-        optionFile << "Terminal=false\n";
-        optionFile << "Hidden=false\n";
-        optionFile.close();
-    }
-    return true;
-}
-
-#else
-
-bool GetStartOnSystemStartup() { return false; }
-bool SetStartOnSystemStartup(bool fAutoStart) { return false; }
-
-#endif
-
 void setClipboard(const QString& str)
 {
     QApplication::clipboard()->setText(str, QClipboard::Clipboard);
     QApplication::clipboard()->setText(str, QClipboard::Selection);
-}
-
-fs::path qstringToBoostPath(const QString &path)
-{
-    return fs::path(path.toStdString());
-}
-
-QString boostPathToQString(const fs::path &path)
-{
-    return QString::fromStdString(path.string());
 }
 
 QString formatDurationStr(int secs)

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -6,7 +6,6 @@
 #define BITCOIN_QT_GUIUTIL_H
 
 #include <amount.h>
-#include <fs.h>
 
 #include <QEvent>
 #include <QHeaderView>
@@ -89,38 +88,6 @@ namespace GUIUtil
 
     void setClipboard(const QString& str);
 
-    /**
-     * Determine default data directory for operating system.
-     */
-    QString getDefaultDataDirectory();
-
-    /** Get save filename, mimics QFileDialog::getSaveFileName, except that it appends a default suffix
-        when no suffix is provided by the user.
-
-      @param[in] parent  Parent window (or 0)
-      @param[in] caption Window caption (or empty, for default)
-      @param[in] dir     Starting directory (or empty, to default to documents directory)
-      @param[in] filter  Filter specification such as "Comma Separated Files (*.csv)"
-      @param[out] selectedSuffixOut  Pointer to return the suffix (file type) that was selected (or 0).
-                  Can be useful when choosing the save file format based on suffix.
-     */
-    QString getSaveFileName(QWidget *parent, const QString &caption, const QString &dir,
-        const QString &filter,
-        QString *selectedSuffixOut);
-
-    /** Get open filename, convenience wrapper for QFileDialog::getOpenFileName.
-
-      @param[in] parent  Parent window (or 0)
-      @param[in] caption Window caption (or empty, for default)
-      @param[in] dir     Starting directory (or empty, to default to documents directory)
-      @param[in] filter  Filter specification such as "Comma Separated Files (*.csv)"
-      @param[out] selectedSuffixOut  Pointer to return the suffix (file type) that was selected (or 0).
-                  Can be useful when choosing the save file format based on suffix.
-     */
-    QString getOpenFileName(QWidget *parent, const QString &caption, const QString &dir,
-        const QString &filter,
-        QString *selectedSuffixOut);
-
     /** Get connection type to call object slot in GUI thread with invokeMethod. The call will be blocking.
 
        @returns If called from the GUI thread, return a Qt::DirectConnection.
@@ -136,12 +103,6 @@ namespace GUIUtil
 
     // Set shortcut to close window
     void handleCloseWindowShortcut(QWidget* w);
-
-    // Open debug.log
-    void openDebugLogfile();
-
-    // Open the config file
-    bool openBitcoinConf();
 
     /** Qt event filter that intercepts ToolTipChange events, and replaces the tooltip with a rich text
       representation if needed. This assures that Qt can word-wrap long tooltip messages.
@@ -214,15 +175,6 @@ namespace GUIUtil
             void on_sectionResized(int logicalIndex, int oldSize, int newSize);
             void on_geometriesChanged();
     };
-
-    bool GetStartOnSystemStartup();
-    bool SetStartOnSystemStartup(bool fAutoStart);
-
-    /* Convert QString to OS specific boost path through UTF-8 */
-    fs::path qstringToBoostPath(const QString &path);
-
-    /* Convert OS specific boost path to QString through UTF-8 */
-    QString boostPathToQString(const fs::path &path);
 
     /* Convert seconds into a QString with days, hours, mins, secs */
     QString formatDurationStr(int secs);

--- a/src/qt/intro.cpp
+++ b/src/qt/intro.cpp
@@ -12,7 +12,7 @@
 #include <qt/forms/ui_intro.h>
 
 #include <qt/guiconstants.h>
-#include <qt/guiutil.h>
+#include <qt/guifileutil.h>
 #include <qt/optionsmodel.h>
 
 #include <interfaces/node.h>

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -11,6 +11,7 @@
 
 #include <qt/bitcoinunits.h>
 #include <qt/guiconstants.h>
+#include <qt/guifileutil.h>
 #include <qt/guiutil.h>
 #include <qt/optionsmodel.h>
 

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -10,7 +10,7 @@
 
 #include <qt/bitcoinunits.h>
 #include <qt/guiconstants.h>
-#include <qt/guiutil.h>
+#include <qt/guifileutil.h>
 
 #include <interfaces/node.h>
 #include <validation.h> // For DEFAULT_SCRIPTCHECK_THREADS

--- a/src/qt/paymentserver.cpp
+++ b/src/qt/paymentserver.cpp
@@ -9,6 +9,7 @@
 #include <qt/paymentserver.h>
 
 #include <qt/bitcoinunits.h>
+#include <qt/guifileutil.h>
 #include <qt/guiutil.h>
 #include <qt/optionsmodel.h>
 

--- a/src/qt/psbtoperationsdialog.cpp
+++ b/src/qt/psbtoperationsdialog.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <qt/psbtoperationsdialog.h>
+#include <qt/forms/ui_psbtoperationsdialog.h>
 
 #include <core_io.h>
 #include <interfaces/node.h>
@@ -10,7 +11,7 @@
 #include <node/psbt.h>
 #include <policy/policy.h>
 #include <qt/bitcoinunits.h>
-#include <qt/forms/ui_psbtoperationsdialog.h>
+#include <qt/guifileutil.h>
 #include <qt/guiutil.h>
 #include <qt/optionsmodel.h>
 #include <util/strencodings.h>

--- a/src/qt/qrimagewidget.cpp
+++ b/src/qt/qrimagewidget.cpp
@@ -4,6 +4,7 @@
 
 #include <qt/qrimagewidget.h>
 
+#include <qt/guifileutil.h>
 #include <qt/guiutil.h>
 
 #include <QApplication>

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -9,15 +9,17 @@
 #include <qt/rpcconsole.h>
 #include <qt/forms/ui_debugwindow.h>
 
-#include <qt/bantablemodel.h>
-#include <qt/clientmodel.h>
-#include <qt/platformstyle.h>
-#include <qt/walletmodel.h>
 #include <chainparams.h>
 #include <interfaces/node.h>
 #include <netbase.h>
-#include <rpc/server.h>
+#include <qt/bantablemodel.h>
+#include <qt/clientmodel.h>
+#include <qt/guifileutil.h>
+#include <qt/guiutil.h>
+#include <qt/platformstyle.h>
+#include <qt/walletmodel.h>
 #include <rpc/client.h>
+#include <rpc/server.h>
 #include <util/strencodings.h>
 #include <util/system.h>
 

--- a/src/qt/rpcconsole.h
+++ b/src/qt/rpcconsole.h
@@ -5,7 +5,6 @@
 #ifndef BITCOIN_QT_RPCCONSOLE_H
 #define BITCOIN_QT_RPCCONSOLE_H
 
-#include <qt/guiutil.h>
 #include <qt/peertablemodel.h>
 
 #include <net.h>

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -13,6 +13,7 @@
 #include <qt/bitcoinunits.h>
 #include <qt/clientmodel.h>
 #include <qt/coincontroldialog.h>
+#include <qt/guifileutil.h>
 #include <qt/guiutil.h>
 #include <qt/optionsmodel.h>
 #include <qt/platformstyle.h>

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -8,6 +8,7 @@
 #include <qt/bitcoinunits.h>
 #include <qt/csvmodelwriter.h>
 #include <qt/editaddressdialog.h>
+#include <qt/guifileutil.h>
 #include <qt/guiutil.h>
 #include <qt/optionsmodel.h>
 #include <qt/platformstyle.h>

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -7,11 +7,12 @@
 #include <qt/addressbookpage.h>
 #include <qt/askpassphrasedialog.h>
 #include <qt/clientmodel.h>
+#include <qt/guifileutil.h>
 #include <qt/guiutil.h>
-#include <qt/psbtoperationsdialog.h>
 #include <qt/optionsmodel.h>
 #include <qt/overviewpage.h>
 #include <qt/platformstyle.h>
+#include <qt/psbtoperationsdialog.h>
 #include <qt/receivecoinsdialog.h>
 #include <qt/sendcoinsdialog.h>
 #include <qt/signverifymessagedialog.h>


### PR DESCRIPTION
On Linux a new menu item "Settings" --> "Integrate with desktop environment" is available now (non-regtest only).

Here are some screenshots:

![Screenshot from 2020-07-20 18-36-52](https://user-images.githubusercontent.com/32963518/87956735-0bdc4680-cab8-11ea-877f-052acdc7de62.png)

![DeepinScreenshot_select-area_20200720190707](https://user-images.githubusercontent.com/32963518/87959938-42b45b80-cabc-11ea-8a8d-ce8fcbb81ad2.png)

![Screenshot from 2020-07-20 18-41-08](https://user-images.githubusercontent.com/32963518/87957168-9b81f500-cab8-11ea-8d0d-5e67b4879469.png)

Closes #31

---

Localization of the  `*.desktop` files is out of this PR scope.