### PR TITLE
qt: Bump transifex slug for 22.x

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1,7 +1,7 @@
 [main]
 host = https://www.transifex.com
 
-[bitcoin.qt-translation-021x]
-file_filter = src/qt/locale/bitcoin_<lang>.ts
+[bitcoin.qt-translation-022x]
+file_filter = src/qt/locale/bitcoin_<lang>.xlf
 source_file = src/qt/locale/bitcoin_en.xlf
 source_lang = en


### PR DESCRIPTION
Opening the 22.x translations early because of experimentation with the new xliff translations format. So change the slug so that the `tx` tool will fetch the right translation.

In this context, change `file_filter` to use `xlf` as well as the files pulled with `tx pull` are that format now. The setting only affects the naming not the format of the files.