### PR TITLE
rpc: Do not accept command while executing another one

### DIFF
--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -926,57 +926,57 @@ void RPCConsole::on_lineEdit_returnPressed()
 {
     QString cmd = ui->lineEdit->text();
 
-    if(!cmd.isEmpty())
-    {
-        std::string strFilteredCmd;
-        try {
-            std::string dummy;
-            if (!RPCParseCommandLine(nullptr, dummy, cmd.toStdString(), false, &strFilteredCmd)) {
-                // Failed to parse command, so we cannot even filter it for the history
-                throw std::runtime_error("Invalid command line");
-            }
-        } catch (const std::exception& e) {
-            QMessageBox::critical(this, "Error", QString("Error: ") + QString::fromStdString(e.what()));
-            return;
+    if (cmd.isEmpty()) {
+        return;
+    }
+
+    std::string strFilteredCmd;
+    try {
+        std::string dummy;
+        if (!RPCParseCommandLine(nullptr, dummy, cmd.toStdString(), false, &strFilteredCmd)) {
+            // Failed to parse command, so we cannot even filter it for the history
+            throw std::runtime_error("Invalid command line");
         }
+    } catch (const std::exception& e) {
+        QMessageBox::critical(this, "Error", QString("Error: ") + QString::fromStdString(e.what()));
+        return;
+    }
 
-        ui->lineEdit->clear();
-
-        cmdBeforeBrowsing = QString();
+    ui->lineEdit->clear();
 
 #ifdef ENABLE_WALLET
-        WalletModel* wallet_model = ui->WalletSelector->currentData().value<WalletModel*>();
+    WalletModel* wallet_model = ui->WalletSelector->currentData().value<WalletModel*>();
 
-        if (m_last_wallet_model != wallet_model) {
-            if (wallet_model) {
-                message(CMD_REQUEST, tr("Executing command using \"%1\" wallet").arg(wallet_model->getWalletName()));
-            } else {
-                message(CMD_REQUEST, tr("Executing command without any wallet"));
-            }
-            m_last_wallet_model = wallet_model;
+    if (m_last_wallet_model != wallet_model) {
+        if (wallet_model) {
+            message(CMD_REQUEST, tr("Executing command using \"%1\" wallet").arg(wallet_model->getWalletName()));
+        } else {
+            message(CMD_REQUEST, tr("Executing command without any wallet"));
         }
-#endif
-
-        message(CMD_REQUEST, QString::fromStdString(strFilteredCmd));
-        //: A console message indicating an entered command is currently being executed.
-        message(CMD_REPLY, tr("Executing…"));
-        Q_EMIT cmdRequest(cmd, m_last_wallet_model);
-
-        cmd = QString::fromStdString(strFilteredCmd);
-
-        // Remove command, if already in history
-        history.removeOne(cmd);
-        // Append command to history
-        history.append(cmd);
-        // Enforce maximum history size
-        while(history.size() > CONSOLE_HISTORY)
-            history.removeFirst();
-        // Set pointer to end of history
-        historyPtr = history.size();
-
-        // Scroll console view to end
-        scrollToEnd();
+        m_last_wallet_model = wallet_model;
     }
+#endif // ENABLE_WALLET
+
+    message(CMD_REQUEST, QString::fromStdString(strFilteredCmd));
+    //: A console message indicating an entered command is currently being executed.
+    message(CMD_REPLY, tr("Executing…"));
+    Q_EMIT cmdRequest(cmd, m_last_wallet_model);
+
+    cmd = QString::fromStdString(strFilteredCmd);
+
+    // Remove command, if already in history
+    history.removeOne(cmd);
+    // Append command to history
+    history.append(cmd);
+    // Enforce maximum history size
+    while (history.size() > CONSOLE_HISTORY) {
+        history.removeFirst();
+    }
+    // Set pointer to end of history
+    historyPtr = history.size();
+
+    // Scroll console view to end
+    scrollToEnd();
 }
 
 void RPCConsole::browseHistory(int offset)

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -924,7 +924,7 @@ void RPCConsole::setMempoolSize(long numberOfTxs, size_t dynUsage)
 
 void RPCConsole::on_lineEdit_returnPressed()
 {
-    QString cmd = ui->lineEdit->text();
+    QString cmd = ui->lineEdit->text().trimmed();
 
     if (cmd.isEmpty()) {
         return;
@@ -939,6 +939,13 @@ void RPCConsole::on_lineEdit_returnPressed()
         }
     } catch (const std::exception& e) {
         QMessageBox::critical(this, "Error", QString("Error: ") + QString::fromStdString(e.what()));
+        return;
+    }
+
+    // A special case allows to request shutdown even a long-running command is executed.
+    if (cmd == QLatin1String("stop")) {
+        std::string dummy;
+        RPCExecuteCommandLine(m_node, dummy, cmd.toStdString());
         return;
     }
 

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -949,6 +949,10 @@ void RPCConsole::on_lineEdit_returnPressed()
         return;
     }
 
+    if (m_is_executing) {
+        return;
+    }
+
     ui->lineEdit->clear();
 
 #ifdef ENABLE_WALLET
@@ -967,6 +971,7 @@ void RPCConsole::on_lineEdit_returnPressed()
     message(CMD_REQUEST, QString::fromStdString(strFilteredCmd));
     //: A console message indicating an entered command is currently being executed.
     message(CMD_REPLY, tr("Executing…"));
+    m_is_executing = true;
     Q_EMIT cmdRequest(cmd, m_last_wallet_model);
 
     cmd = QString::fromStdString(strFilteredCmd);
@@ -1018,6 +1023,7 @@ void RPCConsole::startExecutor()
         ui->messagesWidget->undo();
         message(category, command);
         scrollToEnd();
+        m_is_executing = false;
     });
 
     // Requests from this object must go to executor

--- a/src/qt/rpcconsole.h
+++ b/src/qt/rpcconsole.h
@@ -166,6 +166,7 @@ private:
     QCompleter *autoCompleter = nullptr;
     QThread thread;
     WalletModel* m_last_wallet_model{nullptr};
+    bool m_is_executing{false};
 
     /** Update UI with latest network info from model. */
     void updateNetworkState();

--- a/src/qt/test/apptests.cpp
+++ b/src/qt/test/apptests.cpp
@@ -40,7 +40,7 @@ void TestRpcCommand(RPCConsole* console)
     QTest::keyClicks(lineEdit, "getblockchaininfo");
     QTest::keyClick(lineEdit, Qt::Key_Return);
     QVERIFY(mw_spy.wait(1000));
-    QCOMPARE(mw_spy.count(), 2);
+    QCOMPARE(mw_spy.count(), 4);
     QString output = messagesWidget->toPlainText();
     UniValue value;
     value.read(output.right(output.size() - output.lastIndexOf(QChar::ObjectReplacementCharacter) - 1).toStdString());


### PR DESCRIPTION
On master (3f512f3d563954547061ee743648b57a900cbe04) it is possible to enter another command while the current command is still being executed. That makes a mess in the output.

With this PR:
![Screenshot from 2020-10-29 20-48-55](https://user-images.githubusercontent.com/32963518/97619690-329c0880-1a29-11eb-9f5b-6ae3c02c13b2.png)

Some previous context: https://github.com/bitcoin-core/gui/pull/59#issuecomment-715275185

---

It is still possible to enter and execute the `stop` command any time.