### PR TITLE
Use layout manager for Create Wallet dialog

### DIFF
--- a/src/qt/forms/createwalletdialog.ui
+++ b/src/qt/forms/createwalletdialog.ui
@@ -7,140 +7,135 @@
     <x>0</x>
     <y>0</y>
     <width>364</width>
-    <height>213</height>
+    <height>249</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Create Wallet</string>
   </property>
-  <widget class="QDialogButtonBox" name="buttonBox">
-   <property name="geometry">
-    <rect>
-     <x>10</x>
-     <y>170</y>
-     <width>341</width>
-     <height>32</height>
-    </rect>
-   </property>
-   <property name="orientation">
-    <enum>Qt::Horizontal</enum>
-   </property>
-   <property name="standardButtons">
-    <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-   </property>
-  </widget>
-  <widget class="QLineEdit" name="wallet_name_line_edit">
-   <property name="geometry">
-    <rect>
-     <x>120</x>
-     <y>20</y>
-     <width>231</width>
-     <height>24</height>
-    </rect>
-   </property>
-   <property name="placeholderText">
-     <string>Wallet</string>
-   </property>
-  </widget>
-  <widget class="QLabel" name="label">
-   <property name="geometry">
-    <rect>
-     <x>20</x>
-     <y>20</y>
-     <width>101</width>
-     <height>21</height>
-    </rect>
-   </property>
-   <property name="text">
-    <string>Wallet Name</string>
-   </property>
-  </widget>
-  <widget class="QCheckBox" name="encrypt_wallet_checkbox">
-   <property name="geometry">
-    <rect>
-     <x>20</x>
-     <y>50</y>
-     <width>220</width>
-     <height>22</height>
-    </rect>
-   </property>
-   <property name="toolTip">
-    <string>Encrypt the wallet. The wallet will be encrypted with a passphrase of your choice.</string>
-   </property>
-   <property name="text">
-    <string>Encrypt Wallet</string>
-   </property>
-   <property name="checked">
-    <bool>false</bool>
-   </property>
-  </widget>
-  <widget class="QLabel" name="advanced_options_label">
-   <property name="geometry">
-    <rect>
-     <x>20</x>
-     <y>90</y>
-     <width>220</width>
-     <height>21</height>
-    </rect>
-   </property>
-   <property name="styleSheet">
-    <string notr="true">font-weight:bold;</string>
-   </property>
-   <property name="text">
-    <string>Advanced options</string>
-   </property>
-  </widget>
-  <widget class="QCheckBox" name="disable_privkeys_checkbox">
-   <property name="enabled">
-    <bool>true</bool>
-   </property>
-   <property name="geometry">
-    <rect>
-     <x>20</x>
-     <y>115</y>
-     <width>220</width>
-     <height>22</height>
-    </rect>
-   </property>
-   <property name="toolTip">
-    <string>Disable private keys for this wallet. Wallets with private keys disabled will have no private keys and cannot have an HD seed or imported private keys. This is ideal for watch-only wallets.</string>
-   </property>
-   <property name="text">
-    <string>Disable Private Keys</string>
-   </property>
-  </widget>
-  <widget class="QCheckBox" name="blank_wallet_checkbox">
-   <property name="geometry">
-    <rect>
-     <x>20</x>
-     <y>135</y>
-     <width>220</width>
-     <height>22</height>
-    </rect>
-   </property>
-   <property name="toolTip">
-    <string>Make a blank wallet. Blank wallets do not initially have private keys or scripts. Private keys and addresses can be imported, or an HD seed can be set, at a later time.</string>
-   </property>
-   <property name="text">
-    <string>Make Blank Wallet</string>
-   </property>
-  </widget>
-  <widget class="QCheckBox" name="descriptor_checkbox">
-   <property name="geometry">
-    <rect>
-     <x>20</x>
-     <y>155</y>
-     <width>220</width>
-     <height>22</height>
-    </rect>
-   </property>
-   <property name="toolTip">
-    <string>Use descriptors for scriptPubKey management</string>
-   </property>
-   <property name="text">
-    <string>Descriptor Wallet</string>
-   </property>
-  </widget>
+  <property name="sizeGripEnabled">
+   <bool>true</bool>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QLabel" name="wallet_name_label">
+       <property name="text">
+        <string>Wallet Name</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="wallet_name_line_edit">
+       <property name="minimumSize">
+        <size>
+         <width>262</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="placeholderText">
+        <string>Wallet</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="encrypt_wallet_checkbox">
+     <property name="toolTip">
+      <string>Encrypt the wallet. The wallet will be encrypted with a passphrase of your choice.</string>
+     </property>
+     <property name="text">
+      <string>Encrypt Wallet</string>
+     </property>
+     <property name="checked">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer_1">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Fixed</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>8</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
+      <string>Advanced Options</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_groupbox">
+      <item>
+       <widget class="QCheckBox" name="disable_privkeys_checkbox">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="toolTip">
+         <string>Disable private keys for this wallet. Wallets with private keys disabled will have no private keys and cannot have an HD seed or imported private keys. This is ideal for watch-only wallets.</string>
+        </property>
+        <property name="text">
+         <string>Disable Private Keys</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="blank_wallet_checkbox">
+        <property name="toolTip">
+         <string>Make a blank wallet. Blank wallets do not initially have private keys or scripts. Private keys and addresses can be imported, or an HD seed can be set, at a later time.</string>
+        </property>
+        <property name="text">
+         <string>Make Blank Wallet</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="descriptor_checkbox">
+        <property name="toolTip">
+         <string>Use descriptors for scriptPubKey management</string>
+        </property>
+        <property name="text">
+         <string>Descriptor Wallet</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer_2">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>0</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
  </widget>
  <tabstops>
   <tabstop>wallet_name_line_edit</tabstop>


### PR DESCRIPTION
On master (e75f91eae3936269b40b4bfdfe540d5526270936) not using layout manager causes problems with resizing:

![Screenshot from 2021-01-01 13-03-13](https://user-images.githubusercontent.com/32963518/103437728-ce1d4580-4c33-11eb-8915-1e9482775653.png)
![Screenshot from 2021-01-01 13-03-26](https://user-images.githubusercontent.com/32963518/103437730-d6758080-4c33-11eb-9e0f-87d0dd487fcb.png)

Also text labels are not resized properly on some window managers (https://github.com/bitcoin/bitcoin/issues/20777), or if their lengths are changed (after translation).

This PR introduces a standard layout manager for the "Create Wallet" dialog that fixes all layout issues (actually, the `createwalletdialog.ui` has been re-written from scratch):

![Screenshot from 2021-01-01 13-10-03](https://user-images.githubusercontent.com/32963518/103437822-d0cc6a80-4c34-11eb-84fd-fcb10a16d9ef.png)
![Screenshot from 2021-01-06 23-50-36](https://user-images.githubusercontent.com/32963518/103823090-0b416780-507a-11eb-89dd-3f48a358e168.png)

Additional visual changes:
- advanced options are grouped in `QGroupBox` (https://github.com/bitcoin-core/gui/pull/96#issuecomment-726337165)
- enabled the [size grip](https://doc.qt.io/qt-5/qsizegrip.html#details)

Fix https://github.com/bitcoin/bitcoin/issues/20777