### PR TITLE
Clarify block height label

### DIFF
--- a/src/qt/forms/debugwindow.ui
+++ b/src/qt/forms/debugwindow.ui
@@ -290,7 +290,7 @@
        <item row="11" column="0">
         <widget class="QLabel" name="label_3">
          <property name="text">
-          <string>Current number of blocks</string>
+          <string>Current block height</string>
          </property>
         </widget>
        </item>


### PR DESCRIPTION
Prefer "block height" instead of "number of blocks".

This was done while testing https://github.com/bitcoin/bitcoin/pull/16981.