### PR TITLE
Move third-party tx URL setting from Display to Wallet options tab

### DIFF
--- a/src/qt/forms/optionsdialog.ui
+++ b/src/qt/forms/optionsdialog.ui
@@ -189,7 +189,7 @@
        <item>
         <widget class="QCheckBox" name="enableServer">
          <property name="toolTip">
-          <string extracomment="Tooltip text for Options window setting that enables the RPC server.">This allows you or a third party tool to communicate with the node through command-line and JSON-RPC commands.</string>
+          <string extracomment="Tooltip text for Options window setting that enables the RPC server.">This allows you or a third-party tool to communicate with the node through command-line and JSON-RPC commands.</string>
          </property>
          <property name="text">
           <string extracomment="An Options window setting to enable the RPC server.">Enable RPC &amp;server</string>
@@ -225,6 +225,33 @@
           <string extracomment="An Options window setting to set subtracting the fee from a sending amount as default.">Subtract &amp;fee from amount by default</string>
          </property>
         </widget>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_3_Display">
+         <item>
+          <widget class="QLabel" name="thirdPartyTxUrlsLabel">
+           <property name="toolTip">
+            <string>Third-party URLs (e.g. a block explorer) that appear in the transactions tab as context menu items. "%s" in the URL is replaced by the transaction hash. Multiple URLs are separated by a vertical bar |.</string>
+           </property>
+           <property name="text">
+            <string>&amp;Third-party transaction URLs</string>
+           </property>
+           <property name="buddy">
+            <cstring>thirdPartyTxUrls</cstring>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLineEdit" name="thirdPartyTxUrls">
+           <property name="toolTip">
+            <string>Third-party URLs (e.g. a block explorer) that appear in the transactions tab as context menu items. "%s" in the URL is replaced by the transaction hash. Multiple URLs are separated by a vertical bar |.</string>
+           </property>
+           <property name="placeholderText">
+            <string notr="true">https://example.com/tx/%s</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </item>
        <item>
         <widget class="QGroupBox" name="groupBox">
@@ -729,33 +756,6 @@
           <widget class="QValueComboBox" name="unit">
            <property name="toolTip">
             <string>Choose the default subdivision unit to show in the interface and when sending coins.</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_3_Display">
-         <item>
-          <widget class="QLabel" name="thirdPartyTxUrlsLabel">
-           <property name="toolTip">
-            <string>Third-party URLs (e.g. a block explorer) that appear in the transactions tab as context menu items. %s in the URL is replaced by transaction hash. Multiple URLs are separated by vertical bar |.</string>
-           </property>
-           <property name="text">
-            <string>&amp;Third-party transaction URLs</string>
-           </property>
-           <property name="buddy">
-            <cstring>thirdPartyTxUrls</cstring>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QLineEdit" name="thirdPartyTxUrls">
-           <property name="toolTip">
-            <string>Third-party URLs (e.g. a block explorer) that appear in the transactions tab as context menu items. %s in the URL is replaced by transaction hash. Multiple URLs are separated by vertical bar |.</string>
-           </property>
-           <property name="placeholderText">
-            <string notr="true">https://example.com/tx/%s</string>
            </property>
           </widget>
          </item>

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -207,6 +207,7 @@ void OptionsDialog::setModel(OptionsModel *_model)
     connect(ui->externalSignerPath, &QLineEdit::textChanged, [this]{ showRestartWarning(); });
     connect(ui->threadsScriptVerif, qOverload<int>(&QSpinBox::valueChanged), this, &OptionsDialog::showRestartWarning);
     /* Wallet */
+    connect(ui->thirdPartyTxUrls, &QLineEdit::textChanged, [this] { showRestartWarning(); });
     connect(ui->spendZeroConfChange, &QCheckBox::clicked, this, &OptionsDialog::showRestartWarning);
     /* Network */
     connect(ui->allowIncoming, &QCheckBox::clicked, this, &OptionsDialog::showRestartWarning);
@@ -215,7 +216,6 @@ void OptionsDialog::setModel(OptionsModel *_model)
     connect(ui->connectSocksTor, &QCheckBox::clicked, this, &OptionsDialog::showRestartWarning);
     /* Display */
     connect(ui->lang, qOverload<>(&QValueComboBox::valueChanged), [this]{ showRestartWarning(); });
-    connect(ui->thirdPartyTxUrls, &QLineEdit::textChanged, [this]{ showRestartWarning(); });
 }
 
 void OptionsDialog::setCurrentTab(OptionsDialog::Tab tab)
