### PR TITLE
Do not use QObject::tr plural syntax for numbers with a unit symbol

### DIFF
--- a/src/qt/intro.cpp
+++ b/src/qt/intro.cpp
@@ -278,12 +278,12 @@ void Intro::setStatus(int status, const QString &message, quint64 bytesAvailable
 
 void Intro::UpdateFreeSpaceLabel()
 {
-    QString freeString = tr("%n GB of free space available", "", m_bytes_available / GB_BYTES);
+    QString freeString = tr("%1 GB of free space available").arg(m_bytes_available / GB_BYTES);
     if (m_bytes_available < m_required_space_gb * GB_BYTES) {
-        freeString += " " + tr("(of %n GB needed)", "", m_required_space_gb);
+        freeString += " " + tr("(of %1 GB needed)").arg(m_required_space_gb);
         ui->freeSpace->setStyleSheet("QLabel { color: #800000 }");
     } else if (m_bytes_available / GB_BYTES - m_required_space_gb < 10) {
-        freeString += " " + tr("(%n GB needed for full chain)", "", m_required_space_gb);
+        freeString += " " + tr("(%1 GB needed for full chain)").arg(m_required_space_gb);
         ui->freeSpace->setStyleSheet("QLabel { color: #999900 }");
     } else {
         ui->freeSpace->setStyleSheet("");


### PR DESCRIPTION
Working on translation, I found this is useless and unnecessarily burdensome for translators. I guess, this statement is correct internationally wide :)