### PR TITLE
Fix window title of wallet loading window

### DIFF
--- a/src/qt/guiconstants.h
+++ b/src/qt/guiconstants.h
@@ -44,10 +44,10 @@ static const int TOOLTIP_WRAP_THRESHOLD = 80;
 
 #define QAPP_ORG_NAME "Bitcoin"
 #define QAPP_ORG_DOMAIN "bitcoin.org"
-#define QAPP_APP_NAME_DEFAULT "Bitcoin-Qt"
-#define QAPP_APP_NAME_TESTNET "Bitcoin-Qt-testnet"
-#define QAPP_APP_NAME_SIGNET "Bitcoin-Qt-signet"
-#define QAPP_APP_NAME_REGTEST "Bitcoin-Qt-regtest"
+#define QAPP_APP_NAME_DEFAULT "Bitcoin Core"
+#define QAPP_APP_NAME_TESTNET "Bitcoin Core-testnet"
+#define QAPP_APP_NAME_SIGNET "Bitcoin Core-signet"
+#define QAPP_APP_NAME_REGTEST "Bitcoin Core-regtest"
 
 /* One gigabyte (GB) in bytes */
 static constexpr uint64_t GB_BYTES{1000000000};


### PR DESCRIPTION
The title of the window while loading of wallet is “Bitcoin-Qt”, whereas it should be “Bitcoin Core”. This PR fixes this difference.

Changes introduced in this PR (Runned Bitcoin-GUI on signet network)
|Master|PR|
|---|---|
|![Screenshot from 2021-08-24 00-02-18](https://user-images.githubusercontent.com/85434418/130500309-2f0af2c9-55f0-4609-a92b-3156800fa92e.png)|![Screenshot from 2021-08-23 23-58-26](https://user-images.githubusercontent.com/85434418/130500351-546ee3ae-ea34-4baf-92f7-d9c2012e750d.png)|
