### PR TITLE
gui: ensure inbound block relay peers have relevant services

### DIFF
--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -766,10 +766,10 @@ QString NetworkToQString(Network net)
     assert(false);
 }
 
-QString ConnectionTypeToQString(ConnectionType conn_type, bool relay_txes)
+QString ConnectionTypeToQString(ConnectionType conn_type, bool relay_txes, bool relevant_services)
 {
     switch (conn_type) {
-    case ConnectionType::INBOUND: return relay_txes ? QObject::tr("Inbound Full Relay") : QObject::tr("Inbound Block Relay");
+    case ConnectionType::INBOUND: return !relay_txes && relevant_services ? QObject::tr("Inbound Block Relay") : QObject::tr("Inbound");
     case ConnectionType::OUTBOUND_FULL_RELAY: return QObject::tr("Outbound Full Relay");
     case ConnectionType::BLOCK_RELAY: return QObject::tr("Outbound Block Relay");
     case ConnectionType::MANUAL: return QObject::tr("Outbound Manual");

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -9,6 +9,7 @@
 #include <fs.h>
 #include <net.h>
 #include <netaddress.h>
+#include <protocol.h>
 
 #include <QEvent>
 #include <QHeaderView>
@@ -233,7 +234,7 @@ namespace GUIUtil
     QString NetworkToQString(Network net);
 
     /** Convert enum ConnectionType to QString */
-    QString ConnectionTypeToQString(ConnectionType conn_type, bool relay_txes);
+    QString ConnectionTypeToQString(ConnectionType conn_type, bool relay_txes, bool relevant_services);
 
     /** Convert seconds into a QString with days, hours, mins, secs */
     QString formatDurationStr(int secs);

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -462,7 +462,7 @@ RPCConsole::RPCConsole(interfaces::Node& node, const PlatformStyle *_platformSty
 
     constexpr QChar nonbreaking_hyphen(8209);
     const std::vector<QString> CONNECTION_TYPE_DOC{
-        tr("Inbound Full/Block Relay: initiated by peer"),
+        tr("Inbound/Inbound Block Relay: initiated by peer"),
         tr("Outbound Full Relay: default"),
         tr("Outbound Block Relay: does not relay transactions or addresses"),
         tr("Outbound Manual: added using RPC %1 or %2/%3 configuration options")
@@ -1120,7 +1120,7 @@ void RPCConsole::updateDetailWidget()
     ui->timeoffset->setText(GUIUtil::formatTimeOffset(stats->nodeStats.nTimeOffset));
     ui->peerVersion->setText(QString::number(stats->nodeStats.nVersion));
     ui->peerSubversion->setText(QString::fromStdString(stats->nodeStats.cleanSubVer));
-    ui->peerConnectionType->setText(GUIUtil::ConnectionTypeToQString(stats->nodeStats.m_conn_type, stats->nodeStats.fRelayTxes));
+    ui->peerConnectionType->setText(GUIUtil::ConnectionTypeToQString(stats->nodeStats.m_conn_type, stats->nodeStats.fRelayTxes, HasAllDesirableServiceFlags(stats->nodeStats.nServices)));
     ui->peerNetwork->setText(GUIUtil::NetworkToQString(stats->nodeStats.m_network));
     if (stats->nodeStats.m_permissionFlags == PF_NONE) {
         ui->peerPermissions->setText(tr("N/A"));


### PR DESCRIPTION
Responding to https://github.com/bitcoin-core/gui/pull/180#discussion_r565863674, this ensures that inbound block relay peers have relevant services and returns all others as inbound.