### PR TITLE
Remove progress bar on modal overlay

### DIFF
--- a/src/qt/forms/modaloverlay.ui
+++ b/src/qt/forms/modaloverlay.ui
@@ -271,16 +271,6 @@ QLabel { color: rgb(40,40,40);  }</string>
                </property>
               </widget>
              </item>
-             <item>
-              <widget class="QProgressBar" name="progressBar">
-               <property name="value">
-                <number>24</number>
-               </property>
-               <property name="format">
-                <string/>
-               </property>
-              </widget>
-             </item>
             </layout>
            </item>
            <item row="4" column="0">

--- a/src/qt/modaloverlay.cpp
+++ b/src/qt/modaloverlay.cpp
@@ -134,7 +134,6 @@ void ModalOverlay::tipUpdate(int count, const QDateTime& blockDate, double nVeri
 
     // show the percentage done according to nVerificationProgress
     ui->percentageProgress->setText(QString::number(nVerificationProgress*100, 'f', 2)+"%");
-    ui->progressBar->setValue(nVerificationProgress*100);
 
     if (!bestHeaderDate.isValid())
         // not syncing


### PR DESCRIPTION
This PR removes the progress bar (keeping only the percentage) on modal overlay 

resolves #279

Before:
![1](https://user-images.githubusercontent.com/19480819/116625265-bde65000-a91f-11eb-93ee-72474fc8dd67.PNG)

After:
![2](https://user-images.githubusercontent.com/19480819/116625272-c2126d80-a91f-11eb-80b7-839703f03f87.PNG)


