### PR TITLE
Peers Window rename 'Peer id' to 'Peer'

### DIFF
--- a/src/qt/peertablemodel.h
+++ b/src/qt/peertablemodel.h
@@ -74,7 +74,31 @@ public Q_SLOTS:
 
 private:
     interfaces::Node& m_node;
-    const QStringList columns{tr("Peer"), tr("Address"), tr("Type"), tr("Network"), tr("Ping"), tr("Sent"), tr("Received"), tr("User Agent")};
+    const QStringList columns{
+        /*: Title of Peers Table column which contains a
+            unique number used to identify a connection. */
+        tr("Peer"),
+        /*: Title of Peers Table column which contains the
+            IP/Onion/I2P address of the connected peer. */
+        tr("Address"),
+        /*: Title of Peers Table column which describes the type of
+            peer connection. The "type" describes why the connection exists. */
+        tr("Type"),
+        /*: Title of Peers Table column which states the network the peer
+            connected through. */
+        tr("Network"),
+        /*: Title of Peers Table column which indicates the current latency
+            of the connection with the peer. */
+        tr("Ping"),
+        /*: Title of Peers Table column which indicates the total amount of
+            network information we have sent to the peer. */
+        tr("Sent"),
+        /*: Title of Peers Table column which indicates the total amount of
+            network information we have received from the peer. */
+        tr("Received"),
+        /*: Title of Peers Table column which contains the peer's
+            User Agent string. */
+        tr("User Agent")};
     std::unique_ptr<PeerTablePriv> priv;
     QTimer *timer;
 };

--- a/src/qt/peertablemodel.h
+++ b/src/qt/peertablemodel.h
@@ -74,7 +74,7 @@ public Q_SLOTS:
 
 private:
     interfaces::Node& m_node;
-    const QStringList columns{tr("Peer Id"), tr("Address"), tr("Type"), tr("Network"), tr("Ping"), tr("Sent"), tr("Received"), tr("User Agent")};
+    const QStringList columns{tr("Peer"), tr("Address"), tr("Type"), tr("Network"), tr("Ping"), tr("Sent"), tr("Received"), tr("User Agent")};
     std::unique_ptr<PeerTablePriv> priv;
     QTimer *timer;
 };

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -1023,7 +1023,7 @@ void RPCConsole::updateDetailWidget()
     const auto stats = selected_peers.first().data(PeerTableModel::StatsRole).value<CNodeCombinedStats*>();
     // update the detail ui with latest node information
     QString peerAddrDetails(QString::fromStdString(stats->nodeStats.addrName) + " ");
-    peerAddrDetails += tr("(peer id: %1)").arg(QString::number(stats->nodeStats.nodeid));
+    peerAddrDetails += tr("(peer: %1)").arg(QString::number(stats->nodeStats.nodeid));
     if (!stats->nodeStats.addrLocal.empty())
         peerAddrDetails += "<br />" + tr("via %1").arg(QString::fromStdString(stats->nodeStats.addrLocal));
     ui->peerHeading->setText(peerAddrDetails);


### PR DESCRIPTION
Picking up https://github.com/bitcoin-core/gui/pull/290

**Original PR Description:**
- renames the peers tab column header from `Peer Id` to `Peer` to allow resizing the column more tightly (this will be particularly useful after #256) and does the same for the peer details area.

While here, we also add Qt translator comments for the Peer Table columns.

| Master        | PR               |
| ----------- | ----------- |
| ![Screen Shot 2021-05-03 at 1 23 05 AM](https://user-images.githubusercontent.com/23396902/116843818-20a14b00-abaf-11eb-913e-ddff11cda5cd.png) | ![Screen Shot 2021-05-05 at 4 08 45 AM](https://user-images.githubusercontent.com/23396902/117112825-a2cc7380-ad57-11eb-939b-1aceb4214ad1.png) |



