### PR TITLE
Pass argsmanager reference to intro instead of relying on global

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -34,6 +34,7 @@
 #include <node/ui_interface.h>
 #include <noui.h>
 #include <uint256.h>
+#include <util/check.h>
 #include <util/system.h>
 #include <util/threadnames.h>
 #include <util/translation.h>
@@ -469,6 +470,7 @@ int GuiMain(int argc, char* argv[])
     /// 2. Parse command-line options. We do this after qt in order to show an error if there are problems parsing these
     // Command-line options take precedence:
     SetupServerArgs(node_context);
+    ArgsManager& args = *Assert(node_context.args);
     SetupUIArgs(gArgs);
     std::string error;
     if (!gArgs.ParseParameters(argc, argv, error)) {
@@ -508,7 +510,7 @@ int GuiMain(int argc, char* argv[])
     bool did_show_intro = false;
     bool prune = false; // Intro dialog prune check box
     // Gracefully exit if the user cancels
-    if (!Intro::showIfNeeded(did_show_intro, prune)) return EXIT_SUCCESS;
+    if (!Intro::showIfNeeded(args, did_show_intro, prune)) return EXIT_SUCCESS;
 
     /// 6. Determine availability of data directory and parse bitcoin.conf
     /// - Do not call GetDataDir(true) before this step finishes

--- a/src/qt/intro.h
+++ b/src/qt/intro.h
@@ -11,6 +11,7 @@
 
 static const bool DEFAULT_CHOOSE_DATADIR = false;
 
+class ArgsManager;
 class FreespaceChecker;
 
 namespace interfaces {
@@ -30,8 +31,7 @@ class Intro : public QDialog
     Q_OBJECT
 
 public:
-    explicit Intro(QWidget *parent = nullptr,
-                   int64_t blockchain_size_gb = 0, int64_t chain_state_size_gb = 0);
+    explicit Intro(const ArgsManager& args, QWidget* parent = nullptr, int64_t blockchain_size_gb = 0, int64_t chain_state_size_gb = 0);
     ~Intro();
 
     QString getDataDirectory();
@@ -47,7 +47,7 @@ public:
      * @note do NOT call global GetDataDir() before calling this function, this
      * will cause the wrong path to be cached.
      */
-    static bool showIfNeeded(bool& did_show_intro, bool& prune);
+    static bool showIfNeeded(ArgsManager& args, bool& did_show_intro, bool& prune);
 
 Q_SIGNALS:
     void requestCheck();


### PR DESCRIPTION
Motivation: (copied from https://github.com/bitcoin/bitcoin/pull/19779)

The gArgs global has several issues:

* gArgs is used by each process (bitcoind, bitcoin-qt, bitcoin-wallet, bitcoin-cli, bitcoin-tx, ...), but it is hard to determine which arguments are actually used by each process. For example arguments that have never been registered, but are still used, will always return the fallback value.
* Tests may run several sub-tests, which need different settings. So globals will have to be overwritten, but that is fragile on its own: e.g. https://github.com/bitcoin/bitcoin/pull/19704#issuecomment-678259092 or #19511

The goal is to remove gArgs, but as a first step in that direction this pull will change gArgs to use a passed-in reference instead.