### PR TITLE
Remove user input from URI error message

### DIFF
--- a/src/qt/paymentserver.cpp
+++ b/src/qt/paymentserver.cpp
@@ -232,7 +232,10 @@ void PaymentServer::handleURIOrFile(const QString& s)
             SendCoinsRecipient recipient;
             if (GUIUtil::parseBitcoinURI(s, &recipient))
             {
-                if (!IsValidDestinationString(recipient.address.toStdString())) {
+                std::string error_msg;
+                const CTxDestination dest = DecodeDestination(recipient.address.toStdString(), error_msg);
+
+                if (!IsValidDestination(dest)) {
                     if (uri.hasQueryItem("r")) {  // payment request
                         Q_EMIT message(tr("URI handling"),
                             tr("Cannot process payment request because BIP70 is not supported.\n"
@@ -240,7 +243,7 @@ void PaymentServer::handleURIOrFile(const QString& s)
                                "If you are receiving this error you should request the merchant provide a BIP21 compatible URI."),
                             CClientUIInterface::ICON_WARNING);
                     }
-                    Q_EMIT message(tr("URI handling"), tr("Invalid payment address %1").arg(recipient.address),
+                    Q_EMIT message(tr("URI handling"), QString::fromStdString(error_msg),
                         CClientUIInterface::MSG_ERROR);
                 }
                 else


### PR DESCRIPTION
Removes the user input from error message to avoid it being used in attacks.

Its not really a vulnerability in Bitcoin Core because involves social engineering, dependency on user environment etc. But this PR improves security and by avoiding abuse of URI error in future.

Example of an attack:

1. User opens a link in firefox: 

```
bitcoin:tb1qag2e6yhl52hr53vdxzaxvnjtueupvuftan4yfu%0A%0AWARNING%3A%20DO%20NOT%20CLOSE%20THIS%20WINDOW%20OR%20TURN%20OFF%20YOUR%20PC!%20IF%20YOU%20ABORT%20THIS%20PROCESS%2C%20YOU%20COULD%20DESTROY%20ALL%20OF%20YOU%20DATA!%20PLEASE%20ENSURE%20THAT%20YOUR%20POWER%20CABLE%20IS%20PLUGGED%20IN!%0A%0AYou%20became%20victim%20of%20the%20XYZ%20RANSOMWARE!%0A%0AThe%20hard%20disks%20of%20your%20computer%20have%20been%20encrypted%20with%20a%20military%20grade%20encryption%20algorithm.%20There%20is%20no%20way%20to%20restore%20your%20data%20without%20a%20special%20key.%20You%20can%20purchase%20this%20key%20on%20the%20darknet%20page%20shown%20in%20step%202.%0ATo%20purchase%20your%20key%20and%20restore%20your%20data%2C%20please%20follow%20these%20three%20easy%20steps%3A%0A%0A1.%20Download%20the%20Tor%20browser%20at%20%E2%80%9Chttps%3A%2F%2Fwww.torproject.org%2F%E2%80%9C.%0A2.%20Visit%20one%20of%20the%20following%20pages%20with%20the%20Tor%20Browser%3A%0Ahttp%3A%2F%2Frandomchars.onion%2Fabc123%0A3.%20Send%20BTC%20by%20following%20the%20instructions%20on%20the%20page
```

2. User selects Bitcoin Core to open the link:

![image](https://user-images.githubusercontent.com/13405205/114619801-8ee9a080-9cc8-11eb-9fad-23a2b831e8df.png)

3. User is asked to send BTC with some message convincing enough which can be different depending on the victim:

![image](https://user-images.githubusercontent.com/13405205/114620061-d3753c00-9cc8-11eb-8314-e3362ebb90ac.png)


**After this PR** (_No user input mentioned in the error_):

![image](https://user-images.githubusercontent.com/13405205/114624342-2b627180-9cce-11eb-93a8-0b2438d71571.png)
