### PR TITLE
Add URI info into -help output

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -510,7 +510,12 @@ int GuiMain(int argc, char* argv[])
     // Show help message immediately after parsing command-line options (for "-lang") and setting locale,
     // but before showing splash screen.
     if (HelpRequested(gArgs) || gArgs.IsArgSet("-version")) {
-        HelpMessageDialog help(nullptr, gArgs.IsArgSet("-version"));
+#ifdef ENABLE_WALLET
+        const bool wallet_enabled{WalletModel::isWalletEnabled()};
+#else
+        constexpr bool wallet_enabled{false};
+#endif // ENABLE_WALLET
+        HelpMessageDialog help(nullptr, gArgs.IsArgSet("-version"), wallet_enabled);
         help.showOrPrint();
         return EXIT_SUCCESS;
     }

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -96,7 +96,7 @@ BitcoinGUI::BitcoinGUI(interfaces::Node& node, const PlatformStyle *_platformSty
     updateWindowTitle();
 
     rpcConsole = new RPCConsole(node, _platformStyle, nullptr);
-    helpMessageDialog = new HelpMessageDialog(this, false);
+    helpMessageDialog = new HelpMessageDialog(this, false, enableWallet);
 #ifdef ENABLE_WALLET
     if(enableWallet)
     {

--- a/src/qt/utilitydialog.cpp
+++ b/src/qt/utilitydialog.cpp
@@ -23,14 +23,15 @@
 #include <QLabel>
 #include <QMainWindow>
 #include <QRegExp>
+#include <QStringBuilder>
 #include <QTextCursor>
 #include <QTextTable>
 #include <QVBoxLayout>
 
 /** "Help message" or "About" dialog box */
-HelpMessageDialog::HelpMessageDialog(QWidget *parent, bool about) :
-    QDialog(parent, GUIUtil::dialog_flags),
-    ui(new Ui::HelpMessageDialog)
+HelpMessageDialog::HelpMessageDialog(QWidget* parent, bool about, bool wallet_enabled)
+    : QDialog(parent, GUIUtil::dialog_flags),
+      ui(new Ui::HelpMessageDialog)
 {
     ui->setupUi(this);
 
@@ -58,7 +59,8 @@ HelpMessageDialog::HelpMessageDialog(QWidget *parent, bool about) :
         ui->helpMessage->setVisible(false);
     } else {
         setWindowTitle(tr("Command-line options"));
-        QString header = "Usage:  bitcoin-qt [command-line options]                     \n";
+        const QString uri_info = wallet_enabled ? QStringLiteral(" [URI]\n\nURI must follow BIP 21") : QString();
+        const QString header(QLatin1String("Usage:  bitcoin-qt [options]") % uri_info % QLatin1Char('\n'));
         QTextCursor cursor(ui->helpMessage->document());
         cursor.insertText(version);
         cursor.insertBlock();

--- a/src/qt/utilitydialog.h
+++ b/src/qt/utilitydialog.h
@@ -22,7 +22,7 @@ class HelpMessageDialog : public QDialog
     Q_OBJECT
 
 public:
-    explicit HelpMessageDialog(QWidget *parent, bool about);
+    explicit HelpMessageDialog(QWidget* parent, bool about, bool wallet_enabled = false);
     ~HelpMessageDialog();
 
     void printToConsole();


### PR DESCRIPTION
When wallet is enabled `-help` shows the info about passing an URI to the `bitcoin-qt`:

```
$ src/qt/bitcoin-qt -? | head
Bitcoin Core version v21.99.0-82f37decdbba

Usage:  bitcoin-qt [options] [URI]

URI must follow BIP 21

Options:

  -?
       Print this help message and exit
```

![Screenshot from 2021-02-24 20-47-00](https://user-images.githubusercontent.com/32963518/109049902-76560480-76e1-11eb-9c22-cacea4694237.png)
