### PR TITLE
Support backup to new text-based database dump format

### DIFF
--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -36,6 +36,10 @@ struct WalletContext;
 struct bilingual_str;
 typedef uint8_t isminefilter;
 
+enum class WalletBackupFormat {
+    Raw,   // Literal db copy
+};
+
 namespace interfaces {
 
 class Handler;
@@ -77,7 +81,7 @@ public:
     virtual void abortRescan() = 0;
 
     //! Back up wallet.
-    virtual bool backupWallet(const std::string& filename) = 0;
+    virtual bool backupWallet(const std::string& filename, const WalletBackupFormat format, bilingual_str& error) = 0;
 
     //! Get wallet name.
     virtual std::string getWalletName() = 0;

--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -38,6 +38,7 @@ typedef uint8_t isminefilter;
 
 enum class WalletBackupFormat {
     Raw,   // Literal db copy
+    DbDump,  // DumpWallet plaintext low-level db dump
 };
 
 namespace interfaces {

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -278,7 +278,9 @@ void WalletView::backupWallet()
     if (filename.isEmpty())
         return;
 
-    if (!walletModel->wallet().backupWallet(filename.toLocal8Bit().data())) {
+    constexpr WalletBackupFormat filetype = WalletBackupFormat::Raw;
+    bilingual_str error;
+    if (!walletModel->wallet().backupWallet(filename.toLocal8Bit().data(), filetype, error)) {
         Q_EMIT message(tr("Backup Failed"), tr("There was an error trying to save the wallet data to %1.").arg(filename),
             CClientUIInterface::MSG_ERROR);
         }

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -271,20 +271,30 @@ void WalletView::encryptWallet()
 
 void WalletView::backupWallet()
 {
+    QString filetype_str;
     QString filename = GUIUtil::getSaveFileName(this,
         tr("Backup Wallet"), QString(),
-        tr("Wallet Data (*.dat)"), nullptr);
+        tr("Wallet Data (*.dat);;Wallet Database Dump File (*.walletdbdump)"),
+        &filetype_str);
 
     if (filename.isEmpty())
         return;
 
-    constexpr WalletBackupFormat filetype = WalletBackupFormat::Raw;
+    WalletBackupFormat filetype;
+    if (filetype_str == "walletdbdump") {
+        filetype = WalletBackupFormat::DbDump;
+    } else {
+        filetype = WalletBackupFormat::Raw;
+    }
+
     bilingual_str error;
     if (!walletModel->wallet().backupWallet(filename.toLocal8Bit().data(), filetype, error)) {
-        Q_EMIT message(tr("Backup Failed"), tr("There was an error trying to save the wallet data to %1.").arg(filename),
-            CClientUIInterface::MSG_ERROR);
+        if (error.empty()) {
+            Q_EMIT message(tr("Backup Failed"), tr("There was an error trying to save the wallet data to %1.").arg(filename), CClientUIInterface::MSG_ERROR);
+        } else {
+            Q_EMIT message(tr("Backup Failed"), tr("There was an error trying to save the wallet data to %1: %2").arg(filename).arg(QString::fromStdString(error.translated)), CClientUIInterface::MSG_ERROR);
         }
-    else {
+    } else {
         Q_EMIT message(tr("Backup Successful"), tr("The wallet data was successfully saved to %1.").arg(filename),
             CClientUIInterface::MSG_INFORMATION);
     }

--- a/src/wallet/dump.cpp
+++ b/src/wallet/dump.cpp
@@ -10,15 +10,8 @@
 static const std::string DUMP_MAGIC = "BITCOIN_CORE_WALLET_DUMP";
 uint32_t DUMP_VERSION = 1;
 
-bool DumpWallet(CWallet& wallet, bilingual_str& error)
+bool DumpWallet(CWallet& wallet, bilingual_str& error, const std::string& dump_filename)
 {
-    // Get the dumpfile
-    std::string dump_filename = gArgs.GetArg("-dumpfile", "");
-    if (dump_filename.empty()) {
-        error = _("No dump file provided. To use dump, -dumpfile=<filename> must be provided.");
-        return false;
-    }
-
     fs::path path = dump_filename;
     path = fs::absolute(path);
     if (fs::exists(path)) {

--- a/src/wallet/dump.h
+++ b/src/wallet/dump.h
@@ -11,7 +11,7 @@ class CWallet;
 
 struct bilingual_str;
 
-bool DumpWallet(CWallet& wallet, bilingual_str& error);
+bool DumpWallet(CWallet& wallet, bilingual_str& error, const std::string& dump_filename);
 bool CreateFromDump(const std::string& name, const fs::path& wallet_path, bilingual_str& error, std::vector<bilingual_str>& warnings);
 
 #endif // BITCOIN_WALLET_DUMP_H

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -127,7 +127,13 @@ public:
         return m_wallet->ChangeWalletPassphrase(old_wallet_passphrase, new_wallet_passphrase);
     }
     void abortRescan() override { m_wallet->AbortRescan(); }
-    bool backupWallet(const std::string& filename) override { return m_wallet->BackupWallet(filename); }
+    bool backupWallet(const std::string& filename, const WalletBackupFormat format, bilingual_str& error) override {
+        switch (format) {
+            case WalletBackupFormat::Raw:
+                return m_wallet->BackupWallet(filename);
+        }
+        return false;
+    }
     std::string getWalletName() override { return m_wallet->GetName(); }
     bool getNewDestination(const OutputType type, const std::string label, CTxDestination& dest) override
     {

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -17,8 +17,10 @@
 #include <util/check.h>
 #include <util/ref.h>
 #include <util/system.h>
+#include <util/translation.h>
 #include <util/ui_change_type.h>
 #include <wallet/context.h>
+#include <wallet/dump.h>
 #include <wallet/feebumper.h>
 #include <wallet/fees.h>
 #include <wallet/ismine.h>
@@ -129,6 +131,8 @@ public:
     void abortRescan() override { m_wallet->AbortRescan(); }
     bool backupWallet(const std::string& filename, const WalletBackupFormat format, bilingual_str& error) override {
         switch (format) {
+            case WalletBackupFormat::DbDump:
+                return DumpWallet(*m_wallet, error, filename);
             case WalletBackupFormat::Raw:
                 return m_wallet->BackupWallet(filename);
         }

--- a/src/wallet/wallettool.cpp
+++ b/src/wallet/wallettool.cpp
@@ -167,8 +167,16 @@ bool ExecuteWalletToolFunc(const ArgsManager& args, const std::string& command)
         options.require_existing = true;
         std::shared_ptr<CWallet> wallet_instance = MakeWallet(name, path, options);
         if (!wallet_instance) return false;
+
+        // Get the dumpfile
+        std::string dump_filename = gArgs.GetArg("-dumpfile", "");
+        if (dump_filename.empty()) {
+            tfm::format(std::cerr, "No dump file provided. To use dump, -dumpfile=<filename> must be provided.\n");
+            return false;
+        }
+
         bilingual_str error;
-        bool ret = DumpWallet(*wallet_instance, error);
+        bool ret = DumpWallet(*wallet_instance, error, dump_filename);
         if (!ret && !error.empty()) {
             tfm::format(std::cerr, "%s\n", error.original);
             return ret;


### PR DESCRIPTION
Note: Leaving out the RPC dumpwallet format because it stores an encrypted wallet as unencrypted. If that's desirable to support at all, it can be a followup PR (perhaps with a strong warning).