### PR TITLE
Fix checkbox layout in Create Wallet dialog

### DIFF
--- a/src/qt/forms/createwalletdialog.ui
+++ b/src/qt/forms/createwalletdialog.ui
@@ -60,7 +60,7 @@
     <rect>
      <x>20</x>
      <y>50</y>
-     <width>171</width>
+     <width>220</width>
      <height>22</height>
     </rect>
    </property>
@@ -79,7 +79,7 @@
     <rect>
      <x>20</x>
      <y>90</y>
-     <width>130</width>
+     <width>220</width>
      <height>21</height>
     </rect>
    </property>
@@ -98,7 +98,7 @@
     <rect>
      <x>20</x>
      <y>115</y>
-     <width>171</width>
+     <width>220</width>
      <height>22</height>
     </rect>
    </property>
@@ -130,7 +130,7 @@
     <rect>
      <x>20</x>
      <y>155</y>
-     <width>171</width>
+     <width>220</width>
      <height>22</height>
     </rect>
    </property>


### PR DESCRIPTION
From https://github.com/bitcoin/bitcoin/issues/20555#issuecomment-747742627:
> 0.21.0rc3 compiled from source, Ubuntu 20.04 + i3: tested mainnet, testnet, and signet. created a descriptor wallet in qt, tested torv3 with addnode, and checked if anchors.dat is created on shutdown and removed on startup.
> 
> I've noticed the "Advanced options" label being cut-off in the wallet creation dialog.

This PR should fix this issue.