### PR TITLE
Honor inbound/outbound arrow prefix when sorting peer address column

### DIFF
--- a/src/qt/peertablesortproxy.cpp
+++ b/src/qt/peertablesortproxy.cpp
@@ -21,11 +21,15 @@ bool PeerTableSortProxy::lessThan(const QModelIndex& left_index, const QModelInd
     const CNodeStats left_stats = Assert(sourceModel()->data(left_index, PeerTableModel::StatsRole).value<CNodeCombinedStats*>())->nodeStats;
     const CNodeStats right_stats = Assert(sourceModel()->data(right_index, PeerTableModel::StatsRole).value<CNodeCombinedStats*>())->nodeStats;
 
+    // Add inbound/outbound arrow prefix to include it in sorting Address
+    const std::string left_arrowAddrName = (left_stats.fInbound ? "↓ " : "↑ ") + left_stats.addrName;
+    const std::string right_arrowAddrName = (right_stats.fInbound ? "↓ " : "↑ ") + right_stats.addrName;
+
     switch (static_cast<PeerTableModel::ColumnIndex>(left_index.column())) {
     case PeerTableModel::NetNodeId:
         return left_stats.nodeid < right_stats.nodeid;
     case PeerTableModel::Address:
-        return left_stats.addrName.compare(right_stats.addrName) < 0;
+        return left_arrowAddrName.compare(right_arrowAddrName) < 0;
     case PeerTableModel::ConnectionType:
         return left_stats.m_conn_type < right_stats.m_conn_type;
     case PeerTableModel::Network:


### PR DESCRIPTION
Fixes #397

~This re-establishes a functionality that was lost I guess since 0.21.~

Peer address column sort with current master:
Peers 27 and 51 are sorted without honoring the connection direction.
![address_sort_without_prefix](https://user-images.githubusercontent.com/8447873/128624227-4facc819-dd10-432a-82aa-31e6d1346597.png)

Peer address column sort with this PR:
Peers 16 and 22 are sorted honoring the connection direction.
![address_sort_with_prefix](https://user-images.githubusercontent.com/8447873/128624268-1ffd158c-6403-4203-a5de-6eb0fb843acb.png)

I would be grateful for implementation improvement suggestions.