### PR TITLE
scripted-diff: Use Courier New as tabular figures font in Overview page

### DIFF
--- a/src/qt/forms/overviewpage.ui
+++ b/src/qt/forms/overviewpage.ui
@@ -118,7 +118,7 @@
              <widget class="QLabel" name="labelWatchPending">
               <property name="font">
                <font>
-                <family>Monospace</family>
+                <family>Courier New</family>
                 <weight>75</weight>
                 <bold>true</bold>
                </font>
@@ -144,7 +144,7 @@
              <widget class="QLabel" name="labelUnconfirmed">
               <property name="font">
                <font>
-                <family>Monospace</family>
+                <family>Courier New</family>
                 <weight>75</weight>
                 <bold>true</bold>
                </font>
@@ -170,7 +170,7 @@
              <widget class="QLabel" name="labelWatchImmature">
               <property name="font">
                <font>
-                <family>Monospace</family>
+                <family>Courier New</family>
                 <weight>75</weight>
                 <bold>true</bold>
                </font>
@@ -229,7 +229,7 @@
              <widget class="QLabel" name="labelImmature">
               <property name="font">
                <font>
-                <family>Monospace</family>
+                <family>Courier New</family>
                 <weight>75</weight>
                 <bold>true</bold>
                </font>
@@ -275,7 +275,7 @@
              <widget class="QLabel" name="labelTotal">
               <property name="font">
                <font>
-                <family>Monospace</family>
+                <family>Courier New</family>
                 <weight>75</weight>
                 <bold>true</bold>
                </font>
@@ -301,7 +301,7 @@
              <widget class="QLabel" name="labelWatchTotal">
               <property name="font">
                <font>
-                <family>Monospace</family>
+                <family>Courier New</family>
                 <weight>75</weight>
                 <bold>true</bold>
                </font>
@@ -344,7 +344,7 @@
              <widget class="QLabel" name="labelBalance">
               <property name="font">
                <font>
-                <family>Monospace</family>
+                <family>Courier New</family>
                 <weight>75</weight>
                 <bold>true</bold>
                </font>
@@ -370,7 +370,7 @@
              <widget class="QLabel" name="labelWatchAvailable">
               <property name="font">
                <font>
-                <family>Monospace</family>
+                <family>Courier New</family>
                 <weight>75</weight>
                 <bold>true</bold>
                </font>


### PR DESCRIPTION
The https://github.com/bitcoin/bitcoin/pull/16432/commits/8d75115844baefe5cad4d82ec8dce001dd16eb9c (https://github.com/bitcoin/bitcoin/pull/16432) introduced a monospaced font for tabulated figures.

But the Qt's font matching algorithm does not guarantee that:
- the monospaced font will be chosen at all (see https://github.com/bitcoin/bitcoin/pull/16432#issuecomment-514486077, the actually used font on macOS 11.1 is `.AppleSystemUIFont` which is not monospaced, i.e., `QFontInfo::fixedPitch()` returns `false`)
- the chosen monospaced font has expected style and weight (see https://github.com/bitcoin-core/gui/pull/87#issuecomment-768920736 _"I think the correct monospace font should be bigger and eventually bold"_)

This change suggests to use Courier New explicitly which is available on Windows and macOS by default.
On Linux systems the Qt substitutes the missed Courier New font (in case it is not installed) quite well. For example, the Liberation Mono is used on my system.

This is an alternative to #87. But [personally](https://github.com/bitcoin-core/gui/pull/79#issuecomment-770792758) I still lean to embedding font (#79).