### PR TITLE
Improve URI/file handling message

### DIFF
--- a/src/qt/paymentserver.cpp
+++ b/src/qt/paymentserver.cpp
@@ -235,9 +235,9 @@ void PaymentServer::handleURIOrFile(const QString& s)
                 if (!IsValidDestinationString(recipient.address.toStdString())) {
                     if (uri.hasQueryItem("r")) {  // payment request
                         Q_EMIT message(tr("URI handling"),
-                            tr("Cannot process payment request because BIP70 is not supported.")+
-                            tr("Due to widespread security flaws in BIP70 it's strongly recommended that any merchant instructions to switch wallets be ignored.")+
-                            tr("If you are receiving this error you should request the merchant provide a BIP21 compatible URI."),
+                            tr("Cannot process payment request because BIP70 is not supported.\n"
+                               "Due to widespread security flaws in BIP70 it's strongly recommended that any merchant instructions to switch wallets be ignored.\n"
+                               "If you are receiving this error you should request the merchant provide a BIP21 compatible URI."),
                             CClientUIInterface::ICON_WARNING);
                     }
                     Q_EMIT message(tr("URI handling"), tr("Invalid payment address %1").arg(recipient.address),
@@ -258,9 +258,9 @@ void PaymentServer::handleURIOrFile(const QString& s)
     if (QFile::exists(s)) // payment request file
     {
         Q_EMIT message(tr("Payment request file handling"),
-            tr("Cannot process payment request because BIP70 is not supported.")+
-            tr("Due to widespread security flaws in BIP70 it's strongly recommended that any merchant instructions to switch wallets be ignored.")+
-            tr("If you are receiving this error you should request the merchant provide a BIP21 compatible URI."),
+            tr("Cannot process payment request because BIP70 is not supported.\n"
+               "Due to widespread security flaws in BIP70 it's strongly recommended that any merchant instructions to switch wallets be ignored.\n"
+               "If you are receiving this error you should request the merchant provide a BIP21 compatible URI."),
             CClientUIInterface::ICON_WARNING);
     }
 }


### PR DESCRIPTION
This PR:
- fixes missing spaces after full stops
- makes the translation context much bigger

The latter is the main motivation for this PR, as I became a translator :tiger2: 

Screenshots:
- master (a9d1b40d53ec417eefbe767aa66701ef8e1801d5)

![DeepinScreenshot_select-area_20210317211750](https://user-images.githubusercontent.com/32963518/111527570-bd776880-8768-11eb-9035-96bb08067e74.png)

- this PR:

![Screenshot from 2021-03-17 21-13-36](https://user-images.githubusercontent.com/32963518/111527727-e7308f80-8768-11eb-95c7-e8b802bfed5f.png)
