### PR TITLE
Elide long strings in their middle in the Peers tab

### DIFF
--- a/src/qt/forms/debugwindow.ui
+++ b/src/qt/forms/debugwindow.ui
@@ -923,8 +923,14 @@
              <property name="tabKeyNavigation">
               <bool>false</bool>
              </property>
+             <property name="textElideMode">
+              <enum>Qt::ElideMiddle</enum>
+             </property>
              <property name="sortingEnabled">
               <bool>true</bool>
+             </property>
+             <property name="wordWrap">
+              <bool>false</bool>
              </property>
              <attribute name="horizontalHeaderHighlightSections">
               <bool>false</bool>


### PR DESCRIPTION
The eliding of long addresses (Onion v3 etc) in the Peers tab in their middle was [discussed](https://github.com/bitcoin-core/gui/issues/262#issuecomment-810490396) in #262.

On master (f0fa32450ec35056b3e1025262aeaef4a24c35ee):
![DeepinScreenshot_select-area_20210410141435](https://user-images.githubusercontent.com/32963518/114267903-24eea400-9a07-11eb-8c80-99f68d5cc522.png)

With this PR:
![DeepinScreenshot_select-area_20210410140430](https://user-images.githubusercontent.com/32963518/114267796-83675280-9a06-11eb-921f-ca47c2075496.png)

This PR suggests the minimal diff to achieve the goal. OTOH, this change in behavior is common for all columns in the Peers table, but it seems harmless.