### PR TITLE
Fix unreasonable default size of the main window without loaded wallets

### DIFF
--- a/src/qt/walletframe.cpp
+++ b/src/qt/walletframe.cpp
@@ -2,12 +2,13 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <qt/createwalletdialog.h>
-#include <qt/walletcontroller.h>
 #include <qt/walletframe.h>
-#include <qt/walletmodel.h>
 
 #include <qt/bitcoingui.h>
+#include <qt/createwalletdialog.h>
+#include <qt/overviewpage.h>
+#include <qt/walletcontroller.h>
+#include <qt/walletmodel.h>
 #include <qt/walletview.h>
 
 #include <cassert>
@@ -18,10 +19,11 @@
 #include <QPushButton>
 #include <QVBoxLayout>
 
-WalletFrame::WalletFrame(const PlatformStyle *_platformStyle, BitcoinGUI *_gui) :
-    QFrame(_gui),
-    gui(_gui),
-    platformStyle(_platformStyle)
+WalletFrame::WalletFrame(const PlatformStyle* _platformStyle, BitcoinGUI* _gui)
+    : QFrame(_gui),
+      gui(_gui),
+      platformStyle(_platformStyle),
+      m_size_hint(OverviewPage{platformStyle, nullptr}.sizeHint())
 {
     // Leave HBox hook for adding a list view later
     QHBoxLayout *walletFrameLayout = new QHBoxLayout(this);

--- a/src/qt/walletframe.h
+++ b/src/qt/walletframe.h
@@ -45,6 +45,8 @@ public:
 
     void showOutOfSyncWarning(bool fShow);
 
+    QSize sizeHint() const override { return m_size_hint; }
+
 Q_SIGNALS:
     /** Notify that the user has requested more information about the out-of-sync warning */
     void requestedSyncWarningInfo();
@@ -58,6 +60,8 @@ private:
     bool bOutOfSync;
 
     const PlatformStyle *platformStyle;
+
+    const QSize m_size_hint;
 
 public:
     WalletView* currentWalletView() const;


### PR DESCRIPTION
This PR fixes a bug in master (d67883d01e507dd22d1281f4a4860e79d6a46a47) and in 0.20.1 that could be easily reproduced with
```
$ src/qt/bitcoin-qt -regtest -resetguisettings -nowallet
```

![Screenshot from 2020-10-25 21-21-27](https://user-images.githubusercontent.com/32963518/97117179-b1800100-170a-11eb-87c9-3120d39b9455.png)
![Screenshot from 2020-10-25 21-23-32](https://user-images.githubusercontent.com/32963518/97117186-b644b500-170a-11eb-8b5d-234ff7205003.png)

**With this PR:**

![Screenshot from 2020-10-25 21-20-35](https://user-images.githubusercontent.com/32963518/97117226-f441d900-170a-11eb-8d66-98b7718a2bb1.png)
![Screenshot from 2020-10-25 21-23-03](https://user-images.githubusercontent.com/32963518/97117232-f99f2380-170a-11eb-85ed-c7b5ece926b2.png)

---

Fix #104 
Fix #113 

This PR is an alternative to #107 without [hard-coding a size in pixels](https://github.com/bitcoin-core/gui/pull/107#discussion_r511474021).