### PR TITLE
Emit dataChanged signal to dynamically re-sort Peers table

### DIFF
--- a/src/qt/peertablemodel.cpp
+++ b/src/qt/peertablemodel.cpp
@@ -179,5 +179,7 @@ void PeerTableModel::refresh()
         m_peers_data.swap(new_peers_data);
     }
 
-    Q_EMIT changed();
+    const auto top_left = index(0, 0);
+    const auto bottom_right = index(rowCount() - 1, columnCount() - 1);
+    Q_EMIT dataChanged(top_left, bottom_right);
 }

--- a/src/qt/peertablemodel.h
+++ b/src/qt/peertablemodel.h
@@ -73,9 +73,6 @@ public:
 public Q_SLOTS:
     void refresh();
 
-Q_SIGNALS:
-    void changed();
-
 private:
     //! Internal peer data structure.
     QList<CNodeCombinedStats> m_peers_data{};

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -35,6 +35,7 @@
 #endif
 
 #include <QAbstractButton>
+#include <QAbstractItemModel>
 #include <QDateTime>
 #include <QFont>
 #include <QKeyEvent>
@@ -684,7 +685,7 @@ void RPCConsole::setClientModel(ClientModel *model, int bestblock_height, int64_
 
         // peer table signal handling - update peer details when selecting new node
         connect(ui->peerWidget->selectionModel(), &QItemSelectionModel::selectionChanged, this, &RPCConsole::updateDetailWidget);
-        connect(model->getPeerTableModel(), &PeerTableModel::changed, this, &RPCConsole::updateDetailWidget);
+        connect(model->getPeerTableModel(), &QAbstractItemModel::dataChanged, [this] { updateDetailWidget(); });
 
         // set up ban table
         ui->banlistWidget->setModel(model->getBanTableModel());


### PR DESCRIPTION
[By default](https://doc.qt.io/qt-5/qsortfilterproxymodel.html#details), the `PeerTableSortProxy`
> dynamically re-sorts ... data whenever the original model changes.

That is not the case on master (8cdf91735f2bdc55577d84a9915f5920ce23b00a) as in ecbd91153875c8cdd5b92b840afc116f65e457fb (#164) no signals are emitted to notify about model changes.

This PR uses a dedicated [`dataChanged`](https://doc.qt.io/qt-5/qabstractitemmodel.html#dataChanged) signal.

Fixes #367.

An alternative to #374.