### PR TITLE
qt: Support macOS Dark mode

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -51,9 +51,7 @@ Core should also work on most other Unix-like systems but is not as
 frequently tested on them.  It is not recommended to use Bitcoin Core on
 unsupported systems.
 
-From Bitcoin Core 0.22.0 onwards, macOS versions earlier than 10.14 are no
-longer supported. Additionally, Bitcoin Core does not yet change appearance
-when macOS "dark mode" is activated.
+From Bitcoin Core 22.0 onwards, macOS versions earlier than 10.14 are no longer supported.
 
 Notable changes
 ===============

--- a/share/qt/Info.plist.in
+++ b/share/qt/Info.plist.in
@@ -60,9 +60,6 @@
   <key>NSHighResolutionCapable</key>
     <string>True</string>
 
-  <key>NSRequiresAquaSystemAppearance</key>
-    <string>True</string>
-
   <key>LSApplicationCategoryType</key>
     <string>public.app-category.finance</string>
 </dict>

--- a/src/qt/platformstyle.cpp
+++ b/src/qt/platformstyle.cpp
@@ -18,7 +18,7 @@ static const struct {
     /** Extra padding/spacing in transactionview */
     const bool useExtraSpacing;
 } platform_styles[] = {
-    {"macosx", false, false, true},
+    {"macosx", false, true, true},
     {"windows", true, false, false},
     /* Other: linux, unix, ... */
     {"other", true, true, false}


### PR DESCRIPTION
Allow icons to be colorized on macOS to support native Dark mode color scheme.

Rendering on macOS Big Sur before PR:
![macos-darkmode-before-pr](https://user-images.githubusercontent.com/5577626/102502739-43f3af80-407f-11eb-9263-5bbc27b371c2.png)

Rendering on macOS Big Sur after PR:
![macos-darkmode-after-pr](https://user-images.githubusercontent.com/5577626/102502678-350cfd00-407f-11eb-8b98-e271f2688c36.png)

Light mode stay visually unchanged.

<del>Note, that this currently only affect the build from source, as the macos dmg includes an attributes to force light color scheme on macos windows (see https://github.com/bitcoin/bitcoin/pull/14593). </del>
<del>But once all glitches are fixed, we will be able to remove this temporary fix. </del>
Edit: this PR is know including the removal of `NSRequiresAquaSystemAppearance` on Info.plist file so that the color fix is apply to every build.

Linked issues: #68 #136 