### PR TITLE
Fix regression with initial sorting after pr205

### DIFF
--- a/src/qt/receivecoinsdialog.cpp
+++ b/src/qt/receivecoinsdialog.cpp
@@ -81,7 +81,6 @@ ReceiveCoinsDialog::ReceiveCoinsDialog(const PlatformStyle *_platformStyle, QWid
         tableView->horizontalHeader()->setMinimumSectionSize(MINIMUM_COLUMN_WIDTH);
         tableView->horizontalHeader()->setStretchLastSection(true);
     }
-    tableView->horizontalHeader()->setSortIndicator(RecentRequestsTableModel::Date, Qt::DescendingOrder);
 }
 
 void ReceiveCoinsDialog::setModel(WalletModel *_model)
@@ -96,6 +95,8 @@ void ReceiveCoinsDialog::setModel(WalletModel *_model)
 
         QTableView* tableView = ui->recentRequestsView;
         tableView->setModel(_model->getRecentRequestsTableModel());
+        tableView->sortByColumn(RecentRequestsTableModel::Date, Qt::DescendingOrder);
+
         connect(tableView->selectionModel(),
             &QItemSelectionModel::selectionChanged, this,
             &ReceiveCoinsDialog::recentRequestsView_selectionChanged);

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -160,7 +160,6 @@ TransactionView::TransactionView(const PlatformStyle *platformStyle, QWidget *pa
         transactionView->horizontalHeader()->setMinimumSectionSize(MINIMUM_COLUMN_WIDTH);
         transactionView->horizontalHeader()->setStretchLastSection(true);
     }
-    transactionView->horizontalHeader()->setSortIndicator(TransactionTableModel::Date, Qt::DescendingOrder);
 
     // Actions
     abandonAction = new QAction(tr("Abandon transaction"), this);
@@ -236,6 +235,7 @@ void TransactionView::setModel(WalletModel *_model)
         transactionProxyModel->setFilterCaseSensitivity(Qt::CaseInsensitive);
         transactionProxyModel->setSortRole(Qt::EditRole);
         transactionView->setModel(transactionProxyModel);
+        transactionView->sortByColumn(TransactionTableModel::Date, Qt::DescendingOrder);
 
         if (_model->getOptionsModel())
         {


### PR DESCRIPTION
Unfortunately, #205 introduced a regression. After opening the "Receive" or "Transaction" tab at first time despite of the "Date" header is marked as sorted, table rows are not sorted actually:

![Screenshot from 2021-02-27 17-49-54](https://user-images.githubusercontent.com/32963518/109392491-f7e9a480-7924-11eb-96cc-98b6f932e18e.png)

It appears that sorting the table must be triggered _after_ the `QTableView::setModel` call.

With this PR (and pre-#205):

![Screenshot from 2021-02-27 17-48-40](https://user-images.githubusercontent.com/32963518/109392505-08018400-7925-11eb-8107-8f8685744b83.png)
