### PR TITLE
Don't clear console prompt when font resizing

### DIFF
--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -494,7 +494,7 @@ RPCConsole::RPCConsole(interfaces::Node& node, const PlatformStyle *_platformSty
     ui->lineEdit->setMaxLength(16 * 1024 * 1024);
     ui->messagesWidget->installEventFilter(this);
 
-    connect(ui->clearButton, &QPushButton::clicked, [this] { clear(/* clearHistory */ false); });
+    connect(ui->clearButton, &QPushButton::clicked, [this] { clear(); });
     connect(ui->fontBiggerButton, &QPushButton::clicked, this, &RPCConsole::fontBigger);
     connect(ui->fontSmallerButton, &QPushButton::clicked, this, &RPCConsole::fontSmaller);
     connect(ui->btnClearTrafficGraph, &QPushButton::clicked, ui->trafficGraph, &TrafficGraphWidget::clear);
@@ -776,19 +776,14 @@ void RPCConsole::setFontSize(int newSize)
 
     // clear console (reset icon sizes, default stylesheet) and re-add the content
     float oldPosFactor = 1.0 / ui->messagesWidget->verticalScrollBar()->maximum() * ui->messagesWidget->verticalScrollBar()->value();
-    clear(false);
+    clear();
     ui->messagesWidget->setHtml(str);
     ui->messagesWidget->verticalScrollBar()->setValue(oldPosFactor * ui->messagesWidget->verticalScrollBar()->maximum());
 }
 
-void RPCConsole::clear(bool clearHistory)
+void RPCConsole::clear()
 {
     ui->messagesWidget->clear();
-    if(clearHistory)
-    {
-        history.clear();
-        historyPtr = 0;
-    }
     ui->lineEdit->clear();
     ui->lineEdit->setFocus();
 

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -494,7 +494,7 @@ RPCConsole::RPCConsole(interfaces::Node& node, const PlatformStyle *_platformSty
     ui->lineEdit->setMaxLength(16 * 1024 * 1024);
     ui->messagesWidget->installEventFilter(this);
 
-    connect(ui->clearButton, &QPushButton::clicked, this, &RPCConsole::clear);
+    connect(ui->clearButton, &QPushButton::clicked, [this] { clear(/* clearHistory */ false); });
     connect(ui->fontBiggerButton, &QPushButton::clicked, this, &RPCConsole::fontBigger);
     connect(ui->fontSmallerButton, &QPushButton::clicked, this, &RPCConsole::fontSmaller);
     connect(ui->btnClearTrafficGraph, &QPushButton::clicked, ui->trafficGraph, &TrafficGraphWidget::clear);

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -776,15 +776,15 @@ void RPCConsole::setFontSize(int newSize)
 
     // clear console (reset icon sizes, default stylesheet) and re-add the content
     float oldPosFactor = 1.0 / ui->messagesWidget->verticalScrollBar()->maximum() * ui->messagesWidget->verticalScrollBar()->value();
-    clear();
+    clear(/* keep_prompt */ true);
     ui->messagesWidget->setHtml(str);
     ui->messagesWidget->verticalScrollBar()->setValue(oldPosFactor * ui->messagesWidget->verticalScrollBar()->maximum());
 }
 
-void RPCConsole::clear()
+void RPCConsole::clear(bool keep_prompt)
 {
     ui->messagesWidget->clear();
-    ui->lineEdit->clear();
+    if (!keep_prompt) ui->lineEdit->clear();
     ui->lineEdit->setFocus();
 
     // Add smoothly scaled icon images.

--- a/src/qt/rpcconsole.h
+++ b/src/qt/rpcconsole.h
@@ -99,7 +99,7 @@ private Q_SLOTS:
     void updateDetailWidget();
 
 public Q_SLOTS:
-    void clear();
+    void clear(bool keep_prompt = false);
     void fontBigger();
     void fontSmaller();
     void setFontSize(int newSize);

--- a/src/qt/rpcconsole.h
+++ b/src/qt/rpcconsole.h
@@ -99,7 +99,7 @@ private Q_SLOTS:
     void updateDetailWidget();
 
 public Q_SLOTS:
-    void clear(bool clearHistory = true);
+    void clear();
     void fontBigger();
     void fontSmaller();
     void setFontSize(int newSize);


### PR DESCRIPTION
On master, a console resize event will clear the prompt. To fix this, we store the content of the prompt and re-set it upon a resize. This preserves the prompt text throughout resizes. The text will still clear when you click the clear button, as it should.

**Master**

| Before Resize      | After Resize |
| ----------------- | ------------ |
|  ![master-beforeresize](https://user-images.githubusercontent.com/23396902/113553721-2a428d80-95c6-11eb-971b-bb77151bc6d5.png)  |  ![master-afterresize](https://user-images.githubusercontent.com/23396902/113553769-3d555d80-95c6-11eb-9cdb-9ad1fd7208a9.png) |

**PR**
| Before Resize      | After Resize |
| ----------------- | ------------ |
| ![pr-beforeresize](https://user-images.githubusercontent.com/23396902/113553885-6f66bf80-95c6-11eb-8317-0975f1ebd444.png) | ![pr-afterresize](https://user-images.githubusercontent.com/23396902/113553906-75f53700-95c6-11eb-9a32-b64d8aba98e5.png) |

Closes #269 