### PR TITLE
Always log context function of QtDebugMsg messages

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -147,9 +147,8 @@ static void initTranslations(QTranslator &qtTranslatorBase, QTranslator &qtTrans
 /* qDebug() message handler --> debug.log */
 void DebugMessageHandler(QtMsgType type, const QMessageLogContext& context, const QString &msg)
 {
-    Q_UNUSED(context);
     if (type == QtDebugMsg) {
-        LogPrint(BCLog::QT, "GUI: %s\n", msg.toStdString());
+        LogPrint(BCLog::QT, "GUI: %s: %s\n", context.function, msg.toStdString());
     } else {
         LogPrintf("GUI: %s\n", msg.toStdString());
     }
@@ -270,7 +269,7 @@ void BitcoinApplication::InitPruneSetting(int64_t prune_MiB)
 
 void BitcoinApplication::requestInitialize()
 {
-    qDebug() << __func__ << ": Requesting initialize";
+    qDebug() << "Requesting initialize";
     startThread();
     Q_EMIT requestedInitialize();
 }
@@ -282,7 +281,7 @@ void BitcoinApplication::requestShutdown()
     // for example the RPC console may still be executing a command.
     shutdownWindow.reset(ShutdownWindow::showShutdownWindow(window));
 
-    qDebug() << __func__ << ": Requesting shutdown";
+    qDebug() << "Requesting shutdown";
     window->hide();
     // Must disconnect node signals otherwise current thread can deadlock since
     // no event loop is running.
@@ -304,7 +303,7 @@ void BitcoinApplication::requestShutdown()
 
 void BitcoinApplication::initializeResult(bool success, interfaces::BlockAndHeaderTipInfo tip_info)
 {
-    qDebug() << __func__ << ": Initialization result: " << success;
+    qDebug() << "Initialization result: " << success;
     // Set exit result.
     returnValue = success ? EXIT_SUCCESS : EXIT_FAILURE;
     if(success)

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -268,7 +268,7 @@ static void NotifyAlertChanged(ClientModel *clientmodel)
 
 static void BannedListChanged(ClientModel *clientmodel)
 {
-    qDebug() << QString("%1: Requesting update for peer banlist").arg(__func__);
+    qDebug() << "Requesting update for peer banlist";
     bool invoked = QMetaObject::invokeMethod(clientmodel, "updateBanlist", Qt::QueuedConnection);
     assert(invoked);
 }

--- a/src/qt/initexecutor.cpp
+++ b/src/qt/initexecutor.cpp
@@ -24,10 +24,10 @@ InitExecutor::InitExecutor(interfaces::Node& node)
 
 InitExecutor::~InitExecutor()
 {
-    qDebug() << __func__ << ": Stopping thread";
+    qDebug() << "Stopping thread";
     m_thread.quit();
     m_thread.wait();
-    qDebug() << __func__ << ": Stopped thread";
+    qDebug() << "Stopped thread";
 }
 
 void InitExecutor::handleRunawayException(const std::exception* e)
@@ -40,7 +40,7 @@ void InitExecutor::initialize()
 {
     try {
         util::ThreadRename("qt-init");
-        qDebug() << __func__ << ": Running initialization in thread";
+        qDebug() << "Running initialization in thread";
         interfaces::BlockAndHeaderTipInfo tip_info;
         bool rv = m_node.appInitMain(&tip_info);
         Q_EMIT initializeResult(rv, tip_info);
@@ -54,9 +54,9 @@ void InitExecutor::initialize()
 void InitExecutor::shutdown()
 {
     try {
-        qDebug() << __func__ << ": Running Shutdown in thread";
+        qDebug() << "Running Shutdown in thread";
         m_node.appShutdown();
-        qDebug() << __func__ << ": Shutdown finished";
+        qDebug() << "Shutdown finished";
         Q_EMIT shutdownResult();
     } catch (const std::exception& e) {
         handleRunawayException(&e);


### PR DESCRIPTION
Use `QMessageLogContext::function` consistently for all `qDebug` calls instead of explicitly logging `__func__` in some places.