### PR TITLE
Ensure external signer option remains disabled without signers

### DIFF
--- a/src/qt/createwalletdialog.cpp
+++ b/src/qt/createwalletdialog.cpp
@@ -32,7 +32,7 @@ CreateWalletDialog::CreateWalletDialog(QWidget* parent) :
         // set to true, enable it when isEncryptWalletChecked is false.
         ui->disable_privkeys_checkbox->setEnabled(!checked);
 #ifdef ENABLE_EXTERNAL_SIGNER
-        ui->external_signer_checkbox->setEnabled(!checked);
+        ui->external_signer_checkbox->setEnabled(m_has_signers && !checked);
 #endif
         // When the disable_privkeys_checkbox is disabled, uncheck it.
         if (!ui->disable_privkeys_checkbox->isEnabled()) {
@@ -115,7 +115,8 @@ CreateWalletDialog::~CreateWalletDialog()
 
 void CreateWalletDialog::setSigners(const std::vector<ExternalSigner>& signers)
 {
-    if (!signers.empty()) {
+    m_has_signers = !signers.empty();
+    if (m_has_signers) {
         ui->external_signer_checkbox->setEnabled(true);
         ui->external_signer_checkbox->setChecked(true);
         ui->encrypt_wallet_checkbox->setEnabled(false);

--- a/src/qt/createwalletdialog.h
+++ b/src/qt/createwalletdialog.h
@@ -35,6 +35,7 @@ public:
 
 private:
     Ui::CreateWalletDialog *ui;
+    bool m_has_signers = false;
 };
 
 #endif // BITCOIN_QT_CREATEWALLETDIALOG_H


### PR DESCRIPTION
When no external signers are available, the option to enable external signers should always be disabled. However the encrypt wallet checkbox can erroneously re-enable the external signer checkbox. To avoid this, CreateWalletDialog now stores whether signers were available during setSigners so that future calls to external_signer_checkbox->setEnabled can account for whether signers are available.

Fixes #395