### PR TITLE
Add missing mnemonics in menu bar options

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -326,7 +326,7 @@ void BitcoinGUI::createActions()
     verifyMessageAction->setStatusTip(tr("Verify messages to ensure they were signed with specified Bitcoin addresses"));
     m_load_psbt_action = new QAction(tr("&Load PSBT from file…"), this);
     m_load_psbt_action->setStatusTip(tr("Load Partially Signed Bitcoin Transaction"));
-    m_load_psbt_clipboard_action = new QAction(tr("Load PSBT from clipboard…"), this);
+    m_load_psbt_clipboard_action = new QAction(tr("Load PSBT from &clipboard…"), this);
     m_load_psbt_clipboard_action->setStatusTip(tr("Load Partially Signed Bitcoin Transaction from clipboard"));
 
     openRPCConsoleAction = new QAction(tr("Node window"), this);
@@ -483,7 +483,7 @@ void BitcoinGUI::createMenuBar()
 
     QMenu* window_menu = appMenuBar->addMenu(tr("&Window"));
 
-    QAction* minimize_action = window_menu->addAction(tr("Minimize"));
+    QAction* minimize_action = window_menu->addAction(tr("&Minimize"));
     minimize_action->setShortcut(QKeySequence(Qt::CTRL + Qt::Key_M));
     connect(minimize_action, &QAction::triggered, [] {
         QApplication::activeWindow()->showMinimized();


### PR DESCRIPTION
Since #362 we have defaulted to add mnemonic shortcuts for the context menus.
The Window -> Minimize option and File -> Load PSBT from clipboard were hitherto missing a mnemonic shortcut. This PR adds mnemonic shortcuts for them

Changes introduced in this PR:
| Master | PR |
| ----------| ---- |
| ![Screenshot from 2021-08-23 23-10-07](https://user-images.githubusercontent.com/85434418/130494098-c65ec9da-c3f1-4243-9b3d-0c87cb677825.png) | ![Screenshot from 2021-08-23 23-08-41](https://user-images.githubusercontent.com/85434418/130494083-849ffd14-05e9-4a6d-bdc3-b3e55b8a8861.png)|
|![Screenshot from 2021-08-23 23-10-21](https://user-images.githubusercontent.com/85434418/130494233-1b2e8838-c5d4-48a8-9abf-a4acc8d6146c.png)|![Screenshot from 2021-08-23 23-09-00](https://user-images.githubusercontent.com/85434418/130494181-dcdbf119-a2c6-469d-a6c9-3021506ab40b.png)|

