### PR TITLE
fix bitcoin-qt app categorization on apple silicon

### DIFF
--- a/share/qt/Info.plist.in
+++ b/share/qt/Info.plist.in
@@ -16,6 +16,11 @@
   <key>CFBundlePackageType</key>
   <string>APPL</string>
 
+  <key>CFBundleSupportedPlatforms</key>
+  <array>
+	   <string>MacOSX</string>
+  </array>
+
   <key>NSHumanReadableCopyright</key>
   <string>@CLIENT_VERSION_MAJOR@.@CLIENT_VERSION_MINOR@.@CLIENT_VERSION_BUILD@, Copyright © 2009-@COPYRIGHT_YEAR@ @COPYRIGHT_HOLDERS_FINAL@</string>
 


### PR DESCRIPTION
`System Information` contains many insights into various aspects of your macOS system; the 'Applications' tab contains info on apps. Starting with macOS 11, the 'kind' column under the 'Applications' tab started displaying the CPU architecture of the application. The options are; apple silicon, intel, universal. Previously, the `kind` column indicated where the application originated. The change was made to conveniently determine if the app installed was built to run natively on the new M1 CPU or an intel app that will run under rosetta. Of course, there are several other tools to confirm this; the 'kind' column provides a user-friendly way.

We expect that Bitcoin Core compiled, built, and deployed on an intel CPU will be classified as `Intel`. Similarly, we expect that if this is done on an M1 mac, the resulting app is classified as `Apple Silicon`. In reality, Bitcoin-qt built and deployed on an M1 mac will be classified as `IOS`. This behavior is incorrect and should be fixed.

We fix this by setting the `CFBundleSupportedPlatforms` in our info.plist to the value of `MacOSX`. In doing this, we are telling macOS, "We do not support IOS; stop it!".

Tested and confirmed that this is a no-op on macOS < 11. 

| On [#22546](https://github.com/bitcoin/bitcoin/pull/22546) Branch | [#22546](https://github.com/bitcoin/bitcoin/pull/22546) + PR Branch  |
| ------------------------------------------------------------------- | ----------- |
| ![Screen Shot 2021-09-04 at 6 21 49 PM](https://user-images.githubusercontent.com/23396902/132113868-c697d699-12c3-4834-8b8a-003ff475d946.jpeg) | ![Screen Shot 2021-09-04 at 6 12 14 PM](https://user-images.githubusercontent.com/23396902/132113875-6f004f72-4108-41d6-ab03-e90d3e400713.jpeg) |

**To Test:**
For testing, our base branch will be [#22546](https://github.com/bitcoin/bitcoin/pull/22546). Please perform the following steps on the base branch and then the base branch with the commit from this PR cherry-picked onto it:

- Have an M1 mac
- Compile and deploy bitcoin
- Open up the deployed *.dmg, installed the bundled app
- Eject the bitcoin dmg that should currently be mounted
- Navigate to System Information -> Applications
  - Click on the top-left Apple icon
  - Click about this mac
  - Click on the 'Storage' tab
  - Click on the 'Manage...' button
  - On the left, click on 'Applications'
  - Sort by Name
- Look for the Bitcoin Core application
  - Base Branch: The kind column should state that this application is of type `IOS`
  - PR Branch: The kind column should state that this application is of type `Apple Silicon`
  
Note: Intel users on at least macOS 11 can help test by confirming that the application still shows up as kind=`Intel`