### PR TITLE
refactor: Drop unneeded Q_DECLARE_METATYPE

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -44,6 +44,7 @@
 #include <QLibraryInfo>
 #include <QLocale>
 #include <QMessageBox>
+#include <QMetaType>
 #include <QSettings>
 #include <QThread>
 #include <QTimer>
@@ -60,9 +61,11 @@ Q_IMPORT_PLUGIN(QCocoaIntegrationPlugin);
 #endif
 #endif
 
-// Declare meta types used for QMetaObject::invokeMethod
+// Make types (not aliases) available to QVariant and other template-based Qt functions.
+// Additionally qRegisterMetaType() calls are required to make them available to
+// non-template based Qt functions, including those that use Qt::QueuedConnection.
+// Run `QT_FATAL_WARNINGS=1 bitcoin-qt -debug=qt` to identify missing type registrations.
 Q_DECLARE_METATYPE(bool*)
-Q_DECLARE_METATYPE(CAmount)
 Q_DECLARE_METATYPE(SynchronizationState)
 Q_DECLARE_METATYPE(uint256)
 

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -17,6 +17,7 @@
 
 #include <QAbstractItemDelegate>
 #include <QApplication>
+#include <QMetaType>
 #include <QPainter>
 #include <QStatusTipEvent>
 


### PR DESCRIPTION
Ported from https://github.com/bitcoin/bitcoin/pull/19108.

For `typedef`s, which is `CAmount`, [`qRegisterMetaType(const char*)`](https://doc.qt.io/qt-5/qmetatype.html#qRegisterMetaType) only is required.

No behavior change.