### PR TITLE
Make row color alternating in the Peers tab optional

### DIFF
--- a/src/qt/forms/debugwindow.ui
+++ b/src/qt/forms/debugwindow.ui
@@ -893,9 +893,6 @@
              <property name="tabKeyNavigation">
               <bool>false</bool>
              </property>
-             <property name="alternatingRowColors">
-              <bool>true</bool>
-             </property>
              <property name="textElideMode">
               <enum>Qt::ElideMiddle</enum>
              </property>
@@ -956,9 +953,6 @@
             <widget class="QTableView" name="banlistWidget">
              <property name="tabKeyNavigation">
               <bool>false</bool>
-             </property>
-             <property name="alternatingRowColors">
-              <bool>true</bool>
              </property>
              <property name="sortingEnabled">
               <bool>true</bool>

--- a/src/qt/forms/optionsdialog.ui
+++ b/src/qt/forms/optionsdialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>560</width>
-    <height>440</height>
+    <width>646</width>
+    <height>529</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -833,6 +833,16 @@
            </layout>
           </item>
          </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="peersTabAlternatingRowColors">
+         <property name="toolTip">
+          <string>Alternate the row colors for the &quot;Peers&quot; and &quot;Banned peers&quot; tables in the Peers tab.</string>
+         </property>
+         <property name="text">
+          <string>Alternate row colors in the Peers tab</string>
+         </property>
         </widget>
        </item>
        <item>

--- a/src/qt/forms/optionsdialog.ui
+++ b/src/qt/forms/optionsdialog.ui
@@ -51,20 +51,20 @@
         </spacer>
        </item>
        <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_Main_Prune">
-        <item>
-         <widget class="QCheckBox" name="prune">
-          <property name="toolTip">
-           <string>Enabling pruning significantly reduces the disk space required to store transactions. All blocks are still fully validated. Reverting this setting requires re-downloading the entire blockchain.</string>
-          </property>
-          <property name="text">
-           <string>Prune &amp;block storage to</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QSpinBox" name="pruneSize"/>
-        </item>
+        <layout class="QHBoxLayout" name="horizontalLayout_Main_Prune">
+         <item>
+          <widget class="QCheckBox" name="prune">
+           <property name="toolTip">
+            <string>Enabling pruning significantly reduces the disk space required to store transactions. All blocks are still fully validated. Reverting this setting requires re-downloading the entire blockchain.</string>
+           </property>
+           <property name="text">
+            <string>Prune &amp;block storage to</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QSpinBox" name="pruneSize"/>
+         </item>
          <item>
           <widget class="QLabel" name="pruneSizeUnitLabel">
            <property name="text">

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -263,6 +263,7 @@ void OptionsDialog::setMapper()
     mapper->addMapping(ui->unit, OptionsModel::DisplayUnit);
     mapper->addMapping(ui->thirdPartyTxUrls, OptionsModel::ThirdPartyTxUrls);
     mapper->addMapping(ui->embeddedFont_radioButton, OptionsModel::UseEmbeddedMonospacedFont);
+    mapper->addMapping(ui->peersTabAlternatingRowColors, OptionsModel::PeersTabAlternatingRowColors);
 }
 
 void OptionsDialog::setOkButtonState(bool fState)

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -177,6 +177,12 @@ void OptionsModel::Init(bool resetSettings)
     }
     m_use_embedded_monospaced_font = settings.value("UseEmbeddedMonospacedFont").toBool();
     Q_EMIT useEmbeddedMonospacedFontChanged(m_use_embedded_monospaced_font);
