### PR TITLE
Fix Shortcut Ambiguities, Clean up text

### DIFF
--- a/src/qt/forms/optionsdialog.ui
+++ b/src/qt/forms/optionsdialog.ui
@@ -673,7 +673,7 @@
             <string>Third party URLs (e.g. a block explorer) that appear in the transactions tab as context menu items. %s in the URL is replaced by transaction hash. Multiple URLs are separated by vertical bar |.</string>
            </property>
            <property name="text">
-            <string>&amp;Third party transaction URLs</string>
+            <string>&amp;Third party transaction URLs:</string>
            </property>
            <property name="buddy">
             <cstring>thirdPartyTxUrls</cstring>

--- a/src/qt/forms/optionsdialog.ui
+++ b/src/qt/forms/optionsdialog.ui
@@ -33,7 +33,7 @@
           <string>Automatically start %1 after logging in to the system.</string>
          </property>
          <property name="text">
-          <string>&amp;Start %1 on system login</string>
+          <string>Start &amp;%1 on system login</string>
          </property>
         </widget>
        </item>
@@ -58,7 +58,7 @@
            <string>Disables some advanced features but all blocks will still be fully validated. Reverting this setting requires re-downloading the entire blockchain. Actual disk usage may be somewhat higher.</string>
           </property>
           <property name="text">
-           <string>Prune &amp;block storage to</string>
+           <string>&amp;Prune block storage to:</string>
           </property>
          </widget>
         </item>
@@ -105,7 +105,7 @@
          <item>
           <widget class="QLabel" name="databaseCacheLabel">
            <property name="text">
-            <string>Size of &amp;database cache</string>
+            <string>&amp;Size of database cache:</string>
            </property>
            <property name="textFormat">
             <enum>Qt::PlainText</enum>
@@ -148,7 +148,7 @@
          <item>
           <widget class="QLabel" name="threadsScriptVerifLabel">
            <property name="text">
-            <string>Number of script &amp;verification threads</string>
+            <string>Number of script &amp;verification threads:</string>
            </property>
            <property name="textFormat">
             <enum>Qt::PlainText</enum>
@@ -212,7 +212,7 @@
              <string>Whether to show coin control features or not.</string>
             </property>
             <property name="text">
-             <string>Enable coin &amp;control features</string>
+             <string>&amp;Enable coin control features</string>
             </property>
            </widget>
           </item>
@@ -275,7 +275,7 @@
           <string>Connect to the Bitcoin network through a SOCKS5 proxy.</string>
          </property>
          <property name="text">
-          <string>&amp;Connect through SOCKS5 proxy (default proxy):</string>
+          <string>Connect through SOCKS&amp;5 proxy (default proxy):</string>
          </property>
         </widget>
        </item>
@@ -583,7 +583,7 @@
           <string>Show only a tray icon after minimizing the window.</string>
          </property>
          <property name="text">
-          <string>&amp;Minimize to the tray instead of the taskbar</string>
+          <string>Minimize to the &amp;tray instead of the taskbar</string>
          </property>
         </widget>
        </item>


### PR DESCRIPTION
Removes shortcut ambiguities found in the Settings -> Options menu. Builds upon this [rationale](https://github.com/bitcoin-core/gui/issues/126#issuecomment-720837550).


#### Before/Master
![master](https://user-images.githubusercontent.com/23396902/98448302-110de180-20f9-11eb-8265-7f1695fb8635.png)

#### After/PR
![pr](https://user-images.githubusercontent.com/23396902/98448377-95f8fb00-20f9-11eb-80c5-20286075e3d2.png)


#### Main Tab
1. `Start Bitcoin Core on system login`
   - Moved shortcut from [**S**]tart to -> [**B**]itcoin in order to reserve S for `Size of database cache`
2. `Prune block storage to`
   - Moved shortcut from [**B**]lock to -> [**P**]rune in order to reserve B for `Start Bitcoin Core on system login`
   - Added a colon at the end since this text denotes a data field
3. `Size of database cache`
   - Moved shortcut from [**D**]atabase to -> [**S**]ize in order to fix the conflict with the `Display` tab shortcut
   - Added a colon at the end since this text denotes a data field
4. `Number of script verfication threads`
   - Added a colon at the end since this text denotes a data field

#### Wallet Tab
1. `Enable coin control features`
   - Moved shortcut from [**C**]oin to -> [**E**]nable in order to fix conflict with the `Cancel` button

#### Network Tab
1. `Connect through SOCKS5 proxy (default proxy):
   - Moved shortcut from [**C**]onnect to -> SOCKS[**5**] in order to fix conlict with the `Cancel` button

#### Window Tab
1. `Minimize to the tray instead of the taskbar`
   - Moved shortcut from [**M**]inimize to -> [**T**]ray in order to fix conflict with the `Main` tab

Closes #126 
