### PR TITLE
Dark Mode fixes/portability

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -1173,14 +1173,12 @@ void BitcoinGUI::message(const QString& title, QString message, unsigned int sty
 
 void BitcoinGUI::changeEvent(QEvent *e)
 {
-#ifdef Q_OS_MACOS
     if (e->type() == QEvent::PaletteChange) {
         overviewAction->setIcon(platformStyle->SingleColorIcon(QStringLiteral(":/icons/overview")));
         sendCoinsAction->setIcon(platformStyle->SingleColorIcon(QStringLiteral(":/icons/send")));
         receiveCoinsAction->setIcon(platformStyle->SingleColorIcon(QStringLiteral(":/icons/receiving_addresses")));
         historyAction->setIcon(platformStyle->SingleColorIcon(QStringLiteral(":/icons/history")));
     }
-#endif
 
     QMainWindow::changeEvent(e);
 
@@ -1511,14 +1509,12 @@ void UnitDisplayStatusBarControl::mousePressEvent(QMouseEvent *event)
 
 void UnitDisplayStatusBarControl::changeEvent(QEvent* e)
 {
-#ifdef Q_OS_MACOS
     if (e->type() == QEvent::PaletteChange) {
         QString style = QString("QLabel { color : %1 }").arg(m_platform_style->SingleColor().name());
         if (style != styleSheet()) {
             setStyleSheet(style);
         }
     }
-#endif
 }
 
 /** Creates context menu, its actions, and wires up all the relevant signals for mouse events. */

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -1515,6 +1515,8 @@ void UnitDisplayStatusBarControl::changeEvent(QEvent* e)
             setStyleSheet(style);
         }
     }
+
+    QLabel::changeEvent(e);
 }
 
 /** Creates context menu, its actions, and wires up all the relevant signals for mouse events. */

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -564,11 +564,9 @@ void CoinControlDialog::updateLabels(CCoinControl& m_coin_control, WalletModel *
 
 void CoinControlDialog::changeEvent(QEvent* e)
 {
-#ifdef Q_OS_MACOS
     if (e->type() == QEvent::PaletteChange) {
         updateView();
     }
-#endif
 }
 
 void CoinControlDialog::updateView()

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -567,6 +567,8 @@ void CoinControlDialog::changeEvent(QEvent* e)
     if (e->type() == QEvent::PaletteChange) {
         updateView();
     }
+
+    QDialog::changeEvent(e);
 }
 
 void CoinControlDialog::updateView()

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -809,11 +809,9 @@ void ThemedLabel::setThemedPixmap(const QString& image_filename, int width, int 
 
 void ThemedLabel::changeEvent(QEvent* e)
 {
-#ifdef Q_OS_MACOS
     if (e->type() == QEvent::PaletteChange) {
         updateThemedPixmap();
     }
-#endif
     QLabel::changeEvent(e);
 }
 

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -812,6 +812,7 @@ void ThemedLabel::changeEvent(QEvent* e)
     if (e->type() == QEvent::PaletteChange) {
         updateThemedPixmap();
     }
+
     QLabel::changeEvent(e);
 }
 

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -302,6 +302,8 @@ void OverviewPage::changeEvent(QEvent* e)
         ui->labelTransactionsStatus->setIcon(icon);
         ui->labelWalletStatus->setIcon(icon);
     }
+
+    QWidget::changeEvent(e);
 }
 
 void OverviewPage::updateDisplayUnit()

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -297,13 +297,11 @@ void OverviewPage::setWalletModel(WalletModel *model)
 
 void OverviewPage::changeEvent(QEvent* e)
 {
-#ifdef Q_OS_MACOS
     if (e->type() == QEvent::PaletteChange) {
         QIcon icon = m_platform_style->SingleColorIcon(QStringLiteral(":/icons/warning"));
         ui->labelTransactionsStatus->setIcon(icon);
         ui->labelWalletStatus->setIcon(icon);
     }
-#endif
 }
 
 void OverviewPage::updateDisplayUnit()

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -895,6 +895,8 @@ void RPCConsole::changeEvent(QEvent* e)
                 platformStyle->SingleColorImage(ICON_MAPPING[i].source).scaled(QSize(consoleFontSize * 2, consoleFontSize * 2), Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
         }
     }
+
+    QWidget::changeEvent(e);
 }
 
 void RPCConsole::message(int category, const QString &message, bool html)

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -882,7 +882,6 @@ void RPCConsole::keyPressEvent(QKeyEvent *event)
 
 void RPCConsole::changeEvent(QEvent* e)
 {
-#ifdef Q_OS_MACOS
     if (e->type() == QEvent::PaletteChange) {
         ui->clearButton->setIcon(platformStyle->SingleColorIcon(QStringLiteral(":/icons/remove")));
         ui->fontBiggerButton->setIcon(platformStyle->SingleColorIcon(QStringLiteral(":/icons/fontbigger")));
@@ -896,7 +895,6 @@ void RPCConsole::changeEvent(QEvent* e)
                 platformStyle->SingleColorImage(ICON_MAPPING[i].source).scaled(QSize(consoleFontSize * 2, consoleFontSize * 2), Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
         }
     }
-#endif
 }
 
 void RPCConsole::message(int category, const QString &message, bool html)

