### PR TITLE
qt: Re-add and rename transaction "Edit Label" action

### DIFF
--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -172,6 +172,7 @@ TransactionView::TransactionView(const PlatformStyle *platformStyle, QWidget *pa
     QAction *copyTxIDAction = new QAction(tr("Copy transaction ID"), this);
     QAction *copyTxHexAction = new QAction(tr("Copy raw transaction"), this);
     QAction *copyTxPlainText = new QAction(tr("Copy full transaction details"), this);
+    QAction *editLabelAction = new QAction(tr("Edit label"), this);
     QAction *showDetailsAction = new QAction(tr("Show transaction details"), this);
 
     contextMenu = new QMenu(this);
@@ -186,6 +187,7 @@ TransactionView::TransactionView(const PlatformStyle *platformStyle, QWidget *pa
     contextMenu->addSeparator();
     contextMenu->addAction(bumpFeeAction);
     contextMenu->addAction(abandonAction);
+    contextMenu->addAction(editLabelAction);
 
     connect(dateWidget, static_cast<void (QComboBox::*)(int)>(&QComboBox::activated), this, &TransactionView::chooseDate);
     connect(typeWidget, static_cast<void (QComboBox::*)(int)>(&QComboBox::activated), this, &TransactionView::chooseType);
@@ -206,6 +208,7 @@ TransactionView::TransactionView(const PlatformStyle *platformStyle, QWidget *pa
     connect(copyTxIDAction, &QAction::triggered, this, &TransactionView::copyTxID);
     connect(copyTxHexAction, &QAction::triggered, this, &TransactionView::copyTxHex);
     connect(copyTxPlainText, &QAction::triggered, this, &TransactionView::copyTxPlainText);
+    connect(editLabelAction, &QAction::triggered, this, &TransactionView::editLabel);
     connect(showDetailsAction, &QAction::triggered, this, &TransactionView::showDetails);
     // Double-clicking on a transaction on the transaction history page shows details
     connect(this, &TransactionView::doubleClicked, this, &TransactionView::showDetails);
@@ -472,6 +475,52 @@ void TransactionView::copyTxHex()
 void TransactionView::copyTxPlainText()
 {
     GUIUtil::copyEntryData(transactionView, 0, TransactionTableModel::TxPlainTextRole);
+}
+
+void TransactionView::editLabel()
+{
+    if(!transactionView->selectionModel() ||!model)
+        return;
+    QModelIndexList selection = transactionView->selectionModel()->selectedRows();
+    if(!selection.isEmpty())
+    {
+        AddressTableModel *addressBook = model->getAddressTableModel();
+        if(!addressBook)
+            return;
+        QString address = selection.at(0).data(TransactionTableModel::AddressRole).toString();
+        if(address.isEmpty())
+        {
+            // If this transaction has no associated address, exit
+            return;
+        }
+        // Is address in address book? Address book can miss address when a transaction is
+        // sent from outside the UI.
+        int idx = addressBook->lookupAddress(address);
+        if(idx != -1)
+        {
+            // Edit sending / receiving address
+            QModelIndex modelIdx = addressBook->index(idx, 0, QModelIndex());
+            // Determine type of address, launch appropriate editor dialog type
+            QString type = modelIdx.data(AddressTableModel::TypeRole).toString();
+
+            EditAddressDialog dlg(
+                type == AddressTableModel::Receive
+                ? EditAddressDialog::EditReceivingAddress
+                : EditAddressDialog::EditSendingAddress, this);
+            dlg.setModel(addressBook);
+            dlg.loadRow(idx);
+            dlg.exec();
+        }
+        else
+        {
+            // Add sending address
+            EditAddressDialog dlg(EditAddressDialog::NewSendingAddress,
+                this);
+            dlg.setModel(addressBook);
+            dlg.setAddress(address);
+            dlg.exec();
+        }
+    }
 }
 
 void TransactionView::showDetails()

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -172,7 +172,7 @@ TransactionView::TransactionView(const PlatformStyle *platformStyle, QWidget *pa
     QAction *copyTxIDAction = new QAction(tr("Copy transaction ID"), this);
     QAction *copyTxHexAction = new QAction(tr("Copy raw transaction"), this);
     QAction *copyTxPlainText = new QAction(tr("Copy full transaction details"), this);
-    QAction *editLabelAction = new QAction(tr("Edit label"), this);
+    QAction *editLabelAction = new QAction(tr("Edit address label"), this);
     QAction *showDetailsAction = new QAction(tr("Show transaction details"), this);
 
     contextMenu = new QMenu(this);

--- a/src/qt/transactionview.h
+++ b/src/qt/transactionview.h
@@ -90,6 +90,7 @@ private Q_SLOTS:
     void dateRangeChanged();
     void showDetails();
     void copyAddress();
+    void editLabel();
     void copyLabel();
     void copyAmount();
     void copyTxID();


### PR DESCRIPTION
This reverts PR #211.

I disagree with this change, I use the functionality a lot, it was the primary way I used to organize and edit transactions labels and am sad to see this go.

> you can edit a sending address in the send tab Address Book

Using the address book should not be encouraged at all! A while ago it was even proposed to remove it. There's rarely need to scroll through all historical addresses used and unused. The transaction list does just fine for this.

> While all other actions apply directly to the selected transaction, the Edit Label action applies to the selected transaction's address.

**In practice** when bitcoin is used in the commonly advised way, generate a new address for each transaction, those are equivalent though.

I doubt I (and **luke-jr**) will be the only users that will stumblle on this. Further discussion here: https://github.com/bitcoin-core/gui/pull/211#issuecomment-784755998
