### PR TITLE
qt test: Don't bind to regtest port

### DIFF
--- a/src/qt/test/test_main.cpp
+++ b/src/qt/test/test_main.cpp
@@ -54,6 +54,13 @@ int main(int argc, char* argv[])
 
     NodeContext node_context;
     std::unique_ptr<interfaces::Node> node = interfaces::MakeNode(&node_context);
+    gArgs.ForceSetArg("-listen", "0");
+    gArgs.ForceSetArg("-listenonion", "0");
+    gArgs.ForceSetArg("-discover", "0");
+    gArgs.ForceSetArg("-dnsseed", "0");
+    gArgs.ForceSetArg("-fixedseeds", "0");
+    gArgs.ForceSetArg("-upnp", "0");
+    gArgs.ForceSetArg("-natpmp", "0");
 
     bool fInvalid = false;
 


### PR DESCRIPTION
The qt tests don't need to bind to the regtest port. By not binding, it will no longer conflict with existing regtest instances and the tests will run as normal.

Fixes #10