### PR TITLE
peers-tab: bug fix right panel toggle

### DIFF
--- a/src/qt/forms/debugwindow.ui
+++ b/src/qt/forms/debugwindow.ui
@@ -988,7 +988,7 @@
            </item>
           </layout>
          </widget>
-         <widget class="QWidget" name="widget_2" native="true">
+         <widget class="QWidget" name="peersTabRightPanel" native="true">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
             <horstretch>0</horstretch>

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -1097,7 +1097,7 @@ void RPCConsole::updateDetailWidget()
 {
     const QList<QModelIndex> selected_peers = GUIUtil::getEntryData(ui->peerWidget, PeerTableModel::NetNodeId);
     if (!clientModel || !clientModel->getPeerTableModel() || selected_peers.size() != 1) {
-        ui->detailWidget->hide();
+        ui->peersTabRightPanel->hide();
         ui->peerHeading->setText(tr("Select a peer to view detailed information."));
         return;
     }
@@ -1151,7 +1151,7 @@ void RPCConsole::updateDetailWidget()
         ui->peerHeight->setText(QString::number(stats->nodeStateStats.m_starting_height));
     }
 
-    ui->detailWidget->show();
+    ui->peersTabRightPanel->show();
 }
 
 void RPCConsole::resizeEvent(QResizeEvent *event)


### PR DESCRIPTION
Initial Presentation:

![Screen Shot 2021-01-28 at 8 36 15 PM](https://user-images.githubusercontent.com/152159/106220159-e2a81b80-61a8-11eb-84e9-f9b44375c9a1.png)

When node row selected - panel is presented:

![Screen Shot 2021-01-28 at 8 36 22 PM](https://user-images.githubusercontent.com/152159/106220185-eb98ed00-61a8-11eb-9467-6a762941902d.png)

When network disabled - right panel is hidden:

![Screen Shot 2021-01-28 at 8 36 32 PM](https://user-images.githubusercontent.com/152159/106220235-0a977f00-61a9-11eb-8a10-f31e4312ed31.png)

