### PR TITLE
Add PeerTableModel::StatsRole to prevent data layer violation

### DIFF
--- a/src/qt/peertablemodel.cpp
+++ b/src/qt/peertablemodel.cpp
@@ -221,11 +221,6 @@ QModelIndex PeerTableModel::index(int row, int column, const QModelIndex &parent
     return QModelIndex();
 }
 
-const CNodeCombinedStats *PeerTableModel::getNodeStats(int idx)
-{
-    return priv->index(idx);
-}
-
 void PeerTableModel::refresh()
 {
     Q_EMIT layoutAboutToBeChanged();

--- a/src/qt/peertablemodel.cpp
+++ b/src/qt/peertablemodel.cpp
@@ -181,6 +181,11 @@ QVariant PeerTableModel::data(const QModelIndex &index, int role) const
             default:
                 return QVariant();
         }
+    } else if (role == StatsRole) {
+        switch (index.column()) {
+        case NetNodeId: return QVariant::fromValue(rec);
+        default: return QVariant();
+        }
     }
 
     return QVariant();

--- a/src/qt/peertablemodel.h
+++ b/src/qt/peertablemodel.h
@@ -28,6 +28,7 @@ struct CNodeCombinedStats {
     CNodeStateStats nodeStateStats;
     bool fNodeStateStatsAvailable;
 };
+Q_DECLARE_METATYPE(CNodeCombinedStats*)
 
 class NodeLessThan
 {
@@ -65,6 +66,10 @@ public:
         Sent = 4,
         Received = 5,
         Subversion = 6
+    };
+
+    enum {
+        StatsRole = Qt::UserRole,
     };
 
     /** @name Methods overridden from QAbstractTableModel

--- a/src/qt/peertablemodel.h
+++ b/src/qt/peertablemodel.h
@@ -53,7 +53,6 @@ class PeerTableModel : public QAbstractTableModel
 public:
     explicit PeerTableModel(interfaces::Node& node, QObject* parent);
     ~PeerTableModel();
-    const CNodeCombinedStats *getNodeStats(int idx);
     int getRowByNodeId(NodeId nodeid);
     void startAutoRefresh();
     void stopAutoRefresh();


### PR DESCRIPTION
This PR allows to access to the `CNodeCombinedStats` instance directly from any view object.

The `PeerTableModel::getNodeStats` member function removed as a kind of layer violation.

No behavior changes.

Also other pulls (bugfixes) are based on this one: #18 and #164.