### PR TITLE
Remove "Type" column from peers window

### DIFF
--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -669,12 +669,9 @@ QString NetworkToQString(Network net)
     assert(false);
 }
 
-QString ConnectionTypeToQString(ConnectionType conn_type, bool prepend_direction)
+QString ConnectionTypeToQString(ConnectionType conn_type)
 {
-    QString prefix;
-    if (prepend_direction) {
-        prefix = (conn_type == ConnectionType::INBOUND) ? QObject::tr("Inbound") : QObject::tr("Outbound") + " ";
-    }
+    QString prefix{conn_type == ConnectionType::INBOUND ? QObject::tr("Inbound") : QObject::tr("Outbound") + " "};
     switch (conn_type) {
     case ConnectionType::INBOUND: return prefix;
     case ConnectionType::OUTBOUND_FULL_RELAY: return prefix + QObject::tr("Full Relay");

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -212,7 +212,7 @@ namespace GUIUtil
     QString NetworkToQString(Network net);
 
     /** Convert enum ConnectionType to QString */
-    QString ConnectionTypeToQString(ConnectionType conn_type, bool prepend_direction);
+    QString ConnectionTypeToQString(ConnectionType conn_type);
 
     /** Convert seconds into a QString with days, hours, mins, secs */
     QString formatDurationStr(int secs);

--- a/src/qt/peertablemodel.cpp
+++ b/src/qt/peertablemodel.cpp
@@ -74,8 +74,6 @@ QVariant PeerTableModel::data(const QModelIndex& index, int role) const
         case Address:
             // prepend to peer address down-arrow symbol for inbound connection and up-arrow for outbound connection
             return QString::fromStdString((rec->nodeStats.fInbound ? "↓ " : "↑ ") + rec->nodeStats.addrName);
-        case ConnectionType:
-            return GUIUtil::ConnectionTypeToQString(rec->nodeStats.m_conn_type, /* prepend_direction */ false);
         case Network:
             return GUIUtil::NetworkToQString(rec->nodeStats.m_network);
         case Ping:
@@ -94,7 +92,6 @@ QVariant PeerTableModel::data(const QModelIndex& index, int role) const
             return QVariant(Qt::AlignRight | Qt::AlignVCenter);
         case Address:
             return {};
-        case ConnectionType:
         case Network:
             return QVariant(Qt::AlignCenter);
         case Ping:

--- a/src/qt/peertablemodel.h
+++ b/src/qt/peertablemodel.h
@@ -48,7 +48,6 @@ public:
     enum ColumnIndex {
         NetNodeId = 0,
         Address,
-        ConnectionType,
         Network,
         Ping,
         Sent,
@@ -87,9 +86,6 @@ private:
         /*: Title of Peers Table column which contains the
             IP/Onion/I2P address of the connected peer. */
         tr("Address"),
-        /*: Title of Peers Table column which describes the type of
-            peer connection. The "type" describes why the connection exists. */
-        tr("Type"),
         /*: Title of Peers Table column which states the network the peer
             connected through. */
         tr("Network"),

--- a/src/qt/peertablesortproxy.cpp
+++ b/src/qt/peertablesortproxy.cpp
@@ -26,8 +26,6 @@ bool PeerTableSortProxy::lessThan(const QModelIndex& left_index, const QModelInd
         return left_stats.nodeid < right_stats.nodeid;
     case PeerTableModel::Address:
         return left_stats.addrName.compare(right_stats.addrName) < 0;
-    case PeerTableModel::ConnectionType:
-        return left_stats.m_conn_type < right_stats.m_conn_type;
     case PeerTableModel::Network:
         return left_stats.m_network < right_stats.m_network;
     case PeerTableModel::Ping:

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -1149,7 +1149,7 @@ void RPCConsole::updateDetailWidget()
     ui->timeoffset->setText(GUIUtil::formatTimeOffset(stats->nodeStats.nTimeOffset));
     ui->peerVersion->setText(QString::number(stats->nodeStats.nVersion));
     ui->peerSubversion->setText(QString::fromStdString(stats->nodeStats.cleanSubVer));
-    ui->peerConnectionType->setText(GUIUtil::ConnectionTypeToQString(stats->nodeStats.m_conn_type, /* prepend_direction */ true));
+    ui->peerConnectionType->setText(GUIUtil::ConnectionTypeToQString(stats->nodeStats.m_conn_type));
     ui->peerNetwork->setText(GUIUtil::NetworkToQString(stats->nodeStats.m_network));
     if (stats->nodeStats.m_permissionFlags == NetPermissionFlags::None) {
         ui->peerPermissions->setText(ts.na);


### PR DESCRIPTION
This PR removes the "Type" column from the peers main window that was added in #179, as it is confusing to users and does not make sense to have a Type column without its corresponding Direction column immediately preceding it to indicate Inbound or Outbound, per our current connection type naming (one of the connection types is "Inbound" and is not ever displayed currently).

Three attempts to add the Direction column in #179 (original version), #289, and #317 have seen opposition from some reviewers. 

Therefore, before the v22.0 release, remove the Type column until such time as there is rough consensus to add the Direction Inbound/Outbound column with it (or better yet, merge #317).
