### PR TITLE
Peers window `Peer id` improvements

### DIFF
--- a/src/qt/peertablemodel.cpp
+++ b/src/qt/peertablemodel.cpp
@@ -179,9 +179,9 @@ QVariant PeerTableModel::data(const QModelIndex &index, int role) const
         assert(false);
     } else if (role == Qt::TextAlignmentRole) {
         switch (column) {
-        case NetNodeId:
         case Address:
             return {};
+        case NetNodeId:
         case ConnectionType:
         case Network:
             return QVariant(Qt::AlignCenter);

--- a/src/qt/peertablemodel.h
+++ b/src/qt/peertablemodel.h
@@ -88,7 +88,7 @@ public Q_SLOTS:
 
 private:
     interfaces::Node& m_node;
-    const QStringList columns{tr("Peer Id"), tr("Address"), tr("Type"), tr("Network"), tr("Ping"), tr("Sent"), tr("Received"), tr("User Agent")};
+    const QStringList columns{tr("Peer"), tr("Address"), tr("Type"), tr("Network"), tr("Ping"), tr("Sent"), tr("Received"), tr("User Agent")};
     std::unique_ptr<PeerTablePriv> priv;
     QTimer *timer;
 };

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -1086,7 +1086,7 @@ void RPCConsole::updateDetailWidget()
     const auto stats = selected_peers.first().data(PeerTableModel::StatsRole).value<CNodeCombinedStats*>();
     // update the detail ui with latest node information
     QString peerAddrDetails(QString::fromStdString(stats->nodeStats.addrName) + " ");
-    peerAddrDetails += tr("(peer id: %1)").arg(QString::number(stats->nodeStats.nodeid));
+    peerAddrDetails += tr("(peer: %1)").arg(QString::number(stats->nodeStats.nodeid));
     if (!stats->nodeStats.addrLocal.empty())
         peerAddrDetails += "<br />" + tr("via %1").arg(QString::fromStdString(stats->nodeStats.addrLocal));
     ui->peerHeading->setText(peerAddrDetails);


### PR DESCRIPTION
This patch:

- renames the peers tab column header from `Peer Id` to `Peer` to allow resizing the column more tightly (this will be particularly useful after #256) and does the same for the peer details area.

- center-aligns the entries in the `Peer` column to align them under the column header rather than to the left (I also tried right-alignment but the values are unreadably close to the `Address` values and it seems more esthetic to be aligned under the header :file_cabinet:)

![Screenshot from 2021-04-23 16-43-21](https://user-images.githubusercontent.com/2415484/115888562-97697600-a442-11eb-9d87-12a694f4b637.png)
