### PR TITLE
util: Log static plugins meta data and used style

### DIFF
--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -40,12 +40,14 @@
 #include <QFontDatabase>
 #include <QFontMetrics>
 #include <QGuiApplication>
+#include <QJsonObject>
 #include <QKeyEvent>
 #include <QLineEdit>
 #include <QList>
 #include <QLocale>
 #include <QMenu>
 #include <QMouseEvent>
+#include <QPluginLoader>
 #include <QProgressDialog>
 #include <QScreen>
 #include <QSettings>
@@ -908,6 +910,20 @@ void LogQtInfo()
     const std::string plugin_link{"dynamic"};
 #endif
     LogPrintf("Qt %s (%s), plugin=%s (%s)\n", qVersion(), qt_link, QGuiApplication::platformName().toStdString(), plugin_link);
+    const auto static_plugins = QPluginLoader::staticPlugins();
+    if (static_plugins.empty()) {
+        LogPrintf("No static plugins.\n");
+    } else {
+        LogPrintf("Static plugins:\n");
+        for (const QStaticPlugin& p : static_plugins) {
+            QJsonObject meta_data = p.metaData();
+            const std::string plugin_class = meta_data.take(QString("className")).toString().toStdString();
+            const int plugin_version = meta_data.take(QString("version")).toInt();
+            LogPrintf(" %s, version %d\n", plugin_class, plugin_version);
+        }
+    }
+
+    LogPrintf("Style: %s / %s\n", QApplication::style()->objectName().toStdString(), QApplication::style()->metaObject()->className());
     LogPrintf("System: %s, %s\n", QSysInfo::prettyProductName().toStdString(), QSysInfo::buildAbi().toStdString());
     for (const QScreen* s : QGuiApplication::screens()) {
         LogPrintf("Screen: %s %dx%d, pixel ratio=%.1f\n", s->name().toStdString(), s->size().width(), s->size().height(), s->devicePixelRatio());


### PR DESCRIPTION
This PR is a follow-up of https://github.com/bitcoin/bitcoin/pull/17826, and adds additional info about the imported static plugins and the used style to the `debug.log` I found useful for testing (e.g., with `QT_QPA_PLATFORM`, `QT_QPA_PLATFORMTHEME`, `QT_STYLE_OVERRIDE` variables) and debugging issues (e.g., https://github.com/bitcoin/bitcoin/pull/19716#issuecomment-674052881).

The excerpt from the log:
```
2020-11-15T18:41:45Z [main] Bitcoin Core version v0.20.99.0-f0b933f78 (release build)
2020-11-15T18:41:45Z [main] Qt 5.9.8 (static), plugin=xcb (static)
2020-11-15T18:41:45Z [main] Static plugins:
2020-11-15T18:41:45Z [main]  QXcbIntegrationPlugin, version 329992
2020-11-15T18:41:45Z [main] Style: fusion / QFusionStyle
...
```