### PR TITLE
Toggle chain from menu (using Settings)

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -190,6 +190,10 @@ GUI changes
 - UTXOs which are locked via the GUI are now stored persistently in the
   wallet database, so are not lost on node shutdown or crash. (#23065)
 
+- Toggle chain from mainnet to testnet, signet or regtest. The GUI now always sets `-chain`,
+  so any occurrences of `-testnet`, `-signet` or `-regtest` in `bitcoin.conf` should
+  be replace with `chain=test`, `chain=signet` or `chain=regtest` respectively. (bitcoin-core/gui#414)
+
 - The Bech32 checkbox has been replaced with a dropdown for all address types, including the new Bech32m (BIP-350) standard for Taproot enabled wallets.
 
 Low-level changes

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -564,6 +564,10 @@ int GuiMain(int argc, char* argv[])
     // - QSettings() will use the new application name after this, resulting in network-specific settings
     // - Needs to be done before createOptionsModel
 
+    QSettings settings;
+    std::string chain = settings.value("chain", "main").toString().toStdString();
+    gArgs.SoftSetArg("-chain", chain);
+
     // Check for chain settings (Params() calls are only valid after this clause)
     try {
         SelectParams(gArgs.GetChainName());


### PR DESCRIPTION
Implements #78

It's currently not easy for GUI users to switch to a test chain like signet. E.g on macOS this requires using the command line, since Spotlight doesn't let you add an argument like `-signet`.

This PR makes it easier by adding a menu option to restart with a different chain. ~It does this by adding a `.chain_gui` file. Unfortunately we can't use `settings.json`, because this file is network specific. This file is ignored by `bitcoind`.~ It does this by adding `chain` to the mainnet QSettings.

<img width="445" alt="Schermafbeelding 2021-09-01 om 13 01 37" src="https://user-images.githubusercontent.com/10217/131660689-40dc89b4-bafc-4e11-b75c-254584b43ff2.png">
(it's now under Settings, not File)