@@ -241,6 +241,7 @@ void OptionsDialog::setMapper()
     mapper->addMapping(ui->spendZeroConfChange, OptionsModel::SpendZeroConfChange);
     mapper->addMapping(ui->coinControlFeatures, OptionsModel::CoinControlFeatures);
     mapper->addMapping(ui->subFeeFromAmount, OptionsModel::SubFeeFromAmount);
+    mapper->addMapping(ui->thirdPartyTxUrls, OptionsModel::ThirdPartyTxUrls);
     mapper->addMapping(ui->externalSignerPath, OptionsModel::ExternalSignerPath);
 
     /* Network */
@@ -269,7 +270,6 @@ void OptionsDialog::setMapper()
     /* Display */
     mapper->addMapping(ui->lang, OptionsModel::Language);
     mapper->addMapping(ui->unit, OptionsModel::DisplayUnit);
-    mapper->addMapping(ui->thirdPartyTxUrls, OptionsModel::ThirdPartyTxUrls);
     mapper->addMapping(ui->embeddedFont_radioButton, OptionsModel::UseEmbeddedMonospacedFont);
 }
 

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -75,10 +75,6 @@ void OptionsModel::Init(bool resetSettings)
         settings.setValue("nDisplayUnit", BitcoinUnits::BTC);
     nDisplayUnit = settings.value("nDisplayUnit").toInt();
 
-    if (!settings.contains("strThirdPartyTxUrls"))
-        settings.setValue("strThirdPartyTxUrls", "");
-    strThirdPartyTxUrls = settings.value("strThirdPartyTxUrls", "").toString();
-
     if (!settings.contains("fCoinControlFeatures"))
         settings.setValue("fCoinControlFeatures", false);
     fCoinControlFeatures = settings.value("fCoinControlFeatures", false).toBool();
@@ -129,6 +125,10 @@ void OptionsModel::Init(bool resetSettings)
         settings.setValue("SubFeeFromAmount", false);
     }
     m_sub_fee_from_amount = settings.value("SubFeeFromAmount", false).toBool();
+
+    if (!settings.contains("strThirdPartyTxUrls"))
+        settings.setValue("strThirdPartyTxUrls", "");
+    strThirdPartyTxUrls = settings.value("strThirdPartyTxUrls", "").toString();
 #endif
 
     // Network
@@ -349,11 +349,11 @@ QVariant OptionsModel::data(const QModelIndex & index, int role) const
             return settings.value("external_signer_path");
         case SubFeeFromAmount:
             return m_sub_fee_from_amount;
+        case ThirdPartyTxUrls:
+            return strThirdPartyTxUrls;
 #endif
         case DisplayUnit:
             return nDisplayUnit;
-        case ThirdPartyTxUrls:
-            return strThirdPartyTxUrls;
         case Language:
             return settings.value("language");
         case UseEmbeddedMonospacedFont:
@@ -480,16 +480,16 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
             m_sub_fee_from_amount = value.toBool();
             settings.setValue("SubFeeFromAmount", m_sub_fee_from_amount);
             break;
-#endif
-        case DisplayUnit:
-            setDisplayUnit(value);
-            break;
         case ThirdPartyTxUrls:
             if (strThirdPartyTxUrls != value.toString()) {
                 strThirdPartyTxUrls = value.toString();
                 settings.setValue("strThirdPartyTxUrls", strThirdPartyTxUrls);
                 setRestartRequired(true);
             }
+            break;
+#endif
+        case DisplayUnit:
+            setDisplayUnit(value);
             break;
         case Language:
             if (settings.value("language") != value) {


### PR DESCRIPTION
Out of all the settings in the Display tab, the `Third-party transaction URLs` is the odd one out. All other settings here affect the way the GUI is displayed. This action affects what context menu actions are available when wallet functionality is enabled, and we have a transaction. As such, it is a better fit for this to be in the Wallet tab.

Not a part of #430 as it is not a direct improvement of the related code. Instead, it is a different opinion on the position of this setting.

Screenshots of visual changes:
|  master  |  pr  |
|-------------|------|
| ![master-setting-placement](https://user-images.githubusercontent.com/23396902/134861174-6ebc3936-4f9b-4183-8827-f1e1014ff828.png) | ![pr-setting-placement](https://user-images.githubusercontent.com/23396902/134861202-0c3bb166-7f1f-4a70-ab7c-4b51a79ba28c.png) |


Based on the last commit of #430 to not conflict.