### PR TITLE
gui: Seperate rpcconsole from nodewindow

### DIFF
--- a/contrib/bitcoin-qt.pro
+++ b/contrib/bitcoin-qt.pro
@@ -6,12 +6,12 @@ FORMS += \
     ../src/qt/forms/editaddressdialog.ui \
     ../src/qt/forms/helpmessagedialog.ui \
     ../src/qt/forms/intro.ui \
+    ../src/qt/forms/nodewindow.ui \
     ../src/qt/forms/openuridialog.ui \
     ../src/qt/forms/optionsdialog.ui \
     ../src/qt/forms/overviewpage.ui \
     ../src/qt/forms/receivecoinsdialog.ui \
     ../src/qt/forms/receiverequestdialog.ui \
-    ../src/qt/forms/debugwindow.ui \
     ../src/qt/forms/sendcoinsdialog.ui \
     ../src/qt/forms/sendcoinsentry.ui \
     ../src/qt/forms/signverifymessagedialog.ui \

--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -28,7 +28,7 @@ QT_FORMS_UI = \
   qt/forms/psbtoperationsdialog.ui \
   qt/forms/receivecoinsdialog.ui \
   qt/forms/receiverequestdialog.ui \
-  qt/forms/debugwindow.ui \
+  qt/forms/nodewindow.ui \
   qt/forms/sendcoinsdialog.ui \
   qt/forms/sendcoinsentry.ui \
   qt/forms/signverifymessagedialog.ui \

--- a/src/qt/forms/nodewindow.ui
+++ b/src/qt/forms/nodewindow.ui
@@ -6,12 +6,12 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>740</width>
-    <height>430</height>
+    <width>777</width>
+    <height>475</height>
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Node window</string>
+   <string>Node Window</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_2">
    <item>
@@ -1074,8 +1074,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>300</width>
-                <height>426</height>
+                <width>274</width>
+                <height>456</height>
                </rect>
               </property>
               <layout class="QGridLayout" name="gridLayout_2" columnstretch="0,1">

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -7,7 +7,7 @@
 #endif
 
 #include <qt/rpcconsole.h>
-#include <qt/forms/ui_debugwindow.h>
+#include <qt/forms/ui_nodewindow.h>
 
 #include <qt/bantablemodel.h>
 #include <qt/clientmodel.h>


### PR DESCRIPTION
Since the window is named "Node Window" the .ui file should reflect this.
