### PR TITLE
qt: Make warning label look clickable

### DIFF
--- a/src/qt/forms/overviewpage.ui
+++ b/src/qt/forms/overviewpage.ui
@@ -68,7 +68,7 @@
               </property>
               <property name="maximumSize">
                <size>
-                <width>30</width>
+                <width>45</width>
                 <height>16777215</height>
                </size>
               </property>
@@ -88,9 +88,6 @@
                 <width>24</width>
                 <height>24</height>
                </size>
-              </property>
-              <property name="flat">
-               <bool>true</bool>
               </property>
              </widget>
             </item>
@@ -406,7 +403,7 @@
               </property>
               <property name="maximumSize">
                <size>
-                <width>30</width>
+                <width>45</width>
                 <height>16777215</height>
                </size>
               </property>
@@ -426,9 +423,6 @@
                 <width>24</width>
                 <height>24</height>
                </size>
-              </property>
-              <property name="flat">
-               <bool>true</bool>
               </property>
              </widget>
             </item>


### PR DESCRIPTION
The warning icon on the overview page indicates that there is something important the user should know about, but a user may not be aware that they can click it because, on `master`, the warning label does not look clickable. As detailed in issue #23, the reason to make it look clickable is that it if they "had a more clickable-appearance (borders or beveled button edges) it could help users more quickly understand what they are being alerted to." 

This PR removes the `flat` property from both `QPushButton`'s to make them look like a button, and therefore clickable. Furthermore, it updates the `Maximum Width` to `45` to fix the small hit-box issue outlined in issue #215.

Below are screenshots showing how the warning icon looks under `master` and this `PR`:

**macOS 11.1: Qt 5.15** 
| Master        | PR               |
| ----------- | ----------- |
|  <img width="754" alt="Screen Shot 2021-02-22 at 5 00 40 PM" src="https://user-images.githubusercontent.com/23396902/108776135-f6d50380-752f-11eb-9f96-25163c6a2a02.png"> | <img width="754" alt="Screen Shot 2021-02-22 at 3 08 40 PM" src="https://user-images.githubusercontent.com/23396902/108776068-e0c74300-752f-11eb-9545-3580e2b8f187.png"> |

**Ubuntu 20.04: Qt 5.12**

| Master        | PR               |
| ----------- | ----------- |
| <img width="783" alt="Screen Shot 2021-02-22 at 4 57 32 PM" src="https://user-images.githubusercontent.com/23396902/108776249-284dcf00-7530-11eb-8325-7fe13a9243a7.png"> |   ![Screen Shot 2021-02-22 at 4 12 54 PM](https://user-images.githubusercontent.com/23396902/108776428-60eda880-7530-11eb-8999-59ddd70de85f.png) |

Closes #23 
Closes #215 