### PR TITLE
refactor: Make BitcoinCore class reusable

### DIFF
--- a/build_msvc/libbitcoin_qt/libbitcoin_qt.vcxproj
+++ b/build_msvc/libbitcoin_qt/libbitcoin_qt.vcxproj
@@ -24,6 +24,7 @@
     <ClCompile Include="..\..\src\qt\csvmodelwriter.cpp" />
     <ClCompile Include="..\..\src\qt\editaddressdialog.cpp" />
     <ClCompile Include="..\..\src\qt\guiutil.cpp" />
+    <ClCompile Include="..\..\src\qt\initexecutor.cpp" />
     <ClCompile Include="..\..\src\qt\intro.cpp" />
     <ClCompile Include="..\..\src\qt\modaloverlay.cpp" />
     <ClCompile Include="..\..\src\qt\networkstyle.cpp" />
@@ -78,6 +79,7 @@
     <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_csvmodelwriter.cpp" />
     <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_editaddressdialog.cpp" />
     <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_guiutil.cpp" />
+    <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_initexecutor.cpp" />
     <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_intro.cpp" />
     <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_modaloverlay.cpp" />
     <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_networkstyle.cpp" />

--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -40,9 +40,9 @@ QT_MOC_CPP = \
   qt/moc_askpassphrasedialog.cpp \
   qt/moc_createwalletdialog.cpp \
   qt/moc_bantablemodel.cpp \
+  qt/moc_bitcoin.cpp \
   qt/moc_bitcoinaddressvalidator.cpp \
   qt/moc_bitcoinamountfield.cpp \
-  qt/moc_bitcoin.cpp \
   qt/moc_bitcoingui.cpp \
   qt/moc_bitcoinunits.cpp \
   qt/moc_clientmodel.cpp \
@@ -51,6 +51,7 @@ QT_MOC_CPP = \
   qt/moc_csvmodelwriter.cpp \
   qt/moc_editaddressdialog.cpp \
   qt/moc_guiutil.cpp \
+  qt/moc_initexecutor.cpp \
   qt/moc_intro.cpp \
   qt/moc_macdockiconhandler.cpp \
   qt/moc_macnotificationhandler.cpp \
@@ -109,9 +110,9 @@ BITCOIN_QT_H = \
   qt/addresstablemodel.h \
   qt/askpassphrasedialog.h \
   qt/bantablemodel.h \
+  qt/bitcoin.h \
   qt/bitcoinaddressvalidator.h \
   qt/bitcoinamountfield.h \
-  qt/bitcoin.h \
   qt/bitcoingui.h \
   qt/bitcoinunits.h \
   qt/clientmodel.h \
@@ -122,6 +123,7 @@ BITCOIN_QT_H = \
   qt/editaddressdialog.h \
   qt/guiconstants.h \
   qt/guiutil.h \
+  qt/initexecutor.h \
   qt/intro.h \
   qt/macdockiconhandler.h \
   qt/macnotificationhandler.h \
@@ -227,6 +229,7 @@ BITCOIN_QT_BASE_CPP = \
   qt/clientmodel.cpp \
   qt/csvmodelwriter.cpp \
   qt/guiutil.cpp \
+  qt/initexecutor.cpp \
   qt/intro.cpp \
   qt/modaloverlay.cpp \
   qt/networkstyle.cpp \

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -7,12 +7,19 @@
 #endif
 
 #include <qt/bitcoin.h>
-#include <qt/bitcoingui.h>
 
 #include <chainparams.h>
+#include <init.h>
+#include <interfaces/handler.h>
+#include <interfaces/node.h>
+#include <node/context.h>
+#include <node/ui_interface.h>
+#include <noui.h>
+#include <qt/bitcoingui.h>
 #include <qt/clientmodel.h>
 #include <qt/guiconstants.h>
 #include <qt/guiutil.h>
+#include <qt/initexecutor.h>
 #include <qt/intro.h>
 #include <qt/networkstyle.h>
 #include <qt/optionsmodel.h>
