### PR TITLE
Add "Direction" column to peers tab

### DIFF
--- a/src/qt/addressbookpage.cpp
+++ b/src/qt/addressbookpage.cpp
@@ -16,6 +16,7 @@
 #include <qt/platformstyle.h>
 
 #include <QIcon>
+#include <QLatin1String>
 #include <QMenu>
 #include <QMessageBox>
 #include <QSortFilterProxyModel>

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -666,10 +666,12 @@ QString ConnectionTypeToQString(ConnectionType conn_type, bool prepend_direction
 {
     QString prefix;
     if (prepend_direction) {
+        //: Connection direction. Also used in CONNECTION_TYPE_DOC and PeerTableModel::data().
         prefix = (conn_type == ConnectionType::INBOUND) ? QObject::tr("Inbound") : QObject::tr("Outbound") + " ";
     }
     switch (conn_type) {
     case ConnectionType::INBOUND: return prefix;
+    //: The connection types (Full Relay, Block Relay, Manual, Feeler, Address Fetch) are also used in CONNECTION_TYPE_DOC.
     case ConnectionType::OUTBOUND_FULL_RELAY: return prefix + QObject::tr("Full Relay");
     case ConnectionType::BLOCK_RELAY: return prefix + QObject::tr("Block Relay");
     case ConnectionType::MANUAL: return prefix + QObject::tr("Manual");

--- a/src/qt/peertablemodel.cpp
+++ b/src/qt/peertablemodel.cpp
@@ -113,8 +113,10 @@ QVariant PeerTableModel::data(const QModelIndex &index, int role) const
         case NetNodeId:
             return (qint64)rec->nodeStats.nodeid;
         case Address:
-            // prepend to peer address down-arrow symbol for inbound connection and up-arrow for outbound connection
-            return QString(rec->nodeStats.fInbound ? "↓ " : "↑ ") + QString::fromStdString(rec->nodeStats.addrName);
+            return QString::fromStdString(rec->nodeStats.addrName);
+        case Direction:
+            //: Connection direction. Also used in ConnectionTypeToQString() and CONNECTION_TYPE_DOC.
+            return QString(rec->nodeStats.fInbound ? tr("Inbound") : tr("Outbound"));
         case ConnectionType:
             return GUIUtil::ConnectionTypeToQString(rec->nodeStats.m_conn_type, /* prepend_direction */ false);
         case Network:
@@ -134,6 +136,7 @@ QVariant PeerTableModel::data(const QModelIndex &index, int role) const
         case NetNodeId:
         case Address:
             return {};
+        case Direction:
         case ConnectionType:
         case Network:
             return QVariant(Qt::AlignCenter);

--- a/src/qt/peertablemodel.h
+++ b/src/qt/peertablemodel.h
@@ -47,6 +47,7 @@ public:
     enum ColumnIndex {
         NetNodeId = 0,
         Address,
+        Direction,
         ConnectionType,
         Network,
         Ping,
@@ -74,7 +75,8 @@ public Q_SLOTS:
 
 private:
     interfaces::Node& m_node;
-    const QStringList columns{tr("Peer Id"), tr("Address"), tr("Type"), tr("Network"), tr("Ping"), tr("Sent"), tr("Received"), tr("User Agent")};
+    /*: Column titles of the Peers tab window. */
+    const QStringList columns{tr("Peer Id"), tr("Address"), tr("Direction"), tr("Type"), tr("Network"), tr("Ping"), tr("Sent"), tr("Received"), tr("User Agent")};
     std::unique_ptr<PeerTablePriv> priv;
     QTimer *timer;
 };

--- a/src/qt/peertablesortproxy.cpp
+++ b/src/qt/peertablesortproxy.cpp
@@ -26,6 +26,8 @@ bool PeerTableSortProxy::lessThan(const QModelIndex& left_index, const QModelInd
         return left_stats.nodeid < right_stats.nodeid;
     case PeerTableModel::Address:
         return left_stats.addrName.compare(right_stats.addrName) < 0;
+    case PeerTableModel::Direction:
+        return left_stats.fInbound > right_stats.fInbound; // default sort Inbound, then Outbound
     case PeerTableModel::ConnectionType:
         return left_stats.m_conn_type < right_stats.m_conn_type;
     case PeerTableModel::Network:

--- a/src/qt/psbtoperationsdialog.cpp
+++ b/src/qt/psbtoperationsdialog.cpp
@@ -17,6 +17,8 @@
 
 #include <iostream>
 
+#include <QLatin1String>
+
 
 PSBTOperationsDialog::PSBTOperationsDialog(
     QWidget* parent, WalletModel* wallet_model, ClientModel* client_model) : QDialog(parent, GUIUtil::dialog_flags),

--- a/src/qt/qrimagewidget.cpp
+++ b/src/qt/qrimagewidget.cpp
@@ -10,6 +10,7 @@
 #include <QClipboard>
 #include <QDrag>
 #include <QFontDatabase>
+#include <QLatin1String>
 #include <QMenu>
 #include <QMimeData>
 #include <QMouseEvent>

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -37,12 +37,14 @@
 #include <QDateTime>
 #include <QFont>
 #include <QKeyEvent>
+#include <QLatin1String>
 #include <QMenu>
 #include <QMessageBox>
 #include <QScreen>
 #include <QScrollBar>
 #include <QSettings>
 #include <QString>
+#include <QStringBuilder>
 #include <QStringList>
 #include <QTime>
 #include <QTimer>
@@ -52,6 +54,9 @@ const int CONSOLE_HISTORY = 50;
 const int INITIAL_TRAFFIC_GRAPH_MINS = 30;
 const QSize FONT_RANGE(4, 40);
 const char fontSizeSettingsKey[] = "consoleFontSize";
+
+const QLatin1String COLON_SPACE{": "};
+const QLatin1String SPACE{" "};
 
 const struct {
     const char *url;
@@ -463,16 +468,18 @@ RPCConsole::RPCConsole(interfaces::Node& node, const PlatformStyle *_platformSty
 
     constexpr QChar nonbreaking_hyphen(8209);
     const std::vector<QString> CONNECTION_TYPE_DOC{
-        tr("Inbound: initiated by peer"),
-        tr("Outbound Full Relay: default"),
-        tr("Outbound Block Relay: does not relay transactions or addresses"),
-        tr("Outbound Manual: added using RPC %1 or %2/%3 configuration options")
+        //: The connection direction (Inbound/Outbound) is also used in ConnectionTypeToQString() and PeerTableModel::data().
+        //: The connection types (Full Relay, Block Relay, Manual, Feeler, Address Fetch) are also used in ConnectionTypeToQString().
+        tr("Inbound") % COLON_SPACE % tr("initiated by peer"),
+        tr("Outbound") % SPACE % tr("Full Relay") % COLON_SPACE % tr("default"),
+        tr("Outbound") % SPACE % tr("Block Relay") % COLON_SPACE % tr("does not relay transactions or addresses"),
+        tr("Outbound") % SPACE % tr("Manual") % COLON_SPACE % tr("added using RPC %1 or %2/%3 configuration options")
             .arg("addnode")
-            .arg(QString(nonbreaking_hyphen) + "addnode")
-            .arg(QString(nonbreaking_hyphen) + "connect"),
-        tr("Outbound Feeler: short-lived, for testing addresses"),
-        tr("Outbound Address Fetch: short-lived, for soliciting addresses")};
-    const QString list{"<ul><li>" + Join(CONNECTION_TYPE_DOC, QString("</li><li>")) + "</li></ul>"};
+            .arg(QString(nonbreaking_hyphen) % "addnode")
+            .arg(QString(nonbreaking_hyphen) % "connect"),
+        tr("Outbound") % SPACE % tr("Feeler") % COLON_SPACE % tr("short-lived, for testing addresses"),
+        tr("Outbound") % SPACE % tr("Address Fetch") % COLON_SPACE % tr("short-lived, for soliciting addresses")};
+    const QString list{"<ul><li>" % Join(CONNECTION_TYPE_DOC, QString("</li><li>")) % "</li></ul>"};
     ui->peerConnectionTypeLabel->setToolTip(ui->peerConnectionTypeLabel->toolTip().arg(list));
     const QString hb_list{"<ul><li>\""
         + ts.to + "\" – " + tr("we selected the peer for high bandwidth relay") + "</li><li>\""

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -482,9 +482,9 @@ RPCConsole::RPCConsole(interfaces::Node& node, const PlatformStyle *_platformSty
     const QString list{"<ul><li>" % Join(CONNECTION_TYPE_DOC, QString("</li><li>")) % "</li></ul>"};
     ui->peerConnectionTypeLabel->setToolTip(ui->peerConnectionTypeLabel->toolTip().arg(list));
     const QString hb_list{"<ul><li>\""
-        + ts.to + "\" – " + tr("we selected the peer for high bandwidth relay") + "</li><li>\""
-        + ts.from + "\" – " + tr("the peer selected us for high bandwidth relay") + "</li><li>\""
-        + ts.no + "\" – " + tr("no high bandwidth relay selected") + "</li></ul>"};
+        % ts.to % "\" – " % tr("we selected the peer for high bandwidth relay") % "</li><li>\""
+        % ts.from % "\" – " % tr("the peer selected us for high bandwidth relay") % "</li><li>\""
+        % ts.no % "\" – " % tr("no high bandwidth relay selected") % "</li></ul>"};
     ui->peerHighBandwidthLabel->setToolTip(ui->peerHighBandwidthLabel->toolTip().arg(hb_list));
     ui->dataDir->setToolTip(ui->dataDir->toolTip().arg(QString(nonbreaking_hyphen) + "datadir"));
     ui->blocksDir->setToolTip(ui->blocksDir->toolTip().arg(QString(nonbreaking_hyphen) + "blocksdir"));
@@ -627,10 +627,10 @@ void RPCConsole::setClientModel(ClientModel *model, int bestblock_height, int64_
         // create peer table context menu
         peersTableContextMenu = new QMenu(this);
         peersTableContextMenu->addAction(tr("Disconnect"), this, &RPCConsole::disconnectSelectedNode);
-        peersTableContextMenu->addAction(ts.ban_for + " " + tr("1 hour"), [this] { banSelectedNode(60 * 60); });
-        peersTableContextMenu->addAction(ts.ban_for + " " + tr("1 day"), [this] { banSelectedNode(60 * 60 * 24); });
-        peersTableContextMenu->addAction(ts.ban_for + " " + tr("1 week"), [this] { banSelectedNode(60 * 60 * 24 * 7); });
-        peersTableContextMenu->addAction(ts.ban_for + " " + tr("1 year"), [this] { banSelectedNode(60 * 60 * 24 * 365); });
+        peersTableContextMenu->addAction(ts.ban_for % SPACE % tr("1 hour"), [this] { banSelectedNode(60 * 60); });
+        peersTableContextMenu->addAction(ts.ban_for % SPACE % tr("1 day"), [this] { banSelectedNode(60 * 60 * 24); });
+        peersTableContextMenu->addAction(ts.ban_for % SPACE % tr("1 week"), [this] { banSelectedNode(60 * 60 * 24 * 7); });
+        peersTableContextMenu->addAction(ts.ban_for % SPACE % tr("1 year"), [this] { banSelectedNode(60 * 60 * 24 * 365); });
         connect(ui->peerWidget, &QTableView::customContextMenuRequested, this, &RPCConsole::showPeersTableContextMenu);
 
         // peer table signal handling - update peer details when selecting new node
@@ -842,12 +842,12 @@ void RPCConsole::message(int category, const QString &message, bool html)
 
 void RPCConsole::updateNetworkState()
 {
-    QString connections = QString::number(clientModel->getNumConnections()) + " (";
-    connections += tr("In:") + " " + QString::number(clientModel->getNumConnections(CONNECTIONS_IN)) + " / ";
-    connections += tr("Out:") + " " + QString::number(clientModel->getNumConnections(CONNECTIONS_OUT)) + ")";
+    QString connections = QString::number(clientModel->getNumConnections()) % " (";
+    connections += tr("In:") % SPACE % QString::number(clientModel->getNumConnections(CONNECTIONS_IN)) % " / ";
+    connections += tr("Out:") % SPACE % QString::number(clientModel->getNumConnections(CONNECTIONS_OUT)) % ")";
 
     if(!clientModel->node().getNetworkActive()) {
-        connections += " (" + tr("Network activity disabled") + ")";
+        connections += " (" % tr("Network activity disabled") % ")";
     }
 
     ui->numberOfConnections->setText(connections);
@@ -1029,7 +1029,7 @@ void RPCConsole::updateDetailWidget()
     }
     const auto stats = selected_peers.first().data(PeerTableModel::StatsRole).value<CNodeCombinedStats*>();
     // update the detail ui with latest node information
-    QString peerAddrDetails(QString::fromStdString(stats->nodeStats.addrName) + " ");
+    QString peerAddrDetails(QString::fromStdString(stats->nodeStats.addrName) % SPACE);
     peerAddrDetails += tr("(peer id: %1)").arg(QString::number(stats->nodeStats.nodeid));
     if (!stats->nodeStats.addrLocal.empty())
         peerAddrDetails += "<br />" + tr("via %1").arg(QString::fromStdString(stats->nodeStats.addrLocal));

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -31,6 +31,7 @@
 #include <validation.h>
 
 #include <QFontMetrics>
+#include <QLatin1String>
 #include <QScrollBar>
 #include <QSettings>
 #include <QTextDocument>

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -27,6 +27,7 @@
 #include <QHBoxLayout>
 #include <QHeaderView>
 #include <QLabel>
+#include <QLatin1String>
 #include <QLineEdit>
 #include <QMenu>
 #include <QPoint>

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -30,6 +30,7 @@
 #include <QClipboard>
 #include <QFileDialog>
 #include <QHBoxLayout>
+#include <QLatin1String>
 #include <QProgressDialog>
 #include <QPushButton>
 #include <QVBoxLayout>


### PR DESCRIPTION
![Screenshot from 2021-04-24 13-15-54](https://user-images.githubusercontent.com/2415484/115995575-4df86280-a5cb-11eb-84a6-7f2d3143b980.png)

This was initially proposed in #179 and saw an enthusiastic reception with several ACKs. One contributor was a weak NACK due to the horizontal space and so this was temporarily dropped, but since then #202 (and soon #256 and #293) resolve the issue. Moreover, the current state of displaying only a connection `Type` column without a connection `Direction` column is confusing (e.g. https://github.com/bitcoin/bitcoin/issues/21747#issuecomment-825072559), particularly as both the direction and the type are displayed in the peer details area with the `Direction/Type` row.

This patch fixes it and completes the initial proposal in #179 by adding a `Direction` column, making the peers tab the same as the `Direction/Type` row in the peer details and the direction and type columns in our other user-facing peer connections table in `-netinfo`.

Users can now sort the peers table by direction. The default sort is set to inbound, then outbound.

This patch also makes the direction and type translations the same for the 3 places where they are used (the peers column, the peer details row, and its tooltip), adds translator comments to link them together, and adds QStringBuilder fast QString concatenation with the `%` operator.