### PR TITLE
make GUIUtil::ThemedLabel UI form friendly

### DIFF
--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -793,6 +793,11 @@ qreal calculateIdealFontSize(int width, const QString& text, QFont font, qreal m
     return font_size;
 }
 
+ThemedLabel::ThemedLabel(QWidget* parent)
+{
+    QLabel{parent};
+}
+
 ThemedLabel::ThemedLabel(const PlatformStyle* platform_style, QWidget* parent)
     : QLabel{parent}, m_platform_style{platform_style}
 {
@@ -807,6 +812,11 @@ void ThemedLabel::setThemedPixmap(const QString& image_filename, int width, int 
     updateThemedPixmap();
 }
 
+void ThemedLabel::setPlatformStyle(const PlatformStyle* platform_style)
+{
+    m_platform_style = platform_style;
+    assert(m_platform_style);
+}
 void ThemedLabel::changeEvent(QEvent* e)
 {
 #ifdef Q_OS_MACOS
@@ -819,7 +829,9 @@ void ThemedLabel::changeEvent(QEvent* e)
 
 void ThemedLabel::updateThemedPixmap()
 {
-    setPixmap(m_platform_style->SingleColorIcon(m_image_filename).pixmap(m_pixmap_width, m_pixmap_height));
+    if (m_platform_style) {
+        setPixmap(m_platform_style->SingleColorIcon(m_image_filename).pixmap(m_pixmap_width, m_pixmap_height));
+    }
 }
 
 ClickableLabel::ClickableLabel(const PlatformStyle* platform_style, QWidget* parent)

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -237,14 +237,16 @@ namespace GUIUtil
         Q_OBJECT
 
     public:
+        explicit ThemedLabel(QWidget* parent = nullptr);
         explicit ThemedLabel(const PlatformStyle* platform_style, QWidget* parent = nullptr);
         void setThemedPixmap(const QString& image_filename, int width, int height);
+        void setPlatformStyle(const PlatformStyle* platform_style);
 
     protected:
         void changeEvent(QEvent* e) override;
 
     private:
-        const PlatformStyle* m_platform_style;
+        const PlatformStyle* m_platform_style = nullptr;
         QString m_image_filename;
         int m_pixmap_width;
         int m_pixmap_height;


### PR DESCRIPTION
This allows the `GUIUtil::ThemedLabel` class able to be used in UI form files. This is accomplished by introducing a form file friendly constructor which only takes in a `QWidget* parent`.

You cannot pass in the `platform_style` when initializing a `GUIUtil::ThemedLabel` in a UI form file. This introduces a `setPlatformStyle` function to be able to pass in the `platform_style` at a later point.

Additionally; because we are not initializing the class with a `platform_style`, we need to implement a check in `updateThemedPixmap` so that it only executes when the `m_platform_style` has been set. A segfault would occur without this conditional as a `ChangeEvent` occurs on application start

This allows this class to be used in the form file for #330 for an elegant solution.

