### PR TITLE
qt: Reduce overlay animation to 250ms

### DIFF
--- a/src/qt/modaloverlay.cpp
+++ b/src/qt/modaloverlay.cpp
@@ -36,7 +36,7 @@ userClosed(false)
 
     m_animation.setTargetObject(this);
     m_animation.setPropertyName("pos");
-    m_animation.setDuration(300 /* ms */);
+    m_animation.setDuration(250 /* ms */);
     m_animation.setEasingCurve(QEasingCurve::OutQuad);
 }
 


### PR DESCRIPTION
A faster transition will be perceived better from a UX perspective.
