### PR TITLE
Display send/recv in Bps instead of totals in the debug window

### DIFF
--- a/src/net.h
+++ b/src/net.h
@@ -419,7 +419,6 @@ public:
     RecursiveMutex cs_sendProcessing;
 
     uint64_t nRecvBytes GUARDED_BY(cs_vRecv){0};
-
     std::atomic<int64_t> nLastSend{0};
     std::atomic<int64_t> nLastRecv{0};
     //! Unix epoch time at peer connection, in seconds.

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -781,6 +781,40 @@ QString formatBytes(uint64_t bytes)
     return QObject::tr("%1 GB").arg(bytes / 1'000'000'000);
 }
 
+QString formatBps(float bits)
+{
+    if (bits < 10)
+        //: "Bits per second"
+        return QObject::tr("%1 bps").arg(0.01 * int(bits * 100));
+    if (bits < 100)
+        //: "Bits per second"
+        return QObject::tr("%1 bps").arg(0.1 * int(bits * 10));
+    if (bits < 1'000)
+        //: "Bits per second"
+        return QObject::tr("%1 bps").arg((int)bits);
+    if (bits < 10'000)
+        //: "Kilobits per second"
+        return QObject::tr("%1 kbps").arg(0.01 * ((int)bits / 10));
+    if (bits < 100'000)
+        //: "Kilobits per second"
+        return QObject::tr("%1 kbps").arg(0.1 * ((int)bits / 100));
+    if (bits < 1'000'000)
+        //: "Kilobits per second"
+        return QObject::tr("%1 kbps").arg((int)bits / 1'000);
+    if (bits < 10'000'000)
+        //: "Megabits per second"
+        return QObject::tr("%1 Mbps").arg(0.01 * ((int)bits / 10'000));
+    if (bits < 100'000'000)
+        //: "Megabits per second"
+        return QObject::tr("%1 Mbps").arg(0.1 * ((int)bits / 100'000));
+    if (bits < 10'000'000'000)
+        //: "Megabits per second"
+        return QObject::tr("%1 Mbps").arg((long)bits / 1'000'000);
+
+    //: "Gigabits per second"
+    return QObject::tr("%1 Gbps").arg((long)bits / 1'000'000'000);
+}
+
 qreal calculateIdealFontSize(int width, const QString& text, QFont font, qreal minPointSize, qreal font_size) {
     while(font_size >= minPointSize) {
         font.setPointSizeF(font_size);

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -229,6 +229,7 @@ namespace GUIUtil
     QString formatNiceTimeOffset(qint64 secs);
 
     QString formatBytes(uint64_t bytes);
+    QString formatBps(float bits);
 
     qreal calculateIdealFontSize(int width, const QString& text, QFont font, qreal minPointSize = 4, qreal startPointSize = 14);
 

--- a/src/qt/peertablemodel.cpp
+++ b/src/qt/peertablemodel.cpp
@@ -85,10 +85,20 @@ QVariant PeerTableModel::data(const QModelIndex& index, int role) const
             return GUIUtil::NetworkToQString(rec->nodeStats.m_network);
         case Ping:
             return GUIUtil::formatPingTime(rec->nodeStats.m_min_ping_time);
-        case Sent:
-            return GUIUtil::formatBytes(rec->nodeStats.nSendBytes);
-        case Received:
-            return GUIUtil::formatBytes(rec->nodeStats.nRecvBytes);
+        case Sent: {
+            int64_t now = GetTimeSeconds();
+            if (now != rec->nodeStats.nTimeConnected) // Avoid division by zero
+                return GUIUtil::formatBps(rec->nodeStats.nSendBytes * 8.0 / (now - rec->nodeStats.nTimeConnected));
+            else
+                return QString::fromStdString("");
+        }
+        case Recv: {
+            int64_t now = GetTimeSeconds();
+            if (rec->nodeStats.nTimeConnected != now)
+                return GUIUtil::formatBps(rec->nodeStats.nRecvBytes * 8.0 / (now - rec->nodeStats.nTimeConnected));
+            else
+                return QString::fromStdString("");
+        }
         case Subversion:
             return QString::fromStdString(rec->nodeStats.cleanSubVer);
         } // no default case, so the compiler can warn about missing cases
@@ -105,7 +115,7 @@ QVariant PeerTableModel::data(const QModelIndex& index, int role) const
             return QVariant(Qt::AlignCenter);
         case Ping:
         case Sent:
-        case Received:
+        case Recv:
             return QVariant(Qt::AlignRight | Qt::AlignVCenter);
         case Subversion:
             return {};

--- a/src/qt/peertablemodel.h
+++ b/src/qt/peertablemodel.h
@@ -53,7 +53,7 @@ public:
         Network,
         Ping,
         Sent,
-        Received,
+        Recv,
         Subversion
     };
 
@@ -97,12 +97,12 @@ private:
         /*: Title of Peers Table column which indicates the current latency
             of the connection with the peer. */
         tr("Ping"),
-        /*: Title of Peers Table column which indicates the total amount of
+        /*: Title of Peers Table column which indicates the speed of
             network information we have sent to the peer. */
         tr("Sent"),
-        /*: Title of Peers Table column which indicates the total amount of
+        /*: Title of Peers Table column which indicates the speed of
             network information we have received from the peer. */
-        tr("Received"),
+        tr("Recv"),
         /*: Title of Peers Table column which contains the peer's
             User Agent string. */
         tr("User Agent")};

--- a/src/qt/peertablesortproxy.cpp
+++ b/src/qt/peertablesortproxy.cpp
@@ -34,10 +34,19 @@ bool PeerTableSortProxy::lessThan(const QModelIndex& left_index, const QModelInd
         return left_stats.m_network < right_stats.m_network;
     case PeerTableModel::Ping:
         return left_stats.m_min_ping_time < right_stats.m_min_ping_time;
-    case PeerTableModel::Sent:
-        return left_stats.nSendBytes < right_stats.nSendBytes;
-    case PeerTableModel::Received:
-        return left_stats.nRecvBytes < right_stats.nRecvBytes;
+    case PeerTableModel::Sent: {
+        int64_t now = GetTimeSeconds();
+        int Right = right_stats.nSendBytes * 8 / (now + 1 - right_stats.nTimeConnected);
+        int Left = left_stats.nSendBytes * 8 / (now + 1 - left_stats.nTimeConnected);
+        return Left < Right;
+    }
+    case PeerTableModel::Recv: {
+        int64_t now = GetTimeSeconds();
+        int Right = right_stats.nRecvBytes * 8 / (now + 1 - right_stats.nTimeConnected);
+        int Left = left_stats.nRecvBytes * 8 / (now + 1 - left_stats.nTimeConnected);
+        return Left < Right;
+    }
+
     case PeerTableModel::Subversion:
         return left_stats.cleanSubVer.compare(right_stats.cleanSubVer) < 0;
     } // no default case, so the compiler can warn about missing cases


### PR DESCRIPTION
Moved from https://github.com/bitcoin/bitcoin/pull/21806

I find this far more useful for than the totals. For example, I can easily see which nodes are not really talking with this metric, and not so much with the totals (as is current functionality).

Example:-

![image](https://user-images.githubusercontent.com/1530283/116755885-b5843700-aa3d-11eb-9473-6eb80ed8a393.png)