+
+    if (!settings.contains("PeersTabAlternatingRowColors")) {
+        settings.setValue("PeersTabAlternatingRowColors", "false");
+    }
+    m_peers_tab_alternating_row_colors = settings.value("PeersTabAlternatingRowColors").toBool();
+    Q_EMIT peersTabAlternatingRowColorsChanged(m_peers_tab_alternating_row_colors);
 }
 
 /** Helper function to copy contents from one QSettings to another.
@@ -344,6 +350,8 @@ QVariant OptionsModel::data(const QModelIndex & index, int role) const
             return settings.value("language");
         case UseEmbeddedMonospacedFont:
             return m_use_embedded_monospaced_font;
+        case PeersTabAlternatingRowColors:
+            return m_peers_tab_alternating_row_colors;
         case CoinControlFeatures:
             return fCoinControlFeatures;
         case Prune:
@@ -481,6 +489,11 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
             m_use_embedded_monospaced_font = value.toBool();
             settings.setValue("UseEmbeddedMonospacedFont", m_use_embedded_monospaced_font);
             Q_EMIT useEmbeddedMonospacedFontChanged(m_use_embedded_monospaced_font);
+            break;
+        case PeersTabAlternatingRowColors:
+            m_peers_tab_alternating_row_colors = value.toBool();
+            settings.setValue("PeersTabAlternatingRowColors", m_peers_tab_alternating_row_colors);
+            Q_EMIT peersTabAlternatingRowColorsChanged(m_peers_tab_alternating_row_colors);
             break;
         case CoinControlFeatures:
             fCoinControlFeatures = value.toBool();

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -60,6 +60,7 @@ public:
         ThirdPartyTxUrls,       // QString
         Language,               // QString
         UseEmbeddedMonospacedFont, // bool
+        PeersTabAlternatingRowColors, // bool
         CoinControlFeatures,    // bool
         ThreadsScriptVerif,     // int
         Prune,                  // bool
@@ -87,6 +88,7 @@ public:
     int getDisplayUnit() const { return nDisplayUnit; }
     QString getThirdPartyTxUrls() const { return strThirdPartyTxUrls; }
     bool getUseEmbeddedMonospacedFont() const { return m_use_embedded_monospaced_font; }
+    bool getPeersTabAlternatingRowColors() const { return m_peers_tab_alternating_row_colors; }
     bool getCoinControlFeatures() const { return fCoinControlFeatures; }
     const QString& getOverriddenByCommandLine() { return strOverriddenByCommandLine; }
 
@@ -111,6 +113,7 @@ private:
     int nDisplayUnit;
     QString strThirdPartyTxUrls;
     bool m_use_embedded_monospaced_font;
+    bool m_peers_tab_alternating_row_colors;
     bool fCoinControlFeatures;
     /* settings that were overridden by command-line */
     QString strOverriddenByCommandLine;
@@ -125,6 +128,7 @@ Q_SIGNALS:
     void coinControlFeaturesChanged(bool);
     void showTrayIconChanged(bool);
     void useEmbeddedMonospacedFontChanged(bool);
+    void peersTabAlternatingRowColorsChanged(bool);
 };
 
 #endif // BITCOIN_QT_OPTIONSMODEL_H

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -44,31 +44,31 @@ public:
     explicit OptionsModel(QObject *parent = nullptr, bool resetSettings = false);
 
     enum OptionID {
-        StartAtStartup,         // bool
-        ShowTrayIcon,           // bool
-        MinimizeToTray,         // bool
-        MapPortUPnP,            // bool
-        MapPortNatpmp,          // bool
-        MinimizeOnClose,        // bool
-        ProxyUse,               // bool
-        ProxyIP,                // QString
-        ProxyPort,              // int
-        ProxyUseTor,            // bool
-        ProxyIPTor,             // QString
-        ProxyPortTor,           // int
-        DisplayUnit,            // BitcoinUnits::Unit
-        ThirdPartyTxUrls,       // QString
-        Language,               // QString
-        UseEmbeddedMonospacedFont, // bool
+        StartAtStartup,               // bool
+        ShowTrayIcon,                 // bool
+        MinimizeToTray,               // bool
+        MapPortUPnP,                  // bool
+        MapPortNatpmp,                // bool
+        MinimizeOnClose,              // bool
+        ProxyUse,                     // bool
+        ProxyIP,                      // QString
+        ProxyPort,                    // int
+        ProxyUseTor,                  // bool
+        ProxyIPTor,                   // QString
+        ProxyPortTor,                 // int
+        DisplayUnit,                  // BitcoinUnits::Unit
+        ThirdPartyTxUrls,             // QString
+        Language,                     // QString
+        UseEmbeddedMonospacedFont,    // bool
         PeersTabAlternatingRowColors, // bool
-        CoinControlFeatures,    // bool
-        ThreadsScriptVerif,     // int
-        Prune,                  // bool
-        PruneSize,              // int
-        DatabaseCache,          // int
-        ExternalSignerPath,     // QString
-        SpendZeroConfChange,    // bool
-        Listen,                 // bool
+        CoinControlFeatures,          // bool
+        ThreadsScriptVerif,           // int
+        Prune,                        // bool
+        PruneSize,                    // int
+        DatabaseCache,                // int
+        ExternalSignerPath,           // QString
+        SpendZeroConfChange,          // bool
+        Listen,                       // bool
         OptionIDRowCount,
     };
 

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -14,6 +14,7 @@
 #include <netbase.h>
 #include <qt/bantablemodel.h>
 #include <qt/clientmodel.h>
