### PR TITLE
Slight improve create wallet dialog

### DIFF
--- a/src/qt/createwalletdialog.cpp
+++ b/src/qt/createwalletdialog.cpp
@@ -35,11 +35,28 @@ CreateWalletDialog::CreateWalletDialog(QWidget* parent) :
         }
     });
 
-#ifndef USE_SQLITE
-    ui->descriptor_checkbox->setToolTip(tr("Compiled without sqlite support (required for descriptor wallets)"));
-    ui->descriptor_checkbox->setEnabled(false);
-    ui->descriptor_checkbox->setChecked(false);
-#endif
+    connect(ui->disable_privkeys_checkbox, &QCheckBox::toggled, [this](bool checked) {
+        // Disable the encrypt_wallet_checkbox when isDisablePrivateKeysChecked is
+        // set to true, enable it when isDisablePrivateKeysChecked is false.
+        ui->encrypt_wallet_checkbox->setEnabled(!checked);
+
+        // Wallets without private keys start out blank
+        if (checked) {
+            ui->blank_wallet_checkbox->setChecked(true);
+        }
+
+        // When the encrypt_wallet_checkbox is disabled, uncheck it.
+        if (!ui->encrypt_wallet_checkbox->isEnabled()) {
+            ui->encrypt_wallet_checkbox->setChecked(false);
+        }
+    });
+
+    #ifndef USE_SQLITE
+        ui->descriptor_checkbox->setToolTip(tr("Compiled without sqlite support (required for descriptor wallets)"));
+        ui->descriptor_checkbox->setEnabled(false);
+        ui->descriptor_checkbox->setChecked(false);
+    #endif
+
 }
 
 CreateWalletDialog::~CreateWalletDialog()

--- a/src/qt/forms/createwalletdialog.ui
+++ b/src/qt/forms/createwalletdialog.ui
@@ -68,12 +68,12 @@
     <string>Encrypt Wallet</string>
    </property>
    <property name="checked">
-    <bool>true</bool>
+    <bool>false</bool>
    </property>
   </widget>
   <widget class="QCheckBox" name="disable_privkeys_checkbox">
    <property name="enabled">
-    <bool>false</bool>
+    <bool>true</bool>
    </property>
    <property name="geometry">
     <rect>

--- a/src/qt/forms/createwalletdialog.ui
+++ b/src/qt/forms/createwalletdialog.ui
@@ -74,6 +74,22 @@
     <bool>false</bool>
    </property>
   </widget>
+  <widget class="QLabel" name="advanced_options_label">
+   <property name="geometry">
+    <rect>
+     <x>20</x>
+     <y>90</y>
+     <width>130</width>
+     <height>21</height>
+    </rect>
+   </property>
+   <property name="styleSheet">
+    <string notr="true">font-weight:bold;</string>
+   </property>
+   <property name="text">
+    <string>Advanced options</string>
+   </property>
+  </widget>
   <widget class="QCheckBox" name="disable_privkeys_checkbox">
    <property name="enabled">
     <bool>true</bool>
@@ -81,7 +97,7 @@
    <property name="geometry">
     <rect>
      <x>20</x>
-     <y>80</y>
+     <y>115</y>
      <width>171</width>
      <height>22</height>
     </rect>
@@ -97,8 +113,8 @@
    <property name="geometry">
     <rect>
      <x>20</x>
-     <y>110</y>
-     <width>171</width>
+     <y>135</y>
+     <width>220</width>
      <height>22</height>
     </rect>
    </property>
@@ -113,7 +129,7 @@
    <property name="geometry">
     <rect>
      <x>20</x>
-     <y>140</y>
+     <y>155</y>
      <width>171</width>
      <height>22</height>
     </rect>
@@ -131,6 +147,7 @@
   <tabstop>encrypt_wallet_checkbox</tabstop>
   <tabstop>disable_privkeys_checkbox</tabstop>
   <tabstop>blank_wallet_checkbox</tabstop>
+  <tabstop>descriptor_checkbox</tabstop>
  </tabstops>
  <resources/>
  <connections>

--- a/src/qt/forms/createwalletdialog.ui
+++ b/src/qt/forms/createwalletdialog.ui
@@ -38,6 +38,9 @@
      <height>24</height>
     </rect>
    </property>
+   <property name="placeholderText">
+     <string>Wallet</string>
+   </property>
   </widget>
   <widget class="QLabel" name="label">
    <property name="geometry">


### PR DESCRIPTION
Previously only users who needed a second wallet had to use to the create wallet dialog. With the merge of https://github.com/bitcoin/bitcoin/pull/15454 now all new users have to. I don't think it was user-friendly enough for that.

<img width="403" alt="Schermafbeelding 2020-09-18 om 09 41 44" src="https://user-images.githubusercontent.com/10217/93574129-52ef9680-f998-11ea-9a6f-31144f66d3bf.png">


This PR makes a few simple improvements so that new users don't have to think too much:

<img width="369" alt="Schermafbeelding 2020-10-15 om 16 45 22" src="https://user-images.githubusercontent.com/10217/96145959-0c914700-0f06-11eb-9526-cf447d841d7a.png">

It's lightly inspired by #77. It would be better if those changes made it into the upcoming release, but this PR is a good start imo.

* wallet encryption is no longer checked by default, because such a change in the default needs a separate discussion (fwiw, I suspect it increases the number of users losing access to coins)
* watch-only and descriptor wallet stuff is moved to advanced, so new users know they can safely ignore these check boxes
* bonus: when you click on "disable private keys" it disables encrypt wallet and checks blank wallet
* label changes: see screenshot
* tooltip changes: see code diff

Note that a blank wallet name isn't allowed in the dialog; I haven't addressed that.

_Update 2020-10-30_, dropped the new strings for now:
<img width="450" alt="Schermafbeelding 2020-10-30 om 11 26 55" src="https://user-images.githubusercontent.com/10217/97694591-1b99fc80-1aa3-11eb-8b85-e19f1ad5add4.png">
