### PR TITLE
refactor: Make paths to update Encryption and HD wallet statuses simpler

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -692,7 +692,6 @@ void BitcoinGUI::addWallet(WalletModel* walletModel)
     });
     connect(wallet_view, &WalletView::encryptionStatusChanged, this, &BitcoinGUI::updateWalletStatus);
     connect(wallet_view, &WalletView::incomingTransaction, this, &BitcoinGUI::incomingTransaction);
-    connect(wallet_view, &WalletView::hdEnabledStatusChanged, this, &BitcoinGUI::updateWalletStatus);
     connect(this, &BitcoinGUI::setPrivacy, wallet_view, &WalletView::setPrivacy);
     wallet_view->setPrivacy(isPrivacyModeActivated());
     const QString display_name = walletModel->getDisplayName();

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -110,6 +110,7 @@ BitcoinGUI::BitcoinGUI(interfaces::Node& node, const PlatformStyle *_platformSty
             connect(activity, &CreateWalletActivity::finished, activity, &QObject::deleteLater);
             activity->create();
         });
+        connect(walletFrame, &WalletFrame::currentWalletSet, [this] { updateWalletStatus(); });
         setCentralWidget(walletFrame);
     } else
 #endif // ENABLE_WALLET

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -1337,9 +1337,8 @@ void BitcoinGUI::setEncryptionStatus(int status)
 
 void BitcoinGUI::updateWalletStatus()
 {
-    if (!walletFrame) {
-        return;
-    }
+    assert(walletFrame);
+
     WalletView * const walletView = walletFrame->currentWalletView();
     if (!walletView) {
         return;

--- a/src/qt/walletframe.cpp
+++ b/src/qt/walletframe.cpp
@@ -103,7 +103,8 @@ void WalletFrame::setCurrentWallet(WalletModel* wallet_model)
     walletView->updateGeometry();
 
     walletStack->setCurrentWidget(walletView);
-    walletView->updateEncryptionStatus();
+
+    Q_EMIT currentWalletSet();
 }
 
 void WalletFrame::removeWallet(WalletModel* wallet_model)

--- a/src/qt/walletframe.h
+++ b/src/qt/walletframe.h
@@ -48,6 +48,7 @@ public:
 
 Q_SIGNALS:
     void createWalletButtonClicked();
+    void currentWalletSet();
 
 private:
     QStackedWidget *walletStack;

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -122,7 +122,7 @@ void WalletView::setWalletModel(WalletModel *_walletModel)
 
         // Handle changes in encryption status
         connect(_walletModel, &WalletModel::encryptionStatusChanged, this, &WalletView::encryptionStatusChanged);
-        updateEncryptionStatus();
+        Q_EMIT encryptionStatusChanged();
 
         // update HD status
         Q_EMIT hdEnabledStatusChanged();
@@ -253,11 +253,6 @@ void WalletView::showOutOfSyncWarning(bool fShow)
     overviewPage->showOutOfSyncWarning(fShow);
 }
 
-void WalletView::updateEncryptionStatus()
-{
-    Q_EMIT encryptionStatusChanged();
-}
-
 void WalletView::encryptWallet()
 {
     if(!walletModel)
@@ -266,7 +261,7 @@ void WalletView::encryptWallet()
     dlg.setModel(walletModel);
     dlg.exec();
 
-    updateEncryptionStatus();
+    Q_EMIT encryptionStatusChanged();
 }
 
 void WalletView::backupWallet()

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -122,10 +122,6 @@ void WalletView::setWalletModel(WalletModel *_walletModel)
 
         // Handle changes in encryption status
         connect(_walletModel, &WalletModel::encryptionStatusChanged, this, &WalletView::encryptionStatusChanged);
-        Q_EMIT encryptionStatusChanged();
-
-        // update HD status
-        Q_EMIT hdEnabledStatusChanged();
 
         // Balloon pop-up for new transaction
         connect(_walletModel->getTransactionTableModel(), &TransactionTableModel::rowsInserted, this, &WalletView::processNewTransaction);

--- a/src/qt/walletview.h
+++ b/src/qt/walletview.h
@@ -105,9 +105,6 @@ public Q_SLOTS:
     /** Show used receiving addresses */
     void usedReceivingAddresses();
 
-    /** Re-emit encryption status signal */
-    void updateEncryptionStatus();
-
     /** Show progress dialog e.g. for rescan */
     void showProgress(const QString &title, int nProgress);
 

--- a/src/qt/walletview.h
+++ b/src/qt/walletview.h
@@ -116,8 +116,6 @@ Q_SIGNALS:
     void message(const QString &title, const QString &message, unsigned int style);
     /** Encryption status of wallet changed */
     void encryptionStatusChanged();
-    /** HD-Enabled status of wallet changed (only possible during startup) */
-    void hdEnabledStatusChanged();
     /** Notify that a new transaction appeared */
     void incomingTransaction(const QString& date, int unit, const CAmount& amount, const QString& type, const QString& address, const QString& label, const QString& walletName);
     /** Notify that the out of sync warning icon has been pressed */


### PR DESCRIPTION
This PR makes signal-slot paths to reach `setHDStatus` and `setEncryptionStatus` functions shorter and easier to reason about them.

Required to simplify #398 (see https://github.com/bitcoin-core/gui/pull/398#discussion_r686094883).

---

**Note for reviewers.** Please verify that "Encrypt Wallet..." menu item, and the following icons

![DeepinScreenshot_select-area_20210811202120](https://user-images.githubusercontent.com/32963518/129074601-13fa998a-ac47-4ad2-be00-ba400b12c18a.png)

and updated properly in each and every possible scenario.