### PR TITLE
Fix PaymentServer::handleURIOrFile warning message

### DIFF
--- a/src/qt/paymentserver.cpp
+++ b/src/qt/paymentserver.cpp
@@ -251,7 +251,7 @@ void PaymentServer::handleURIOrFile(const QString& s)
             }
             else
                 Q_EMIT message(tr("URI handling"),
-                    tr("URI cannot be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters."),
+                    tr("URI cannot be parsed! This can be caused by malformed URI parameters."),
                     CClientUIInterface::ICON_WARNING);
 
             return;


### PR DESCRIPTION
`GUIUtil::parseBitcoinURI` does not check address validity. Therefore, an invalid address cannot cause parsing failure.

An invalid address case is covered by its own message.

This PR fixes the warning messages.

