### PR TITLE
Refactor open date range to use std::optional

### DIFF
--- a/src/qt/transactionfilterproxy.cpp
+++ b/src/qt/transactionfilterproxy.cpp
@@ -9,15 +9,8 @@
 
 #include <cstdlib>
 
-// Earliest date that can be represented (far in the past)
-const QDateTime TransactionFilterProxy::MIN_DATE = QDateTime::fromTime_t(0);
-// Last date that can be represented (far in the future)
-const QDateTime TransactionFilterProxy::MAX_DATE = QDateTime::fromTime_t(0xFFFFFFFF);
-
 TransactionFilterProxy::TransactionFilterProxy(QObject *parent) :
     QSortFilterProxyModel(parent),
-    dateFrom(MIN_DATE),
-    dateTo(MAX_DATE),
     m_search_string(),
     typeFilter(ALL_TYPES),
     watchOnlyFilter(WatchOnlyFilter_All),
@@ -46,8 +39,8 @@ bool TransactionFilterProxy::filterAcceptsRow(int sourceRow, const QModelIndex &
         return false;
 
     QDateTime datetime = index.data(TransactionTableModel::DateRole).toDateTime();
-    if (datetime < dateFrom || datetime > dateTo)
-        return false;
+    if (dateFrom && datetime < *dateFrom) return false;
+    if (dateTo && datetime > *dateTo) return false;
 
     QString address = index.data(TransactionTableModel::AddressRole).toString();
     QString label = index.data(TransactionTableModel::LabelRole).toString();
@@ -65,10 +58,10 @@ bool TransactionFilterProxy::filterAcceptsRow(int sourceRow, const QModelIndex &
     return true;
 }
 
-void TransactionFilterProxy::setDateRange(const QDateTime &from, const QDateTime &to)
+void TransactionFilterProxy::setDateRange(const std::optional<QDateTime>& from, const std::optional<QDateTime>& to)
 {
-    this->dateFrom = from;
-    this->dateTo = to;
+    dateFrom = from;
+    dateTo = to;
     invalidateFilter();
 }
 

--- a/src/qt/transactionfilterproxy.h
+++ b/src/qt/transactionfilterproxy.h
@@ -10,6 +10,8 @@
 #include <QDateTime>
 #include <QSortFilterProxyModel>
 
+#include <optional>
+
 /** Filter the transaction list according to pre-specified rules. */
 class TransactionFilterProxy : public QSortFilterProxyModel
 {
@@ -18,10 +20,6 @@ class TransactionFilterProxy : public QSortFilterProxyModel
 public:
     explicit TransactionFilterProxy(QObject *parent = nullptr);
 
-    /** Earliest date that can be represented (far in the past) */
-    static const QDateTime MIN_DATE;
-    /** Last date that can be represented (far in the future) */
-    static const QDateTime MAX_DATE;
     /** Type filter bit field (all types) */
     static const quint32 ALL_TYPES = 0xFFFFFFFF;
 
@@ -34,7 +32,8 @@ public:
         WatchOnlyFilter_No
     };
 
-    void setDateRange(const QDateTime &from, const QDateTime &to);
+    /** Filter transactions between date range. Use std::nullopt for open range. */
+    void setDateRange(const std::optional<QDateTime>& from, const std::optional<QDateTime>& to);
     void setSearchString(const QString &);
     /**
       @note Type filter takes a bit field created with TYPE() or ALL_TYPES
@@ -55,8 +54,8 @@ protected:
     bool filterAcceptsRow(int source_row, const QModelIndex & source_parent) const override;
 
 private:
-    QDateTime dateFrom;
-    QDateTime dateTo;
+    std::optional<QDateTime> dateFrom;
+    std::optional<QDateTime> dateTo;
     QString m_search_string;
     quint32 typeFilter;
     WatchOnlyFilter watchOnlyFilter;

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -19,6 +19,8 @@
 
 #include <node/ui_interface.h>
 
+#include <optional>
+
 #include <QApplication>
 #include <QComboBox>
 #include <QDateTimeEdit>
@@ -266,26 +268,26 @@ void TransactionView::chooseDate(int idx)
     {
     case All:
         transactionProxyModel->setDateRange(
-                TransactionFilterProxy::MIN_DATE,
-                TransactionFilterProxy::MAX_DATE);
+                std::nullopt,
+                std::nullopt);
         break;
     case Today:
         transactionProxyModel->setDateRange(
                 GUIUtil::StartOfDay(current),
-                TransactionFilterProxy::MAX_DATE);
+                std::nullopt);
         break;
     case ThisWeek: {
         // Find last Monday
         QDate startOfWeek = current.addDays(-(current.dayOfWeek()-1));
         transactionProxyModel->setDateRange(
                 GUIUtil::StartOfDay(startOfWeek),
-                TransactionFilterProxy::MAX_DATE);
+                std::nullopt);
 
         } break;
     case ThisMonth:
         transactionProxyModel->setDateRange(
                 GUIUtil::StartOfDay(QDate(current.year(), current.month(), 1)),
-                TransactionFilterProxy::MAX_DATE);
+                std::nullopt);
         break;
     case LastMonth:
         transactionProxyModel->setDateRange(
@@ -295,7 +297,7 @@ void TransactionView::chooseDate(int idx)
     case ThisYear:
         transactionProxyModel->setDateRange(
                 GUIUtil::StartOfDay(QDate(current.year(), 1, 1)),
-                TransactionFilterProxy::MAX_DATE);
+                std::nullopt);
         break;
     case Range:
         dateRangeWidget->setVisible(true);


### PR DESCRIPTION
Use `std::nullopt` for open date range instead of `TransactionFilterProxy::MIN_DATE` and `TransactionFilterProxy::MAX_DATE`.