### PR TITLE
Display node address in peer table with monospace font for clean alignment

### DIFF
--- a/src/qt/peertablemodel.cpp
+++ b/src/qt/peertablemodel.cpp
@@ -198,6 +198,13 @@ QVariant PeerTableModel::data(const QModelIndex &index, int role) const
         case NetNodeId: return QVariant::fromValue(rec);
         default: return QVariant();
         }
+    } else if (role == Qt::FontRole) {
+        switch (column) {
+        case Address:
+            return GUIUtil::fixedPitchFont();
+        default:
+            return QFont();
+        }
     }
 
     return QVariant();


### PR DESCRIPTION
0.21.0 on Debian 10 "Buster"

I think it would be nicer and clearer to the user if addresses that consist of a defined static amount of characters, like Onion addresses (16 characters long in v2 format, 56 characters long in v3 format) are displayed with each same visible length.

To achieve this, this PR changes the font of the peer table's node address column to a monospace font.

In the screenshot of how it is now, it leaves a feeling of uncertainty to me that the onion addresses are not displayed in the same length (for each type v2/v3):

![bildschirmfoto](https://user-images.githubusercontent.com/8447873/112767623-23d97200-9018-11eb-9c29-a48985ef274e.png)

With this PR applied it looks like so, nicely clean aligned:

![bildschirmfoto2](https://user-images.githubusercontent.com/8447873/112799187-51e9a100-906e-11eb-8572-414173698190.png)


I took over this approach from `src/qt/addresstablemodel.cpp` lines 214-221, which as I understand causes in the payment tab the receivers address being displayed in monospace font, unlike the receiver's address label below that, so it seems there was also a demand for a fixed-length display of address.