### PR TITLE
bugfix: initialize IsHDEnabled correctly.

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1364,9 +1364,13 @@ CAmount CWallet::GetDebit(const CTransaction& tx, const isminefilter& filter) co
 bool CWallet::IsHDEnabled() const
 {
     // All Active ScriptPubKeyMans must be HD for this to be true
-    bool result = true;
+    bool result = false;
     for (const auto& spk_man : GetActiveScriptPubKeyMans()) {
-        result &= spk_man->IsHDEnabled();
+        if (spk_man->IsHDEnabled()) {
+            result = true;
+        } else {
+            return false;
+        }
     }
     return result;
 }


### PR DESCRIPTION

the result of `IsHDEnabled()` was initialized with true.

But in case of no keys or a blank hd wallet the iterator would be skipped
and not set to false.
What had resulted in a wrong return and subsequent false hd and watch only icon display
in gui when reloading a wallet after closing.
