### PR TITLE
Keep InitExecutor in main gui thread

### DIFF
--- a/src/qt/initexecutor.h
+++ b/src/qt/initexecutor.h
@@ -40,6 +40,7 @@ private:
     void handleRunawayException(const std::exception* e);
 
     interfaces::Node& m_node;
+    QObject m_context;
     QThread m_thread;
 };
 

--- a/src/qt/test/test_main.cpp
+++ b/src/qt/test/test_main.cpp
@@ -9,7 +9,6 @@
 #include <interfaces/init.h>
 #include <interfaces/node.h>
 #include <qt/bitcoin.h>
-#include <qt/initexecutor.h>
 #include <qt/test/apptests.h>
 #include <qt/test/rpcnestedtests.h>
 #include <qt/test/uritests.h>


### PR DESCRIPTION
The `InitExecutor` constructor moves the instance to a dedicated thread. This PR changes that by using `GUIUtil::ObjectInvoke` to run the relevant code in that thread.

A possible follow-up is to ditch the dedicated thread and use `QThreadPool` or even `QtConcurrent::run` (if we want to enable that). 