+#include <qt/optionsmodel.h>
 #include <qt/peertablesortproxy.h>
 #include <qt/platformstyle.h>
 #include <qt/walletmodel.h>
@@ -489,6 +490,7 @@ RPCConsole::RPCConsole(interfaces::Node& node, const PlatformStyle *_platformSty
 
     m_peer_widget_header_state = settings.value("PeersTabPeerHeaderState").toByteArray();
     m_banlist_widget_header_state = settings.value("PeersTabBanlistHeaderState").toByteArray();
+    m_alternating_row_colors = settings.value("PeersTabAlternatingRowColors").toBool();
 
     constexpr QChar nonbreaking_hyphen(8209);
     const std::vector<QString> CONNECTION_TYPE_DOC{
@@ -658,6 +660,11 @@ void RPCConsole::setClientModel(ClientModel *model, int bestblock_height, int64_
 
         connect(model, &ClientModel::mempoolSizeChanged, this, &RPCConsole::setMempoolSize);
 
+        connect(model->getOptionsModel(), &OptionsModel::peersTabAlternatingRowColorsChanged, [this](bool alternating_row_colors) {
+            ui->peerWidget->setAlternatingRowColors(alternating_row_colors);
+            ui->banlistWidget->setAlternatingRowColors(alternating_row_colors);
+        });
+
         // set up peer table
         ui->peerWidget->setModel(model->peerTableSortProxy());
         ui->peerWidget->verticalHeader()->hide();
@@ -672,6 +679,7 @@ void RPCConsole::setClientModel(ClientModel *model, int bestblock_height, int64_
         }
         ui->peerWidget->horizontalHeader()->setStretchLastSection(true);
         ui->peerWidget->setItemDelegateForColumn(PeerTableModel::NetNodeId, new PeerIdViewDelegate(this));
+        ui->peerWidget->setAlternatingRowColors(m_alternating_row_colors);
 
         // create peer table context menu
         peersTableContextMenu = new QMenu(this);
@@ -698,6 +706,7 @@ void RPCConsole::setClientModel(ClientModel *model, int bestblock_height, int64_
             ui->banlistWidget->setColumnWidth(BanTableModel::Bantime, BANTIME_COLUMN_WIDTH);
         }
         ui->banlistWidget->horizontalHeader()->setStretchLastSection(true);
+        ui->banlistWidget->setAlternatingRowColors(m_alternating_row_colors);
 
         // create ban table context menu
         banTableContextMenu = new QMenu(this);

--- a/src/qt/rpcconsole.h
+++ b/src/qt/rpcconsole.h
@@ -170,6 +170,7 @@ private:
     bool m_is_executing{false};
     QByteArray m_peer_widget_header_state;
     QByteArray m_banlist_widget_header_state;
+    bool m_alternating_row_colors{false};
 
     /** Update UI with latest network info from model. */
     void updateNetworkState();


### PR DESCRIPTION
This PR:
- makes an "alternating row colors" feature in the Peers tab switchable to satisfy all users with different tastes.
- is a follow up of #298
- is an alternative to #306

Screenshot:

![Screenshot from 2021-05-01 18-56-44](https://user-images.githubusercontent.com/32963518/116787820-0718da00-aaaf-11eb-909d-26caa2f09cfc.png)