@@ -20,24 +27,17 @@
 #include <qt/splashscreen.h>
 #include <qt/utilitydialog.h>
 #include <qt/winshutdownmonitor.h>
+#include <uint256.h>
+#include <util/system.h>
+#include <util/threadnames.h>
+#include <util/translation.h>
+#include <validation.h>
 
 #ifdef ENABLE_WALLET
 #include <qt/paymentserver.h>
 #include <qt/walletcontroller.h>
 #include <qt/walletmodel.h>
 #endif // ENABLE_WALLET
-
-#include <init.h>
-#include <interfaces/handler.h>
-#include <interfaces/node.h>
-#include <node/context.h>
-#include <node/ui_interface.h>
-#include <noui.h>
-#include <uint256.h>
-#include <util/system.h>
-#include <util/threadnames.h>
-#include <util/translation.h>
-#include <validation.h>
 
 #include <boost/signals2/connection.hpp>
 #include <memory>
@@ -152,58 +152,6 @@ void DebugMessageHandler(QtMsgType type, const QMessageLogContext& context, cons
         LogPrint(BCLog::QT, "GUI: %s\n", msg.toStdString());
     } else {
         LogPrintf("GUI: %s\n", msg.toStdString());
-    }
-}
-
-InitExecutor::InitExecutor(interfaces::Node& node) :
-    QObject(), m_node(node)
-{
-    this->moveToThread(&m_thread);
-    m_thread.start();
-}
-
-InitExecutor::~InitExecutor()
-{
-    qDebug() << __func__ << ": Stopping thread";
-    m_thread.quit();
-    m_thread.wait();
-    qDebug() << __func__ << ": Stopped thread";
-}
-
-void InitExecutor::handleRunawayException(const std::exception *e)
-{
-    PrintExceptionContinue(e, "Runaway exception");
-    Q_EMIT runawayException(QString::fromStdString(m_node.getWarnings().translated));
-}
-
-void InitExecutor::initialize()
-{
-    try
-    {
-        util::ThreadRename("qt-init");
-        qDebug() << __func__ << ": Running initialization in thread";
-        interfaces::BlockAndHeaderTipInfo tip_info;
-        bool rv = m_node.appInitMain(&tip_info);
-        Q_EMIT initializeResult(rv, tip_info);
-    } catch (const std::exception& e) {
-        handleRunawayException(&e);
-    } catch (...) {
-        handleRunawayException(nullptr);
-    }
-}
-
-void InitExecutor::shutdown()
-{
-    try
-    {
-        qDebug() << __func__ << ": Running Shutdown in thread";
-        m_node.appShutdown();
-        qDebug() << __func__ << ": Shutdown finished";
-        Q_EMIT shutdownResult();
-    } catch (const std::exception& e) {
-        handleRunawayException(&e);
-    } catch (...) {
-        handleRunawayException(nullptr);
     }
 }
 

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -155,14 +155,14 @@ void DebugMessageHandler(QtMsgType type, const QMessageLogContext& context, cons
     }
 }
 
-BitcoinCore::BitcoinCore(interfaces::Node& node) :
+InitExecutor::InitExecutor(interfaces::Node& node) :
     QObject(), m_node(node)
 {
     this->moveToThread(&m_thread);
     m_thread.start();
 }
 
-BitcoinCore::~BitcoinCore()
+InitExecutor::~InitExecutor()
 {
     qDebug() << __func__ << ": Stopping thread";
     m_thread.quit();
@@ -170,13 +170,13 @@ BitcoinCore::~BitcoinCore()
     qDebug() << __func__ << ": Stopped thread";
 }
 
-void BitcoinCore::handleRunawayException(const std::exception *e)
+void InitExecutor::handleRunawayException(const std::exception *e)
 {
     PrintExceptionContinue(e, "Runaway exception");
     Q_EMIT runawayException(QString::fromStdString(m_node.getWarnings().translated));
 }
 
-void BitcoinCore::initialize()
+void InitExecutor::initialize()
 {
     try
     {
@@ -192,7 +192,7 @@ void BitcoinCore::initialize()
     }
 }
 
