### PR TITLE
Ensure translator comments end in full stop

### DIFF
--- a/src/qt/addressbookpage.cpp
+++ b/src/qt/addressbookpage.cpp
@@ -282,7 +282,7 @@ void AddressBookPage::on_exportButton_clicked()
     QString filename = GUIUtil::getSaveFileName(this,
         tr("Export Address List"), QString(),
         /*: Expanded name of the CSV file format.
-            See https://en.wikipedia.org/wiki/Comma-separated_values */
+            See: https://en.wikipedia.org/wiki/Comma-separated_values. */
         tr("Comma separated file") + QLatin1String(" (*.csv)"), nullptr);
 
     if (filename.isNull())

--- a/src/qt/qrimagewidget.cpp
+++ b/src/qt/qrimagewidget.cpp
@@ -119,7 +119,7 @@ void QRImageWidget::saveImage()
     QString fn = GUIUtil::getSaveFileName(
         this, tr("Save QR Code"), QString(),
         /*: Expanded name of the PNG file format.
-            See https://en.wikipedia.org/wiki/Portable_Network_Graphics */
+            See: https://en.wikipedia.org/wiki/Portable_Network_Graphics. */
         tr("PNG Image") + QLatin1String(" (*.png)"), nullptr);
     if (!fn.isEmpty())
     {

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -680,7 +680,7 @@ void RPCConsole::setClientModel(ClientModel *model, int bestblock_height, int64_
 
         // create peer table context menu
         peersTableContextMenu = new QMenu(this);
-        //: Context menu action to copy the address of a peer
+        //: Context menu action to copy the address of a peer.
         peersTableContextMenu->addAction(tr("&Copy address"), [this] {
             GUIUtil::copyEntryData(ui->peerWidget, PeerTableModel::Address, Qt::DisplayRole);
         });
@@ -713,7 +713,7 @@ void RPCConsole::setClientModel(ClientModel *model, int bestblock_height, int64_
         banTableContextMenu = new QMenu(this);
         /*: Context menu action to copy the IP/Netmask of a banned peer.
             IP/Netmask is the combination of a peer's IP address and its Netmask.
-            For IP address see: https://en.wikipedia.org/wiki/IP_address */
+            For IP address, see: https://en.wikipedia.org/wiki/IP_address. */
         banTableContextMenu->addAction(tr("&Copy IP/Netmask"), [this] {
             GUIUtil::copyEntryData(ui->banlistWidget, BanTableModel::Address, Qt::DisplayRole);
         });

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -200,7 +200,7 @@ void SendCoinsDialog::setModel(WalletModel *_model)
         ui->optInRBF->setCheckState(Qt::Checked);
 
         if (model->wallet().hasExternalSigner()) {
-            //: "device" usually means a hardware wallet
+            //: "device" usually means a hardware wallet.
             ui->sendButton->setText(tr("Sign on device"));
             if (gArgs.GetArg("-signer", "") != "") {
                 ui->sendButton->setEnabled(true);

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -353,7 +353,7 @@ void TransactionView::exportClicked()
     QString filename = GUIUtil::getSaveFileName(this,
         tr("Export Transaction History"), QString(),
         /*: Expanded name of the CSV file format.
-            See https://en.wikipedia.org/wiki/Comma-separated_values */
+            See: https://en.wikipedia.org/wiki/Comma-separated_values. */
         tr("Comma separated file") + QLatin1String(" (*.csv)"), nullptr);
 
     if (filename.isNull())


### PR DESCRIPTION
This is a follow-up to #318 which addresses this [nit](https://github.com/bitcoin-core/gui/pull/318#discussion_r706856893) by addressing it globally.

This ensures that all GUI translator comments end in a full stop. If a comment does not end in a full stop, a translator may think  that the rest of the comment is being cut off.

While here, add a colon to the word "see" for any comments touched which point to look at a link.
