### PR TITLE
Improvements to the open up transaction in third-party link action

### DIFF
--- a/src/qt/forms/optionsdialog.ui
+++ b/src/qt/forms/optionsdialog.ui
@@ -729,10 +729,10 @@
          <item>
           <widget class="QLabel" name="thirdPartyTxUrlsLabel">
            <property name="toolTip">
-            <string>Third party URLs (e.g. a block explorer) that appear in the transactions tab as context menu items. %s in the URL is replaced by transaction hash. Multiple URLs are separated by vertical bar |.</string>
+            <string>Third-party URLs (e.g. a block explorer) that appear in the transactions tab as context menu items. %s in the URL is replaced by transaction hash. Multiple URLs are separated by vertical bar |.</string>
            </property>
            <property name="text">
-            <string>&amp;Third party transaction URLs</string>
+            <string>&amp;Third-party transaction URLs</string>
            </property>
            <property name="buddy">
             <cstring>thirdPartyTxUrls</cstring>
@@ -742,7 +742,7 @@
          <item>
           <widget class="QLineEdit" name="thirdPartyTxUrls">
            <property name="toolTip">
-            <string>Third party URLs (e.g. a block explorer) that appear in the transactions tab as context menu items. %s in the URL is replaced by transaction hash. Multiple URLs are separated by vertical bar |.</string>
+            <string>Third-party URLs (e.g. a block explorer) that appear in the transactions tab as context menu items. %s in the URL is replaced by transaction hash. Multiple URLs are separated by vertical bar |.</string>
            </property>
            <property name="placeholderText">
             <string notr="true">https://example.com/tx/%s</string>

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -222,14 +222,17 @@ void TransactionView::setModel(WalletModel *_model)
         {
             // Add third party transaction URLs to context menu
             QStringList listUrls = GUIUtil::SplitSkipEmptyParts(_model->getOptionsModel()->getThirdPartyTxUrls(), "|");
+            bool actions_created = false;
             for (int i = 0; i < listUrls.size(); ++i)
             {
                 QString url = listUrls[i].trimmed();
                 QString host = QUrl(url, QUrl::StrictMode).host();
                 if (!host.isEmpty())
                 {
-                    if (i == 0)
+                    if (!actions_created) {
                         contextMenu->addSeparator();
+                        actions_created = true;
+                    }
                     /*: Transactions table context menu action to show the
                         selected transaction in a third-party block explorer.
                         %1 is a stand-in argument for the URL of the explorer. */

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -228,11 +228,9 @@ void TransactionView::setModel(WalletModel *_model)
                 QString host = QUrl(url, QUrl::StrictMode).host();
                 if (!host.isEmpty())
                 {
-                    QAction *thirdPartyTxUrlAction = new QAction(host, this); // use host as menu item label
                     if (i == 0)
                         contextMenu->addSeparator();
-                    contextMenu->addAction(thirdPartyTxUrlAction);
-                    connect(thirdPartyTxUrlAction, &QAction::triggered, [this, url] { openThirdPartyTxUrl(url); });
+                    contextMenu->addAction(host, [this, url] { openThirdPartyTxUrl(url); });
                 }
             }
         }

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -230,7 +230,10 @@ void TransactionView::setModel(WalletModel *_model)
                 {
                     if (i == 0)
                         contextMenu->addSeparator();
-                    contextMenu->addAction(host, [this, url] { openThirdPartyTxUrl(url); });
+                    /*: Transactions table context menu action to show the
+                        selected transaction in a third-party block explorer.
+                        %1 is a stand-in argument for the URL of the explorer. */
+                    contextMenu->addAction(tr("Show in %1").arg(host), [this, url] { openThirdPartyTxUrl(url); });
                 }
             }
         }


### PR DESCRIPTION
[#4092](https://github.com/bitcoin/bitcoin/pull/4092) introduced the ability to open up a transaction in a block explorer. This improves the related code by simplifying the addition and connection of the action through an [overloaded](https://doc.qt.io/archives/qt-5.9/qmenu.html#addAction-5) `addAction` function and prepends action description text to the host, "Show in". The reason to add this text is to make it clear what the action does. It also creates a clearer mental correlation between a user doing the work to add the 3rd-party tx link and this new menu action popping up.

This updates the setting text so that "third-party" is hyphenated. It should be hyphenated because it is being used as a modifier of both "URL" and "transaction URLs".

Additionally, this fixes #431 by ensuring that the seperator will be added before creating action.

Screenshots of visual changes:

**Context menu actions**
|   master   |   pr   |
|--------------|--------|
| <img width="248" alt="3pt-master" src="https://user-images.githubusercontent.com/23396902/134618354-00278ac6-5094-44ee-8ba7-fe648fdcb7d2.png"> | <img width="248" alt="3pt-pr" src="https://user-images.githubusercontent.com/23396902/134618364-ddb64269-e5ee-40af-a2a6-1922001b6f4e.png"> |

**Setting text**
(tooltip text containing usage of "third-party" is also properly hyphenated)
|   master   |   pr   |
|--------------|--------|
| ![unnamed](https://user-images.githubusercontent.com/23396902/134854070-fb299ba5-3491-487f-b37f-c0cd96514353.png) | ![pr-hyphenate](https://user-images.githubusercontent.com/23396902/134854127-88630cc2-a178-4376-a569-f413f66eba0d.png) |

 