-void BitcoinCore::shutdown()
+void InitExecutor::shutdown()
 {
     try
     {
@@ -298,11 +298,11 @@ void BitcoinApplication::startThread()
     m_executor.emplace(node());
 
     /*  communication to and from thread */
-    connect(&m_executor.value(), &BitcoinCore::initializeResult, this, &BitcoinApplication::initializeResult);
-    connect(&m_executor.value(), &BitcoinCore::shutdownResult, this, &BitcoinApplication::shutdownResult);
-    connect(&m_executor.value(), &BitcoinCore::runawayException, this, &BitcoinApplication::handleRunawayException);
-    connect(this, &BitcoinApplication::requestedInitialize, &m_executor.value(), &BitcoinCore::initialize);
-    connect(this, &BitcoinApplication::requestedShutdown, &m_executor.value(), &BitcoinCore::shutdown);
+    connect(&m_executor.value(), &InitExecutor::initializeResult, this, &BitcoinApplication::initializeResult);
+    connect(&m_executor.value(), &InitExecutor::shutdownResult, this, &BitcoinApplication::shutdownResult);
+    connect(&m_executor.value(), &InitExecutor::runawayException, this, &BitcoinApplication::handleRunawayException);
+    connect(this, &BitcoinApplication::requestedInitialize, &m_executor.value(), &InitExecutor::initialize);
+    connect(this, &BitcoinApplication::requestedShutdown, &m_executor.value(), &InitExecutor::shutdown);
 }
 
 void BitcoinApplication::parameterSetup()

--- a/src/qt/bitcoin.h
+++ b/src/qt/bitcoin.h
@@ -32,12 +32,12 @@ class WalletModel;
 /** Class encapsulating Bitcoin Core startup and shutdown.
  * Allows running startup and shutdown in a different thread from the UI thread.
  */
-class BitcoinCore: public QObject
+class InitExecutor: public QObject
 {
     Q_OBJECT
 public:
-    explicit BitcoinCore(interfaces::Node& node);
-    ~BitcoinCore();
+    explicit InitExecutor(interfaces::Node& node);
+    ~InitExecutor();
 
 public Q_SLOTS:
     void initialize();
@@ -117,7 +117,7 @@ Q_SIGNALS:
     void windowShown(BitcoinGUI* window);
 
 private:
-    std::optional<BitcoinCore> m_executor;
+    std::optional<InitExecutor> m_executor;
     OptionsModel *optionsModel;
     ClientModel *clientModel;
     BitcoinGUI *window;

--- a/src/qt/bitcoin.h
+++ b/src/qt/bitcoin.h
@@ -10,13 +10,13 @@
 #endif
 
 #include <interfaces/node.h>
+#include <qt/initexecutor.h>
 
 #include <assert.h>
 #include <memory>
 #include <optional>
 
 #include <QApplication>
-#include <QThread>
 
 class BitcoinGUI;
 class ClientModel;
@@ -28,33 +28,6 @@ class SplashScreen;
 class WalletController;
 class WalletModel;
 
-
-/** Class encapsulating Bitcoin Core startup and shutdown.
- * Allows running startup and shutdown in a different thread from the UI thread.
- */
-class InitExecutor: public QObject
-{
-    Q_OBJECT
-public:
-    explicit InitExecutor(interfaces::Node& node);
-    ~InitExecutor();
-
-public Q_SLOTS:
-    void initialize();
-    void shutdown();
-
-Q_SIGNALS:
-    void initializeResult(bool success, interfaces::BlockAndHeaderTipInfo tip_info);
-    void shutdownResult();
-    void runawayException(const QString &message);
-
-private:
-    /// Pass fatal exception message to UI thread
-    void handleRunawayException(const std::exception *e);
-
-    interfaces::Node& m_node;
-    QThread m_thread;
-};
 
 /** Main Bitcoin application object */
 class BitcoinApplication: public QApplication

--- a/src/qt/bitcoin.h
+++ b/src/qt/bitcoin.h
@@ -9,11 +9,14 @@
 #include <config/bitcoin-config.h>
 #endif
 
-#include <QApplication>
+#include <interfaces/node.h>
+
 #include <assert.h>
 #include <memory>
+#include <optional>
 
-#include <interfaces/node.h>
+#include <QApplication>
+#include <QThread>
 
 class BitcoinGUI;
 class ClientModel;
@@ -34,6 +37,7 @@ class BitcoinCore: public QObject
     Q_OBJECT
 public:
     explicit BitcoinCore(interfaces::Node& node);
+    ~BitcoinCore();
 
 public Q_SLOTS:
     void initialize();
@@ -49,6 +53,7 @@ private:
     void handleRunawayException(const std::exception *e);
 
     interfaces::Node& m_node;
+    QThread m_thread;
 };
 
 /** Main Bitcoin application object */
@@ -112,7 +117,7 @@ Q_SIGNALS:
     void windowShown(BitcoinGUI* window);
 
 private:
-    QThread *coreThread;
+    std::optional<BitcoinCore> m_executor;
     OptionsModel *optionsModel;
     ClientModel *clientModel;
     BitcoinGUI *window;

--- a/src/qt/initexecutor.cpp
+++ b/src/qt/initexecutor.cpp
@@ -1,0 +1,68 @@
+// Copyright (c) 2014-2021 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <qt/initexecutor.h>
+
+#include <interfaces/node.h>
+#include <util/system.h>
+#include <util/threadnames.h>
+
+#include <exception>
+
+#include <QDebug>
+#include <QObject>
+#include <QString>
+#include <QThread>
+
+InitExecutor::InitExecutor(interfaces::Node& node) :
+    QObject(), m_node(node)
+{
+    this->moveToThread(&m_thread);
+    m_thread.start();
+}
+
+InitExecutor::~InitExecutor()
+{
+    qDebug() << __func__ << ": Stopping thread";
+    m_thread.quit();
+    m_thread.wait();
+    qDebug() << __func__ << ": Stopped thread";
+}
+
+void InitExecutor::handleRunawayException(const std::exception *e)
+{
+    PrintExceptionContinue(e, "Runaway exception");
+    Q_EMIT runawayException(QString::fromStdString(m_node.getWarnings().translated));
+}
+
+void InitExecutor::initialize()
+{
+    try
+    {
+        util::ThreadRename("qt-init");
+        qDebug() << __func__ << ": Running initialization in thread";
+        interfaces::BlockAndHeaderTipInfo tip_info;
+        bool rv = m_node.appInitMain(&tip_info);
+        Q_EMIT initializeResult(rv, tip_info);
+    } catch (const std::exception& e) {
+        handleRunawayException(&e);
+    } catch (...) {
+        handleRunawayException(nullptr);
+    }
+}
+
+void InitExecutor::shutdown()
+{
+    try
+    {
+        qDebug() << __func__ << ": Running Shutdown in thread";
+        m_node.appShutdown();
+        qDebug() << __func__ << ": Shutdown finished";
+        Q_EMIT shutdownResult();
+    } catch (const std::exception& e) {
+        handleRunawayException(&e);
+    } catch (...) {
+        handleRunawayException(nullptr);
+    }
+}

--- a/src/qt/initexecutor.cpp
+++ b/src/qt/initexecutor.cpp
@@ -15,8 +15,8 @@
 #include <QString>
 #include <QThread>
 
-InitExecutor::InitExecutor(interfaces::Node& node) :
-    QObject(), m_node(node)
+InitExecutor::InitExecutor(interfaces::Node& node)
+    : QObject(), m_node(node)
 {
     this->moveToThread(&m_thread);
     m_thread.start();
@@ -30,7 +30,7 @@ InitExecutor::~InitExecutor()
     qDebug() << __func__ << ": Stopped thread";
 }
 
-void InitExecutor::handleRunawayException(const std::exception *e)
+void InitExecutor::handleRunawayException(const std::exception* e)
 {
     PrintExceptionContinue(e, "Runaway exception");
     Q_EMIT runawayException(QString::fromStdString(m_node.getWarnings().translated));
@@ -38,8 +38,7 @@ void InitExecutor::handleRunawayException(const std::exception *e)
 
 void InitExecutor::initialize()
 {
-    try
-    {
+    try {
         util::ThreadRename("qt-init");
         qDebug() << __func__ << ": Running initialization in thread";
         interfaces::BlockAndHeaderTipInfo tip_info;
@@ -54,8 +53,7 @@ void InitExecutor::initialize()
 
 void InitExecutor::shutdown()
 {
-    try
-    {
+    try {
         qDebug() << __func__ << ": Running Shutdown in thread";
         m_node.appShutdown();
         qDebug() << __func__ << ": Shutdown finished";

--- a/src/qt/initexecutor.h
+++ b/src/qt/initexecutor.h
@@ -19,7 +19,7 @@ QT_END_NAMESPACE
 /** Class encapsulating Bitcoin Core startup and shutdown.
  * Allows running startup and shutdown in a different thread from the UI thread.
  */
-class InitExecutor: public QObject
+class InitExecutor : public QObject
 {
     Q_OBJECT
 public:
@@ -33,11 +33,11 @@ public Q_SLOTS:
 Q_SIGNALS:
     void initializeResult(bool success, interfaces::BlockAndHeaderTipInfo tip_info);
     void shutdownResult();
-    void runawayException(const QString &message);
+    void runawayException(const QString& message);
 
 private:
     /// Pass fatal exception message to UI thread
-    void handleRunawayException(const std::exception *e);
+    void handleRunawayException(const std::exception* e);
 
     interfaces::Node& m_node;
     QThread m_thread;

--- a/src/qt/initexecutor.h
+++ b/src/qt/initexecutor.h
@@ -1,0 +1,46 @@
+// Copyright (c) 2014-2021 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QT_INITEXECUTOR_H
+#define BITCOIN_QT_INITEXECUTOR_H
+
+#include <interfaces/node.h>
+
+#include <exception>
+
+#include <QObject>
+#include <QThread>
+
+QT_BEGIN_NAMESPACE
+class QString;
+QT_END_NAMESPACE
+
+/** Class encapsulating Bitcoin Core startup and shutdown.
+ * Allows running startup and shutdown in a different thread from the UI thread.
+ */
+class InitExecutor: public QObject
+{
+    Q_OBJECT
+public:
+    explicit InitExecutor(interfaces::Node& node);
+    ~InitExecutor();
+
+public Q_SLOTS:
+    void initialize();
+    void shutdown();
+
+Q_SIGNALS:
+    void initializeResult(bool success, interfaces::BlockAndHeaderTipInfo tip_info);
+    void shutdownResult();
+    void runawayException(const QString &message);
+
+private:
+    /// Pass fatal exception message to UI thread
+    void handleRunawayException(const std::exception *e);
+
+    interfaces::Node& m_node;
+    QThread m_thread;
+};
+
+#endif // BITCOIN_QT_INITEXECUTOR_H

--- a/src/qt/test/test_main.cpp
+++ b/src/qt/test/test_main.cpp
@@ -8,6 +8,7 @@
 
 #include <interfaces/node.h>
 #include <qt/bitcoin.h>
+#include <qt/initexecutor.h>
 #include <qt/test/apptests.h>
 #include <qt/test/rpcnestedtests.h>
 #include <qt/test/uritests.h>


### PR DESCRIPTION
This PR makes the `BitcoinCore` class reusable, i.e., it can be used by the widget-based GUI or by the [QML-based](https://github.com/bitcoin-core/gui-qml/tree/main/src/qml) one, and it makes the divergence between these two repos minimal.

The small benefit to the current branch is more structured code.

Actually, this PR is ported from https://github.com/bitcoin-core/gui-qml/pull/10.
The example of the re-using of the `BitcoinCore` class is https://github.com/bitcoin-core/gui-qml/pull/11.