### PR TITLE
Add `Type` column to peers window, update peer details name/tooltip

### DIFF
--- a/src/qt/forms/debugwindow.ui
+++ b/src/qt/forms/debugwindow.ui
@@ -1079,10 +1079,10 @@
                <item row="1" column="0">
                 <widget class="QLabel" name="peerConnectionTypeLabel">
                  <property name="toolTip">
-                   <string>The type of peer connection: %1</string>
+                   <string>The direction and type of peer connection: %1</string>
                  </property>
                  <property name="text">
-                  <string>Connection Type</string>
+                  <string>Direction/Type</string>
                  </property>
                 </widget>
                </item>

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -766,15 +766,19 @@ QString NetworkToQString(Network net)
     assert(false);
 }
 
-QString ConnectionTypeToQString(ConnectionType conn_type)
+QString ConnectionTypeToQString(ConnectionType conn_type, bool prepend_direction)
 {
+    QString prefix;
+    if (prepend_direction) {
+        prefix = (conn_type == ConnectionType::INBOUND) ? QObject::tr("Inbound") : QObject::tr("Outbound") + " ";
+    }
     switch (conn_type) {
-    case ConnectionType::INBOUND: return QObject::tr("Inbound");
-    case ConnectionType::OUTBOUND_FULL_RELAY: return QObject::tr("Outbound Full Relay");
-    case ConnectionType::BLOCK_RELAY: return QObject::tr("Outbound Block Relay");
-    case ConnectionType::MANUAL: return QObject::tr("Outbound Manual");
-    case ConnectionType::FEELER: return QObject::tr("Outbound Feeler");
-    case ConnectionType::ADDR_FETCH: return QObject::tr("Outbound Address Fetch");
+    case ConnectionType::INBOUND: return prefix;
+    case ConnectionType::OUTBOUND_FULL_RELAY: return prefix + QObject::tr("Full Relay");
+    case ConnectionType::BLOCK_RELAY: return prefix + QObject::tr("Block Relay");
+    case ConnectionType::MANUAL: return prefix + QObject::tr("Manual");
+    case ConnectionType::FEELER: return prefix + QObject::tr("Feeler");
+    case ConnectionType::ADDR_FETCH: return prefix + QObject::tr("Address Fetch");
     } // no default case, so the compiler can warn about missing cases
     assert(false);
 }

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -233,7 +233,7 @@ namespace GUIUtil
     QString NetworkToQString(Network net);
 
     /** Convert enum ConnectionType to QString */
-    QString ConnectionTypeToQString(ConnectionType conn_type);
+    QString ConnectionTypeToQString(ConnectionType conn_type, bool prepend_direction);
 
     /** Convert seconds into a QString with days, hours, mins, secs */
     QString formatDurationStr(int secs);

--- a/src/qt/peertablemodel.cpp
+++ b/src/qt/peertablemodel.cpp
@@ -29,6 +29,8 @@ bool NodeLessThan::operator()(const CNodeCombinedStats &left, const CNodeCombine
         return pLeft->nodeid < pRight->nodeid;
     case PeerTableModel::Address:
         return pLeft->addrName.compare(pRight->addrName) < 0;
+    case PeerTableModel::ConnectionType:
+        return pLeft->m_conn_type < pRight->m_conn_type;
     case PeerTableModel::Network:
         return pLeft->m_network < pRight->m_network;
     case PeerTableModel::Ping:
@@ -163,6 +165,8 @@ QVariant PeerTableModel::data(const QModelIndex &index, int role) const
         case Address:
             // prepend to peer address down-arrow symbol for inbound connection and up-arrow for outbound connection
             return QString(rec->nodeStats.fInbound ? "↓ " : "↑ ") + QString::fromStdString(rec->nodeStats.addrName);
+        case ConnectionType:
+            return GUIUtil::ConnectionTypeToQString(rec->nodeStats.m_conn_type, /* prepend_direction */ false);
         case Network:
             return GUIUtil::NetworkToQString(rec->nodeStats.m_network);
         case Ping:
@@ -176,6 +180,7 @@ QVariant PeerTableModel::data(const QModelIndex &index, int role) const
         }
     } else if (role == Qt::TextAlignmentRole) {
         switch (index.column()) {
+            case ConnectionType:
             case Network:
                 return QVariant(Qt::AlignCenter);
             case Ping:

--- a/src/qt/peertablemodel.h
+++ b/src/qt/peertablemodel.h
@@ -59,12 +59,13 @@ public:
 
     enum ColumnIndex {
         NetNodeId = 0,
-        Address = 1,
-        Network = 2,
-        Ping = 3,
-        Sent = 4,
-        Received = 5,
-        Subversion = 6
+        Address,
+        ConnectionType,
+        Network,
+        Ping,
+        Sent,
+        Received,
+        Subversion
     };
 
     enum {
@@ -87,7 +88,7 @@ public Q_SLOTS:
 
 private:
     interfaces::Node& m_node;
-    const QStringList columns{tr("Peer Id"), tr("Address"), tr("Network"), tr("Ping"), tr("Sent"), tr("Received"), tr("User Agent")};
+    const QStringList columns{tr("Peer Id"), tr("Address"), tr("Type"), tr("Network"), tr("Ping"), tr("Sent"), tr("Received"), tr("User Agent")};
     std::unique_ptr<PeerTablePriv> priv;
     QTimer *timer;
 };

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -1120,7 +1120,7 @@ void RPCConsole::updateDetailWidget()
     ui->timeoffset->setText(GUIUtil::formatTimeOffset(stats->nodeStats.nTimeOffset));
     ui->peerVersion->setText(QString::number(stats->nodeStats.nVersion));
     ui->peerSubversion->setText(QString::fromStdString(stats->nodeStats.cleanSubVer));
-    ui->peerConnectionType->setText(GUIUtil::ConnectionTypeToQString(stats->nodeStats.m_conn_type));
+    ui->peerConnectionType->setText(GUIUtil::ConnectionTypeToQString(stats->nodeStats.m_conn_type, /* prepend_direction */ true));
     ui->peerNetwork->setText(GUIUtil::NetworkToQString(stats->nodeStats.m_network));
     if (stats->nodeStats.m_permissionFlags == PF_NONE) {
         ui->peerPermissions->setText(tr("N/A"));


### PR DESCRIPTION
This pull:

- adds a sortable `Type` column to the GUI Peers tab window
- updates the peer details row to `Direction/Type`, so the `Type` column without a direction makes sense (the tooltip is also updated)

![Screenshot from 2021-02-06 22-53-11](https://user-images.githubusercontent.com/2415484/107130646-973bee80-68c7-11eb-9025-b18394ac5c93.png)
