### PR TITLE
Allow prompt icon to be colorized

### DIFF
--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -508,6 +508,8 @@ RPCConsole::RPCConsole(interfaces::Node& node, const PlatformStyle *_platformSty
     //: Secondary shortcut to decrease the RPC console font size.
     GUIUtil::AddButtonShortcut(ui->fontSmallerButton, tr("Ctrl+_"));
 
+    ui->promptIcon->setIcon(platformStyle->SingleColorIcon(QStringLiteral(":/icons/prompticon")));
+
     // Install event filter for up and down arrow
     ui->lineEdit->installEventFilter(this);
     ui->lineEdit->setMaxLength(16 * 1024 * 1024);


### PR DESCRIPTION
Opening the console on macOS, while in dark mode, the console prompt icon will not be colorized white like other icons. This applies the `platformStyle` to the icon so that It can be colorized white.

While here, refactor the `promptIcon` widget from a `QPushButton` to `QLabel`; which is more appropriate, per [Qt Docs](https://doc.qt.io/qt-5/qlabel.html#details):
> QLabel is used for displaying text or an image. No user interaction functionality is provided. 

| Master        | PR               |
| ----------- | ----------- |
| ![Screen Shot 2021-05-14 at 11 46 33 PM](https://user-images.githubusercontent.com/23396902/118347462-8f689780-b511-11eb-8335-329f7d2a9992.png) | ![Screen Shot 2021-05-14 at 11 45 41 PM](https://user-images.githubusercontent.com/23396902/118347463-92638800-b511-11eb-9044-073f51ef27ff.png) |