### PR TITLE
Un-color the scammers warning when using testnet.

### DIFF
--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -861,17 +861,18 @@ void RPCConsole::clear(bool keep_prompt)
            "Use %3 and %4 to increase or decrease the font size.\n"
            "Type %5 for an overview of available commands.\n"
            "For more information on using this console, type %6.\n"
-           "\n"
-           "%7WARNING: Scammers have been active, telling users to type"
-           " commands here, stealing their wallet contents. Do not use this console"
-           " without fully understanding the ramifications of a command.%8")
+           "\n")
             .arg(PACKAGE_NAME,
                  "<b>" + ui->clearButton->shortcut().toString(QKeySequence::NativeText) + "</b>",
                  "<b>" + ui->fontBiggerButton->shortcut().toString(QKeySequence::NativeText) + "</b>",
                  "<b>" + ui->fontSmallerButton->shortcut().toString(QKeySequence::NativeText) + "</b>",
                  "<b>help</b>",
-                 "<b>help-console</b>",
-                 "<span class=\"secwarning\">",
+                 "<b>help-console</b>") +
+        tr(
+           "%7WARNING: Scammers have been active, telling users to type"
+           " commands here, stealing their wallet contents. Do not use this console"
+           " without fully understanding the ramifications of a command.%8")
+            .arg("<span class=\"secwarning\">",
                  "<span>");
 
     message(CMD_REPLY, welcome_message, true);

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -872,7 +872,7 @@ void RPCConsole::clear(bool keep_prompt)
            "%7WARNING: Scammers have been active, telling users to type"
            " commands here, stealing their wallet contents. Do not use this console"
            " without fully understanding the ramifications of a command.%8")
-            .arg("<span class=\"secwarning\">",
+            .arg(gArgs.GetChainName() == CBaseChainParams::TESTNET ? "<span>" : "<span class=\"secwarning\">",
                  "<span>");
 
     message(CMD_REPLY, welcome_message, true);


### PR DESCRIPTION
If scammers are active, telling users to type commands in the console, stealing their testnet wallet contents, maybe someone can send them some more testnet coins.
