### PR TITLE
fix issue when disabling the auto-enabled blank wallet checkbox

### DIFF
--- a/src/qt/createwalletdialog.cpp
+++ b/src/qt/createwalletdialog.cpp
@@ -53,6 +53,12 @@ CreateWalletDialog::CreateWalletDialog(QWidget* parent) :
         }
     });
 
+    connect(ui->blank_wallet_checkbox, &QCheckBox::toggled, [this](bool checked) {
+        if (!checked) {
+          ui->disable_privkeys_checkbox->setChecked(false);
+        }
+    });
+
 #ifndef USE_SQLITE
         ui->descriptor_checkbox->setToolTip(tr("Compiled without sqlite support (required for descriptor wallets)"));
         ui->descriptor_checkbox->setEnabled(false);


### PR DESCRIPTION
As detailed by #151, On `master` a user can create the confusing scenario where you have a disabled `Encrypt Wallet` checkbox and a selected `Disable Private Keys` checkbox after unselecting the auto-enabled `Blank Wallet` checkbox.

This commit makes it so that when the `Blank Wallet` checkbox is auto-selected after the user selects `Disable Private keys`, unselecting it will also unselect the `Disable Private Keys` checkbox, which in turn re-enables the `Encrypt Wallet` checkbox.

Below are screenshots comparing the behavior of selecting `Disable Private Keys` then unselecting the `Blank Wallet` between `master` and this `PR`:

**Master:**
| Select `Disable Private Keys` | Unselect `Blank Wallet` |
| ----------------------------- | ------------------------ |
| ![Screen Shot 2021-03-09 at 7 57 14 PM](https://user-images.githubusercontent.com/23396902/110560141-77405a80-8113-11eb-9285-5acba6241dcf.png) |   ![Screen Shot 2021-03-09 at 7 57 31 PM](https://user-images.githubusercontent.com/23396902/110560159-81faef80-8113-11eb-9b37-086aa39ecb9f.png)    |

**PR:**
| Select `Disable Private Keys` | Unselect `Blank Wallet` |
| ----------------------------- | ------------------------ |
| ![Screen Shot 2021-03-09 at 7 34 12 PM](https://user-images.githubusercontent.com/23396902/110560379-e3bb5980-8113-11eb-899a-3a4c6a1bc115.png) | ![Screen Shot 2021-03-09 at 7 34 20 PM](https://user-images.githubusercontent.com/23396902/110560412-f170df00-8113-11eb-8bd0-f7fe6fc0d739.png) |