### PR TITLE
Show received bitcoins in green

### DIFF
--- a/src/qt/guiconstants.h
+++ b/src/qt/guiconstants.h
@@ -25,6 +25,8 @@ static const bool DEFAULT_SPLASHSCREEN = true;
 #define COLOR_UNCONFIRMED QColor(128, 128, 128)
 /* Transaction list -- negative amount */
 #define COLOR_NEGATIVE QColor(255, 0, 0)
+/* Transaction list -- positive amount */
+#define COLOR_CONFIRMED QColor(0, 102, 10)
 /* Transaction list -- bare address (without label) */
 #define COLOR_BAREADDRESS QColor(140, 140, 140)
 /* Transaction list -- TX status decoration - open until date */

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -91,7 +91,7 @@ public:
         }
         else
         {
-            foreground = option.palette.color(QPalette::Text);
+            foreground = COLOR_CONFIRMED;
         }
         painter->setPen(foreground);
         QString amountText = BitcoinUnits::formatWithUnit(unit, amount, true, BitcoinUnits::SeparatorStyle::ALWAYS);


### PR DESCRIPTION
We, humans, have an age-old notion of associating the color green with acceptance and growth. It is pretty common to see the received money displayed in green while the deducted money is red. This property was not utilized till now in GUI, though, which showed deducted coins in red while received in black. This PR changes the color of received coins to green to make them look more natural and increase user-friendliness.

|Master|PR|
|---------|----|
|![master](https://user-images.githubusercontent.com/85434418/134961274-3970c57c-c7d7-490e-bec8-924ef6529537.png)|![pr](https://user-images.githubusercontent.com/85434418/134961298-18d69e2b-eaf0-4d54-8ed7-f1d506a2551b.png)|

I made sure to use a darker shade of green to boost contrast with the background, increasing the text visibility. Here is the contrast report for the added green.
![Screenshot from 2021-09-27 23-37-04](https://user-images.githubusercontent.com/85434418/134961744-5d8d0c60-971d-4876-8397-c7f15425dad8.png)

