### PR TITLE
macOS theme switching not supported

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -52,6 +52,7 @@ frequently tested on them.  It is not recommended to use Bitcoin Core on
 unsupported systems.
 
 From Bitcoin Core 22.0 onwards, macOS versions earlier than 10.14 are no longer supported.
+Additionally, switching between Light and Dark mode is not supported.
 
 Notable changes
 ===============


### PR DESCRIPTION
It was originally believed that theme switching on macOS was broken only on macOS 10.14: https://github.com/bitcoin-core/gui/pull/154#issuecomment-786885443, https://github.com/bitcoin-core/gui/pull/154#pullrequestreview-600078428

It is actually broken on `Catalina` and `Big Sur` as well (building and compiling off master). When switching from one theme to another the Icons do not get re-colorized. 

This PR documents that theme switching is not currently supported in the release notes. Based on https://github.com/bitcoin-core/gui/pull/154#issuecomment-806292153, but drops the macOS 10.14 part.

Below are screenshots that were taken on `Big Sur` which show this behavior. The same occurs on `Catalina`.

**Light Mode to Dark Mode**
|  Light Mode     | Dark Mode |
| -------------- | ----------- |
| ![Screen Shot 2021-04-02 at 3 39 05 PM](https://user-images.githubusercontent.com/23396902/113469371-fb3be880-941a-11eb-9097-03c818d1af12.png) | ![Screen Shot 2021-04-02 at 3 39 32 PM](https://user-images.githubusercontent.com/23396902/113469377-04c55080-941b-11eb-9304-7657f1a656e2.png) |

**Dark Mode to Light Mode**
|  Dark Mode    | Light Mode |
| ------------- | ----------- |
| ![Screen Shot 2021-04-02 at 3 40 22 PM](https://user-images.githubusercontent.com/23396902/113469425-5077fa00-941b-11eb-94a0-7bd72e11e278.png) | ![Screen Shot 2021-04-02 at 3 40 31 PM](https://user-images.githubusercontent.com/23396902/113469429-5bcb2580-941b-11eb-9e6a-2790fdefa7e9.png) |

