### PR TITLE
Avoid unnecessary translations

### DIFF
--- a/src/qt/forms/optionsdialog.ui
+++ b/src/qt/forms/optionsdialog.ui
@@ -738,14 +738,14 @@
               <item>
                <widget class="QLabel" name="embeddedFont_label_1">
                 <property name="text">
-                 <string>111.11111111 BTC</string>
+                 <string notr="true">111.11111111 BTC</string>
                 </property>
                </widget>
               </item>
               <item>
                <widget class="QLabel" name="embeddedFont_label_9">
                 <property name="text">
-                 <string>909.09090909 BTC</string>
+                 <string notr="true">909.09090909 BTC</string>
                 </property>
                </widget>
               </item>
@@ -787,14 +787,14 @@
               <item>
                <widget class="QLabel" name="systemFont_label_1">
                 <property name="text">
-                 <string>111.11111111 BTC</string>
+                 <string notr="true">111.11111111 BTC</string>
                 </property>
                </widget>
               </item>
               <item>
                <widget class="QLabel" name="systemFont_label_9">
                 <property name="text">
-                 <string>909.09090909 BTC</string>
+                 <string notr="true">909.09090909 BTC</string>
                 </property>
                </widget>
               </item>


### PR DESCRIPTION
Working on translation, I found these translations introduced in #79, that are unnecessary (assuming the universal nature of the "BTC" string).