### PR TITLE
Early subscribe core signals in transaction table model

### DIFF
--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -97,6 +97,8 @@ public:
     QList<TransactionRecord> cachedWallet;
 
     bool fQueueNotifications = false;
+    /** True when model finishes loading all wallet transactions on start */
+    bool m_loaded = false;
     std::vector< TransactionNotification > vQueueNotifications;
 
     void NotifyTransactionChanged(const uint256 &hash, ChangeType status);
@@ -106,8 +108,7 @@ public:
      */
     void refreshWallet(interfaces::Wallet& wallet)
     {
-        qDebug() << "TransactionTablePriv::refreshWallet";
-        cachedWallet.clear();
+        assert(!m_loaded);
         {
             for (const auto& wtx : wallet.getWalletTxs()) {
                 if (TransactionRecord::showTransaction()) {
@@ -115,6 +116,7 @@ public:
                 }
             }
         }
+        m_loaded = true;
     }
 
     /* Update our model of the wallet incrementally, to synchronize our model of the wallet


### PR DESCRIPTION
This fixes the case where transaction notifications arrive between `getWalletTxs` and `subscribeToCoreSignals`. Basically notifications are queued until `getWalletTxs` and wallet rescan complete.

This is also a requirement to call `getWalletTxs` in a background thread.

Motivated by https://github.com/bitcoin/bitcoin/issues/20241.