### PR TITLE
Handle peer addition/removal in a right way

### DIFF
--- a/src/qt/peertablemodel.cpp
+++ b/src/qt/peertablemodel.cpp
@@ -84,7 +84,7 @@ void PeerTableModel::stopAutoRefresh()
     timer->stop();
 }
 
-int PeerTableModel::rowCount(const QModelIndex &parent) const
+int PeerTableModel::rowCount(const QModelIndex& parent) const
 {
     if (parent.isValid()) {
         return 0;
@@ -92,7 +92,7 @@ int PeerTableModel::rowCount(const QModelIndex &parent) const
     return priv->size();
 }
 
-int PeerTableModel::columnCount(const QModelIndex &parent) const
+int PeerTableModel::columnCount(const QModelIndex& parent) const
 {
     if (parent.isValid()) {
         return 0;
@@ -100,7 +100,7 @@ int PeerTableModel::columnCount(const QModelIndex &parent) const
     return columns.length();
 }
 
-QVariant PeerTableModel::data(const QModelIndex &index, int role) const
+QVariant PeerTableModel::data(const QModelIndex& index, int role) const
 {
     if(!index.isValid())
         return QVariant();
@@ -172,7 +172,7 @@ Qt::ItemFlags PeerTableModel::flags(const QModelIndex &index) const
     return retval;
 }
 
-QModelIndex PeerTableModel::index(int row, int column, const QModelIndex &parent) const
+QModelIndex PeerTableModel::index(int row, int column, const QModelIndex& parent) const
 {
     Q_UNUSED(parent);
     CNodeCombinedStats *data = priv->index(row);

--- a/src/qt/peertablemodel.h
+++ b/src/qt/peertablemodel.h
@@ -73,6 +73,9 @@ public:
 public Q_SLOTS:
     void refresh();
 
+Q_SIGNALS:
+    void changed();
+
 private:
     //! Internal peer data structure.
     QList<CNodeCombinedStats> m_peers_data{};

--- a/src/qt/peertablemodel.h
+++ b/src/qt/peertablemodel.h
@@ -61,11 +61,11 @@ public:
 
     /** @name Methods overridden from QAbstractTableModel
         @{*/
-    int rowCount(const QModelIndex &parent) const override;
-    int columnCount(const QModelIndex &parent) const override;
-    QVariant data(const QModelIndex &index, int role) const override;
-    QVariant headerData(int section, Qt::Orientation orientation, int role) const override;
-    QModelIndex index(int row, int column, const QModelIndex &parent) const override;
+    int rowCount(const QModelIndex& parent = QModelIndex()) const override;
+    int columnCount(const QModelIndex& parent = QModelIndex()) const override;
+    QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
+    QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
+    QModelIndex index(int row, int column, const QModelIndex& parent = QModelIndex()) const override;
     Qt::ItemFlags flags(const QModelIndex &index) const override;
     /*@}*/
 

--- a/src/qt/peertablemodel.h
+++ b/src/qt/peertablemodel.h
@@ -8,10 +8,11 @@
 #include <net_processing.h> // For CNodeStateStats
 #include <net.h>
 
-#include <memory>
-
 #include <QAbstractTableModel>
+#include <QList>
+#include <QModelIndex>
 #include <QStringList>
+#include <QVariant>
 
 class PeerTablePriv;
 
@@ -73,6 +74,8 @@ public Q_SLOTS:
     void refresh();
 
 private:
+    //! Internal peer data structure.
+    QList<CNodeCombinedStats> m_peers_data{};
     interfaces::Node& m_node;
     const QStringList columns{
         /*: Title of Peers Table column which contains a
@@ -99,7 +102,6 @@ private:
         /*: Title of Peers Table column which contains the peer's
             User Agent string. */
         tr("User Agent")};
-    std::unique_ptr<PeerTablePriv> priv;
     QTimer *timer;
 };
 

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -656,7 +656,7 @@ void RPCConsole::setClientModel(ClientModel *model, int bestblock_height, int64_
 
         // peer table signal handling - update peer details when selecting new node
         connect(ui->peerWidget->selectionModel(), &QItemSelectionModel::selectionChanged, this, &RPCConsole::updateDetailWidget);
-        connect(model->getPeerTableModel(), &PeerTableModel::layoutChanged, this, &RPCConsole::updateDetailWidget);
+        connect(model->getPeerTableModel(), &PeerTableModel::changed, this, &RPCConsole::updateDetailWidget);
 
         // set up ban table
         ui->banlistWidget->setModel(model->getBanTableModel());


### PR DESCRIPTION
This PR makes `PeerTableModel` handle a peer addition/removal in a right way. See:
- https://doc.qt.io/qt-5/model-view-programming.html#inserting-and-removing-rows
- https://doc.qt.io/qt-5/model-view-programming.html#resizable-models

Fixes #160.

Fixes #191.