### PR TITLE
Ditch wallet model juggling

### DIFF
--- a/src/qt/addresstablemodel.cpp
+++ b/src/qt/addresstablemodel.cpp
@@ -70,12 +70,13 @@ class AddressTablePriv
 {
 public:
     QList<AddressTableEntry> cachedAddressTable;
-    AddressTableModel *parent;
+    AddressTableModel* const parent;
+    const bool pk_hash_only;
 
-    explicit AddressTablePriv(AddressTableModel *_parent):
-        parent(_parent) {}
+    explicit AddressTablePriv(AddressTableModel *_parent, bool pk_hash_only):
+        parent(_parent), pk_hash_only(pk_hash_only) {}
 
-    void refreshAddressTable(interfaces::Wallet& wallet, bool pk_hash_only = false)
+    void refreshAddressTable(interfaces::Wallet& wallet)
     {
         cachedAddressTable.clear();
         {
@@ -166,13 +167,17 @@ AddressTableModel::AddressTableModel(WalletModel *parent, bool pk_hash_only) :
     QAbstractTableModel(parent), walletModel(parent)
 {
     columns << tr("Label") << tr("Address");
-    priv = new AddressTablePriv(this);
-    priv->refreshAddressTable(parent->wallet(), pk_hash_only);
+    priv = new AddressTablePriv(this, pk_hash_only);
 }
 
 AddressTableModel::~AddressTableModel()
 {
     delete priv;
+}
+
+void AddressTableModel::preload()
+{
+    priv->refreshAddressTable(walletModel->wallet());
 }
 
 int AddressTableModel::rowCount(const QModelIndex &parent) const

--- a/src/qt/addresstablemodel.h
+++ b/src/qt/addresstablemodel.h
@@ -50,6 +50,8 @@ public:
     static const QString Send;      /**< Specifies send address */
     static const QString Receive;   /**< Specifies receive address */
 
+    void preload();
+
     /** @name Methods overridden from QAbstractTableModel
         @{*/
     int rowCount(const QModelIndex &parent) const override;

--- a/src/qt/recentrequeststablemodel.cpp
+++ b/src/qt/recentrequeststablemodel.cpp
@@ -23,11 +23,6 @@
 RecentRequestsTableModel::RecentRequestsTableModel(WalletModel *parent) :
     QAbstractTableModel(parent), walletModel(parent)
 {
-    // Load entries from wallet
-    for (const std::string& request : parent->wallet().getAddressReceiveRequests()) {
-        addNewRequest(request);
-    }
-
     /* These columns must match the indices in the ColumnIndex enumeration */
     columns << tr("Date") << tr("Label") << tr("Message") << getAmountTitle();
 
@@ -35,6 +30,14 @@ RecentRequestsTableModel::RecentRequestsTableModel(WalletModel *parent) :
 }
 
 RecentRequestsTableModel::~RecentRequestsTableModel() = default;
+
+void RecentRequestsTableModel::preload()
+{
+    // Load entries from wallet
+    for (const std::string& request : walletModel->wallet().getAddressReceiveRequests()) {
+        addNewRequest(request);
+    }
+}
 
 int RecentRequestsTableModel::rowCount(const QModelIndex &parent) const
 {

--- a/src/qt/recentrequeststablemodel.h
+++ b/src/qt/recentrequeststablemodel.h
@@ -65,6 +65,8 @@ public:
         NUMBER_OF_COLUMNS
     };
 
+    void preload();
+
     /** @name Methods overridden from QAbstractTableModel
         @{*/
     int rowCount(const QModelIndex &parent) const override;

--- a/src/qt/test/addressbooktests.cpp
+++ b/src/qt/test/addressbooktests.cpp
@@ -129,6 +129,7 @@ void TestAddAddressesToSendBook(interfaces::Node& node)
     WalletContext& context = *node.walletLoader().context();
     AddWallet(context, wallet);
     WalletModel walletModel(interfaces::MakeWallet(context, wallet), clientModel, platformStyle.get());
+    walletModel.preload();
     RemoveWallet(context, wallet, /* load_on_start= */ std::nullopt);
     EditAddressDialog editAddressDialog(EditAddressDialog::NewSendingAddress);
     editAddressDialog.setModel(walletModel.getAddressTableModel());

--- a/src/qt/test/wallettests.cpp
+++ b/src/qt/test/wallettests.cpp
@@ -189,6 +189,7 @@ void TestGUI(interfaces::Node& node)
     WalletContext& context = *node.walletLoader().context();
     AddWallet(context, wallet);
     WalletModel walletModel(interfaces::MakeWallet(context, wallet), clientModel, platformStyle.get());
+    walletModel.preload();
     RemoveWallet(context, wallet, /* load_on_start= */ std::nullopt);
     sendCoinsDialog.setModel(&walletModel);
     transactionView.setModel(&walletModel);

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -256,11 +256,7 @@ TransactionTableModel::TransactionTableModel(const PlatformStyle *_platformStyle
         fProcessingQueuedTransactions(false),
         platformStyle(_platformStyle)
 {
-    subscribeToCoreSignals();
-
     columns << QString() << QString() << tr("Date") << tr("Type") << tr("Label") << BitcoinUnits::getAmountColumnTitle(walletModel->getOptionsModel()->getDisplayUnit());
-    priv->refreshWallet(walletModel->wallet());
-
     connect(walletModel->getOptionsModel(), &OptionsModel::displayUnitChanged, this, &TransactionTableModel::updateDisplayUnit);
 }
 
@@ -268,6 +264,12 @@ TransactionTableModel::~TransactionTableModel()
 {
     unsubscribeFromCoreSignals();
     delete priv;
+}
+
+void TransactionTableModel::preload()
+{
+    subscribeToCoreSignals();
+    priv->refreshWallet(walletModel->wallet());
 }
 
 /** Updates the column title to "Amount (DisplayUnit)" and emits headerDataChanged() signal for table headers to react. */

--- a/src/qt/transactiontablemodel.h
+++ b/src/qt/transactiontablemodel.h
@@ -76,6 +76,8 @@ public:
         RawDecorationRole,
     };
 
+    void preload();
+
     int rowCount(const QModelIndex &parent) const override;
     int columnCount(const QModelIndex &parent) const override;
     QVariant data(const QModelIndex &index, int role) const override;

--- a/src/qt/walletcontroller.cpp
+++ b/src/qt/walletcontroller.cpp
@@ -131,6 +131,8 @@ WalletModel* WalletController::getOrCreateWallet(std::unique_ptr<interfaces::Wal
         wallet_model = new WalletModel(std::move(wallet), m_client_model, m_platform_style, this);
     }, GUIUtil::blockingGUIThreadConnection());
 
+    wallet_model->preload();
+
     m_wallets.push_back(wallet_model);
 
     // WalletModel::startPollBalance needs to be called in a thread managed by

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -56,13 +56,19 @@ WalletModel::WalletModel(std::unique_ptr<interfaces::Wallet> wallet, ClientModel
     addressTableModel = new AddressTableModel(this);
     transactionTableModel = new TransactionTableModel(platformStyle, this);
     recentRequestsTableModel = new RecentRequestsTableModel(this);
-
-    subscribeToCoreSignals();
 }
 
 WalletModel::~WalletModel()
 {
     unsubscribeFromCoreSignals();
+}
+
+void WalletModel::preload()
+{
+    addressTableModel->preload();
+    transactionTableModel->preload();
+    recentRequestsTableModel->preload();
+    subscribeToCoreSignals();
 }
 
 void WalletModel::startPollBalance()

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -77,6 +77,8 @@ public:
         Unlocked      // wallet->IsCrypted() && !wallet->IsLocked()
     };
 
+    void preload();
+
     OptionsModel* getOptionsModel() const;
     AddressTableModel* getAddressTableModel() const;
     TransactionTableModel* getTransactionTableModel() const;


### PR DESCRIPTION
Instantiate `WalletModel` in the main thread - avoids calling`setParent` and `moveToThread`.

Also ensures loading (fetching transactions, addresses, etc) still occurs in the background thread.