### PR TITLE
add copy subnet action for banned peer

### DIFF
--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -706,6 +706,11 @@ void RPCConsole::setClientModel(ClientModel *model, int bestblock_height, int64_
 
         // create ban table context menu
         banTableContextMenu = new QMenu(this);
+        //: Context menu action to copy the subnet of a banned peer
+        banTableContextMenu->addAction(tr("Copy subnet"), [this] {
+            GUIUtil::copyEntryData(ui->banlistWidget, BanTableModel::Address, Qt::DisplayRole);
+        });
+        banTableContextMenu->addSeparator();
         banTableContextMenu->addAction(tr("&Unban"), this, &RPCConsole::unbanSelectedNode);
         connect(ui->banlistWidget, &QTableView::customContextMenuRequested, this, &RPCConsole::showBanTableContextMenu);
 


### PR DESCRIPTION
This PR adds a Copy Subnet context menu action to the Banned Peers Table.

This feature is quite helpful if a node using GUI might want to alert its peer about a particular malicious user. So it can copy that user’s subnet and broadcast it to its peers so they can ban it instantly using the setban command in the console.

| Master        | PR               |
| ----------- | ----------- |
| ![Screenshot_from_2021-07-21_00-01-331](https://user-images.githubusercontent.com/23396902/126377808-bd23bb19-3f47-4f1b-8371-39baa9747bbe.png) | ![Screenshot_from_2021-07-20_23-59-271](https://user-images.githubusercontent.com/23396902/126377824-818e0c9b-0058-481a-84eb-c8177ead69ce.png) |