### PR TITLE
peers-tab: enable wordWrap for Services

### DIFF
--- a/src/qt/forms/debugwindow.ui
+++ b/src/qt/forms/debugwindow.ui
@@ -1198,6 +1198,9 @@
                  <property name="textFormat">
                   <enum>Qt::PlainText</enum>
                  </property>
+                 <property name="wordWrap">
+                  <bool>true</bool>
+                 </property>
                  <property name="textInteractionFlags">
                   <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
                  </property>


### PR DESCRIPTION

### wordWrap enable user to view all service flags without needing to scroll horizontally.

#### Before:
![Screen Shot 2021-04-24 at 7 30 25 PM](https://user-images.githubusercontent.com/152159/115975533-a0864000-a533-11eb-81b9-b69bb429605c.png)

#### After:
![Screen Shot 2021-04-24 at 7 21 43 PM](https://user-images.githubusercontent.com/152159/115975495-42f1f380-a533-11eb-8a47-6d29a84bf28b.png)
