### PR TITLE
Add missing tooltips to options menu settings

### DIFF
--- a/src/qt/forms/optionsdialog.ui
+++ b/src/qt/forms/optionsdialog.ui
@@ -104,6 +104,9 @@
         <layout class="QHBoxLayout" name="horizontalLayout_2_Main">
          <item>
           <widget class="QLabel" name="databaseCacheLabel">
+           <property name="toolTip">
+            <string extracomment="Tooltip text for Options window setting that sets the size of the database cache. Explains the corresponding effects of increasing/decreasing this value.">Maximum database cache size. A larger cache can contribute to faster sync, after which the benefit is less pronounced for most use cases. Lowering the cache size will reduce memory usage. Unused mempool memory is shared for this cache.</string>
+           </property>
            <property name="text">
             <string>Size of &amp;database cache</string>
            </property>
@@ -147,6 +150,9 @@
         <layout class="QHBoxLayout" name="horizontalLayout_Main_VerifyLabel">
          <item>
           <widget class="QLabel" name="threadsScriptVerifLabel">
+           <property name="toolTip">
+            <string extracomment="Tooltip text for Options window setting that sets the number of script verification threads. Explains that negative values mean to leave these many cores free to the system.">Set the number of script verification threads. Negative values correspond to the number of cores you want to leave free to the system.</string>
+           </property>
            <property name="text">
             <string>Number of script &amp;verification threads</string>
            </property>


### PR DESCRIPTION
This adds missing tooltips to the text of the `Size of database cache` and the `Number of script verification threads` settings. 

All settings in the Options window will now have appropriate tooltip texts.