### PR TITLE
Improve Overview tab look on Windows

### DIFF
--- a/src/qt/forms/overviewpage.ui
+++ b/src/qt/forms/overviewpage.ui
@@ -40,10 +40,7 @@
        <item>
         <widget class="QFrame" name="frame">
          <property name="frameShape">
-          <enum>QFrame::StyledPanel</enum>
-         </property>
-         <property name="frameShadow">
-          <enum>QFrame::Raised</enum>
+          <enum>QFrame::Panel</enum>
          </property>
          <layout class="QVBoxLayout" name="verticalLayout_4">
           <item>
@@ -375,10 +372,7 @@
        <item>
         <widget class="QFrame" name="frame_2">
          <property name="frameShape">
-          <enum>QFrame::StyledPanel</enum>
-         </property>
-         <property name="frameShadow">
-          <enum>QFrame::Raised</enum>
+          <enum>QFrame::Panel</enum>
          </property>
          <layout class="QVBoxLayout" name="verticalLayout">
           <item>


### PR DESCRIPTION
This PR replaces raised frames with plane ones on the Overview tab, and improves its look on Windows.

Fixes #303.