### PR TITLE
Add cancel button to configuration options popup

### DIFF
--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -295,10 +295,22 @@ void OptionsDialog::on_resetButton_clicked()
 
 void OptionsDialog::on_openBitcoinConfButton_clicked()
 {
-    /* explain the purpose of the config file */
-    QMessageBox::information(this, tr("Configuration options"),
-        tr("The configuration file is used to specify advanced user options which override GUI settings. "
-           "Additionally, any command-line options will override this configuration file."));
+    QMessageBox config_msgbox(this);
+    config_msgbox.setIcon(QMessageBox::Information);
+    //: Window title text of pop-up box that allows opening up of configuration file.
+    config_msgbox.setWindowTitle(tr("Configuration options"));
+    /*: Explanatory text about the priority order of instructions considered by client.
+        The order from high to low being: command-line, configuration file, GUI settings. */
+    config_msgbox.setText(tr("The configuration file is used to specify advanced user options which override GUI settings. "
+                             "Additionally, any command-line options will override this configuration file."));
+
+    QPushButton* open_button = config_msgbox.addButton(tr("Continue"), QMessageBox::ActionRole);
+    config_msgbox.addButton(tr("Cancel"), QMessageBox::RejectRole);
+    open_button->setDefault(true);
+
+    config_msgbox.exec();
+
+    if (config_msgbox.clickedButton() != open_button) return;
 
     /* show an error if there was some problem opening the file */
     if (!GUIUtil::openBitcoinConf())


### PR DESCRIPTION
This PR renames the **OK** button to **Continue** and adds a **Cancel** button to the configuration options pop-up.

This feature will give the user an option to abort opening the configuration file if they want to. This is an essential helpful feature that was missing in the master branch.

In some windows managers such as Windows I3. The exit button at the top right corner is missing. So this feature becomes crucial there. And even when the exit button is there, it doesn't prevent the opening of the configuration file even when pressed.

Additionally, it will always be possible to close using Keyboard Shortcut. This PR helps accessibility for those who need to use a mouse.

<table>
  <tr>
   <td>Master
   </td>
   <td>PR
   </td>
  </tr>
  <tr>
   <td>

![Cancel-conf master(1)](https://user-images.githubusercontent.com/85434418/127555137-7a16dffd-109d-4024-917b-6b85f4df4f4a.png)


   </td>
   <td>

![Screenshot from 2021-09-07 20-15-28](https://user-images.githubusercontent.com/85434418/132365729-14f71f92-220b-4bb6-bed4-8315bd5697e6.png)



   </td>
  </tr>
</table>
