### PR TITLE
Fix SplashScreen crash when run with -disablewallet

### DIFF
--- a/src/qt/splashscreen.cpp
+++ b/src/qt/splashscreen.cpp
@@ -14,6 +14,7 @@
 #include <interfaces/wallet.h>
 #include <qt/guiutil.h>
 #include <qt/networkstyle.h>
+#include <qt/walletmodel.h>
 #include <util/system.h>
 #include <util/translation.h>
 
@@ -196,6 +197,7 @@ void SplashScreen::subscribeToCoreSignals()
 void SplashScreen::handleLoadWallet()
 {
 #ifdef ENABLE_WALLET
+    if (!WalletModel::isWalletEnabled()) return;
     m_handler_load_wallet = m_node->walletClient().handleLoadWallet([this](std::unique_ptr<interfaces::Wallet> wallet) {
         m_connected_wallet_handlers.emplace_back(wallet->handleShowProgress(std::bind(ShowProgress, this, std::placeholders::_1, std::placeholders::_2, false)));
         m_connected_wallets.emplace_back(std::move(wallet));


### PR DESCRIPTION
This PR fixes the bug introduced in https://github.com/bitcoin/bitcoin/pull/19099:

```
$ src/qt/bitcoin-qt -disablewallet
bitcoin-qt: interfaces/node.cpp:236: auto interfaces::(anonymous namespace)::NodeImpl::walletClient()::(anonymous class)::operator()() const: Assertion `"m_context->wallet_client" && check' failed.
Aborted (core dumped)
```