### PR TITLE
refactor: No need to implement index for non-hierarchical models

### DIFF
--- a/src/qt/addresstablemodel.cpp
+++ b/src/qt/addresstablemodel.cpp
@@ -196,7 +196,7 @@ QVariant AddressTableModel::data(const QModelIndex &index, int role) const
     if(!index.isValid())
         return QVariant();
 
-    AddressTableEntry *rec = static_cast<AddressTableEntry*>(index.internalPointer());
+    const AddressTableEntry* rec{priv->index(index.row())};
 
     if(role == Qt::DisplayRole || role == Qt::EditRole)
     {
@@ -242,7 +242,8 @@ bool AddressTableModel::setData(const QModelIndex &index, const QVariant &value,
 {
     if(!index.isValid())
         return false;
-    AddressTableEntry *rec = static_cast<AddressTableEntry*>(index.internalPointer());
+
+    const AddressTableEntry* rec{priv->index(index.row())};
     std::string strPurpose = (rec->type == AddressTableEntry::Sending ? "send" : "receive");
     editStatus = OK;
 
@@ -310,7 +311,7 @@ Qt::ItemFlags AddressTableModel::flags(const QModelIndex &index) const
 {
     if (!index.isValid()) return Qt::NoItemFlags;
 
-    AddressTableEntry *rec = static_cast<AddressTableEntry*>(index.internalPointer());
+    const AddressTableEntry* rec{priv->index(index.row())};
 
     Qt::ItemFlags retval = Qt::ItemIsSelectable | Qt::ItemIsEnabled;
     // Can edit address and label for sending addresses,
@@ -321,20 +322,6 @@ Qt::ItemFlags AddressTableModel::flags(const QModelIndex &index) const
         retval |= Qt::ItemIsEditable;
     }
     return retval;
-}
-
-QModelIndex AddressTableModel::index(int row, int column, const QModelIndex &parent) const
-{
-    Q_UNUSED(parent);
-    AddressTableEntry *data = priv->index(row);
-    if(data)
-    {
-        return createIndex(row, column, priv->index(row));
-    }
-    else
-    {
-        return QModelIndex();
-    }
 }
 
 void AddressTableModel::updateEntry(const QString &address,

--- a/src/qt/addresstablemodel.h
+++ b/src/qt/addresstablemodel.h
@@ -57,7 +57,6 @@ public:
     QVariant data(const QModelIndex &index, int role) const override;
     bool setData(const QModelIndex &index, const QVariant &value, int role) override;
     QVariant headerData(int section, Qt::Orientation orientation, int role) const override;
-    QModelIndex index(int row, int column, const QModelIndex &parent) const override;
     bool removeRows(int row, int count, const QModelIndex &parent = QModelIndex()) override;
     Qt::ItemFlags flags(const QModelIndex &index) const override;
     /*@}*/

--- a/src/qt/bantablemodel.cpp
+++ b/src/qt/bantablemodel.cpp
@@ -117,7 +117,7 @@ QVariant BanTableModel::data(const QModelIndex &index, int role) const
     if(!index.isValid())
         return QVariant();
 
-    CCombinedBan *rec = static_cast<CCombinedBan*>(index.internalPointer());
+    const CCombinedBan* rec{priv->index(index.row())};
 
     if (role == Qt::DisplayRole) {
         switch(index.column())
@@ -152,16 +152,6 @@ Qt::ItemFlags BanTableModel::flags(const QModelIndex &index) const
 
     Qt::ItemFlags retval = Qt::ItemIsSelectable | Qt::ItemIsEnabled;
     return retval;
-}
-
-QModelIndex BanTableModel::index(int row, int column, const QModelIndex &parent) const
-{
-    Q_UNUSED(parent);
-    CCombinedBan *data = priv->index(row);
-
-    if (data)
-        return createIndex(row, column, data);
-    return QModelIndex();
 }
 
 void BanTableModel::refresh()

--- a/src/qt/bantablemodel.h
+++ b/src/qt/bantablemodel.h
@@ -60,7 +60,6 @@ public:
     int columnCount(const QModelIndex &parent) const override;
     QVariant data(const QModelIndex &index, int role) const override;
     QVariant headerData(int section, Qt::Orientation orientation, int role) const override;
-    QModelIndex index(int row, int column, const QModelIndex &parent) const override;
     Qt::ItemFlags flags(const QModelIndex &index) const override;
     void sort(int column, Qt::SortOrder order) override;
     /*@}*/

--- a/src/qt/peertablemodel.cpp
+++ b/src/qt/peertablemodel.cpp
@@ -153,7 +153,7 @@ QVariant PeerTableModel::data(const QModelIndex &index, int role) const
     if(!index.isValid())
         return QVariant();
 
-    CNodeCombinedStats *rec = static_cast<CNodeCombinedStats*>(index.internalPointer());
+    CNodeCombinedStats* rec{priv->index(index.row())};
 
     if (role == Qt::DisplayRole) {
         switch(index.column())
@@ -213,16 +213,6 @@ Qt::ItemFlags PeerTableModel::flags(const QModelIndex &index) const
 
     Qt::ItemFlags retval = Qt::ItemIsSelectable | Qt::ItemIsEnabled;
     return retval;
-}
-
-QModelIndex PeerTableModel::index(int row, int column, const QModelIndex &parent) const
-{
-    Q_UNUSED(parent);
-    CNodeCombinedStats *data = priv->index(row);
-
-    if (data)
-        return createIndex(row, column, data);
-    return QModelIndex();
 }
 
 void PeerTableModel::refresh()

--- a/src/qt/peertablemodel.h
+++ b/src/qt/peertablemodel.h
@@ -77,7 +77,6 @@ public:
     int columnCount(const QModelIndex &parent) const override;
     QVariant data(const QModelIndex &index, int role) const override;
     QVariant headerData(int section, Qt::Orientation orientation, int role) const override;
-    QModelIndex index(int row, int column, const QModelIndex &parent) const override;
     Qt::ItemFlags flags(const QModelIndex &index) const override;
     void sort(int column, Qt::SortOrder order) override;
     /*@}*/

--- a/src/qt/recentrequeststablemodel.cpp
+++ b/src/qt/recentrequeststablemodel.cpp
@@ -127,13 +127,6 @@ QString RecentRequestsTableModel::getAmountTitle()
     return (this->walletModel->getOptionsModel() != nullptr) ? tr("Requested") + " ("+BitcoinUnits::shortName(this->walletModel->getOptionsModel()->getDisplayUnit()) + ")" : "";
 }
 
-QModelIndex RecentRequestsTableModel::index(int row, int column, const QModelIndex &parent) const
-{
-    Q_UNUSED(parent);
-
-    return createIndex(row, column);
-}
-
 bool RecentRequestsTableModel::removeRows(int row, int count, const QModelIndex &parent)
 {
     Q_UNUSED(parent);

--- a/src/qt/recentrequeststablemodel.h
+++ b/src/qt/recentrequeststablemodel.h
@@ -70,7 +70,6 @@ public:
     QVariant data(const QModelIndex &index, int role) const override;
     bool setData(const QModelIndex &index, const QVariant &value, int role) override;
     QVariant headerData(int section, Qt::Orientation orientation, int role) const override;
-    QModelIndex index(int row, int column, const QModelIndex &parent = QModelIndex()) const override;
     bool removeRows(int row, int count, const QModelIndex &parent = QModelIndex()) override;
     Qt::ItemFlags flags(const QModelIndex &index) const override;
     void sort(int column, Qt::SortOrder order = Qt::AscendingOrder) override;

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -523,7 +523,8 @@ QVariant TransactionTableModel::data(const QModelIndex &index, int role) const
 {
     if(!index.isValid())
         return QVariant();
-    TransactionRecord *rec = static_cast<TransactionRecord*>(index.internalPointer());
+
+    TransactionRecord* rec{priv->index(walletModel->wallet(), walletModel->getLastBlockProcessed(), index.row())};
 
     switch(role)
     {
@@ -688,17 +689,6 @@ QVariant TransactionTableModel::headerData(int section, Qt::Orientation orientat
         }
     }
     return QVariant();
-}
-
-QModelIndex TransactionTableModel::index(int row, int column, const QModelIndex &parent) const
-{
-    Q_UNUSED(parent);
-    TransactionRecord* data = priv->index(walletModel->wallet(), walletModel->getLastBlockProcessed(), row);
-    if(data)
-    {
-        return createIndex(row, column, data);
-    }
-    return QModelIndex();
 }
 
 void TransactionTableModel::updateDisplayUnit()

--- a/src/qt/transactiontablemodel.h
+++ b/src/qt/transactiontablemodel.h
@@ -80,7 +80,6 @@ public:
     int columnCount(const QModelIndex &parent) const override;
     QVariant data(const QModelIndex &index, int role) const override;
     QVariant headerData(int section, Qt::Orientation orientation, int role) const override;
-    QModelIndex index(int row, int column, const QModelIndex & parent = QModelIndex()) const override;
     bool processingQueuedTransactions() const { return fProcessingQueuedTransactions; }
 
 private:


### PR DESCRIPTION
From Qt docs:

- https://doc.qt.io/qt-5/model-view-programming.html#a-read-only-example-model:
> If our model was hierarchical, we would also have to implement the `index()` and `parent()` functions.

- https://doc.qt.io/qt-5/qabstracttablemodel.html#subclassing:
> Default implementations of the `index()` and `parent()` functions are provided by `QAbstractTableModel`.