--- a/src/qt/sendcoinsentry.cpp
+++ b/src/qt/sendcoinsentry.cpp
@@ -245,6 +245,8 @@ void SendCoinsEntry::changeEvent(QEvent* e)
         ui->deleteButton_is->setIcon(platformStyle->SingleColorIcon(QStringLiteral(":/icons/remove")));
         ui->deleteButton_s->setIcon(platformStyle->SingleColorIcon(QStringLiteral(":/icons/remove")));
     }
+
+    QStackedWidget::changeEvent(e);
 }
 
 bool SendCoinsEntry::updateLabel(const QString &address)

--- a/src/qt/sendcoinsentry.cpp
+++ b/src/qt/sendcoinsentry.cpp
@@ -238,7 +238,6 @@ void SendCoinsEntry::updateDisplayUnit()
 
 void SendCoinsEntry::changeEvent(QEvent* e)
 {
-#ifdef Q_OS_MACOS
     if (e->type() == QEvent::PaletteChange) {
         ui->addressBookButton->setIcon(platformStyle->SingleColorIcon(QStringLiteral(":/icons/address-book")));
         ui->pasteButton->setIcon(platformStyle->SingleColorIcon(QStringLiteral(":/icons/editpaste")));
@@ -246,7 +245,6 @@ void SendCoinsEntry::changeEvent(QEvent* e)
         ui->deleteButton_is->setIcon(platformStyle->SingleColorIcon(QStringLiteral(":/icons/remove")));
         ui->deleteButton_s->setIcon(platformStyle->SingleColorIcon(QStringLiteral(":/icons/remove")));
     }
-#endif
 }
 
 bool SendCoinsEntry::updateLabel(const QString &address)

--- a/src/qt/signverifymessagedialog.cpp
+++ b/src/qt/signverifymessagedialog.cpp
@@ -286,7 +286,6 @@ bool SignVerifyMessageDialog::eventFilter(QObject *object, QEvent *event)
 
 void SignVerifyMessageDialog::changeEvent(QEvent* e)
 {
-#ifdef Q_OS_MACOS
     if (e->type() == QEvent::PaletteChange) {
         ui->addressBookButton_SM->setIcon(platformStyle->SingleColorIcon(QStringLiteral(":/icons/address-book")));
         ui->pasteButton_SM->setIcon(platformStyle->SingleColorIcon(QStringLiteral(":/icons/editpaste")));
@@ -297,5 +296,4 @@ void SignVerifyMessageDialog::changeEvent(QEvent* e)
         ui->verifyMessageButton_VM->setIcon(platformStyle->SingleColorIcon(QStringLiteral(":/icons/transaction_0")));
         ui->clearButton_VM->setIcon(platformStyle->SingleColorIcon(QStringLiteral(":/icons/remove")));
     }
-#endif
 }

--- a/src/qt/signverifymessagedialog.cpp
+++ b/src/qt/signverifymessagedialog.cpp
@@ -296,4 +296,6 @@ void SignVerifyMessageDialog::changeEvent(QEvent* e)
         ui->verifyMessageButton_VM->setIcon(platformStyle->SingleColorIcon(QStringLiteral(":/icons/transaction_0")));
         ui->clearButton_VM->setIcon(platformStyle->SingleColorIcon(QStringLiteral(":/icons/remove")));
     }
+
+    QDialog::changeEvent(e);
 }

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -253,6 +253,8 @@ void TransactionView::changeEvent(QEvent* e)
             TransactionFilterProxy::WatchOnlyFilter_No,
             m_platform_style->SingleColorIcon(QStringLiteral(":/icons/eye_minus")));
     }
+
+    QWidget::changeEvent(e);
 }
 
 void TransactionView::chooseDate(int idx)

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -245,7 +245,6 @@ void TransactionView::setModel(WalletModel *_model)
 
 void TransactionView::changeEvent(QEvent* e)
 {
-#ifdef Q_OS_MACOS
     if (e->type() == QEvent::PaletteChange) {
         watchOnlyWidget->setItemIcon(
             TransactionFilterProxy::WatchOnlyFilter_Yes,
@@ -254,7 +253,6 @@ void TransactionView::changeEvent(QEvent* e)
             TransactionFilterProxy::WatchOnlyFilter_No,
             m_platform_style->SingleColorIcon(QStringLiteral(":/icons/eye_minus")));
     }
-#endif
 }
 
 void TransactionView::chooseDate(int idx)


### PR DESCRIPTION
The changes to support macOS "Dark Mode" are valid for any platform, and should work so long as Qt implements the PaletteChange event. (Worst case, we're no worse off with trying.)

Additionally, we shouldn't block the parent classes from implementing event handlers. Who knows what side effects that could have.