### PR TITLE
test: Use Regex Search in Apptests

### DIFF
--- a/src/qt/test/apptests.cpp
+++ b/src/qt/test/apptests.cpp
@@ -21,6 +21,7 @@
 
 #include <QAction>
 #include <QLineEdit>
+#include <QRegularExpression>
 #include <QScopedPointer>
 #include <QSignalSpy>
 #include <QTest>
@@ -30,6 +31,13 @@
 #include <QtTest/QtTestGui>
 
 namespace {
+//! Regex find a string group inside of the console output
+QString FindInConsole(const QString& output, const QString& pattern)
+{
+    const QRegularExpression re(pattern);
+    return re.match(output).captured(1);
+}
+
 //! Call getblockchaininfo RPC and check first field of JSON output.
 void TestRpcCommand(RPCConsole* console)
 {

--- a/src/qt/test/apptests.cpp
+++ b/src/qt/test/apptests.cpp
@@ -12,7 +12,6 @@
 #include <qt/rpcconsole.h>
 #include <shutdown.h>
 #include <test/util/setup_common.h>
-#include <univalue.h>
 #include <validation.h>
 
 #if defined(HAVE_CONFIG_H)
@@ -24,6 +23,7 @@
 #include <QRegularExpression>
 #include <QScopedPointer>
 #include <QSignalSpy>
+#include <QString>
 #include <QTest>
 #include <QTextEdit>
 #include <QtGlobal>
@@ -49,10 +49,9 @@ void TestRpcCommand(RPCConsole* console)
     QTest::keyClick(lineEdit, Qt::Key_Return);
     QVERIFY(mw_spy.wait(1000));
     QCOMPARE(mw_spy.count(), 4);
-    QString output = messagesWidget->toPlainText();
-    UniValue value;
-    value.read(output.right(output.size() - output.lastIndexOf(QChar::ObjectReplacementCharacter) - 1).toStdString());
-    QCOMPARE(value["chain"].get_str(), std::string("regtest"));
+    const QString output = messagesWidget->toPlainText();
+    const QString pattern = QStringLiteral("\"chain\": \"(\\w+)\"");
+    QCOMPARE(FindInConsole(output, pattern), QString("regtest"));
 }
 } // namespace
 


### PR DESCRIPTION
This PR refactors our GUI `apptests` so that it uses regex search to find values in our console/qtextedit output regardless if it is in `plaintext`, `html`, or `markdown`. 

This introduces a new function `FindInConsole` which uses [QRegularExpression](https://doc.qt.io/qt-5/qregularexpression.html) to search the output of the console. The function must be provided with a [perl compatible regex](https://www.debuggex.com/cheatsheet/regex/pcre) pattern which wants to match a single group. The function then returns the matched group. If no match is found, an empty `QString` is returned.

We then use this new function in `TestRpcCommand` to find the current `chain` value instead of reading with univalue. 

This approach can apply to a wider variety of testing scenarios as we can reuse this function to search for values when the console output is exported in a different format than `plaintext`. As an example, A follow up PR will add tests for console resizing and needs to look for the size in `html` tags after exporting the console text with `toHtml()`.