### PR TITLE
Do not show unused widgets at startup

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -171,7 +171,9 @@ BitcoinGUI::BitcoinGUI(interfaces::Node& node, const PlatformStyle *_platformSty
         frameBlocksLayout->addWidget(unitDisplayControl);
         frameBlocksLayout->addStretch();
         frameBlocksLayout->addWidget(labelWalletEncryptionIcon);
+        labelWalletEncryptionIcon->hide();
         frameBlocksLayout->addWidget(labelWalletHDStatusIcon);
+        labelWalletHDStatusIcon->hide();
     }
     frameBlocksLayout->addWidget(labelProxyIcon);
     frameBlocksLayout->addStretch();


### PR DESCRIPTION
On master (8d83f9c1d19d9e701291b9906723dfb548d3dc5f), when starting without wallets the `labelWalletEncryptionIcon` and
`labelWalletHDStatusIcon` widgets are not used but still visible as empty space:

![Screenshot from 2021-09-29 21-59-22](https://user-images.githubusercontent.com/32963518/135332107-f02db936-3c3a-436b-9e78-c5721df8852b.png)

If one opens any wallet then closes it, the widget layout becomes densed:

![Screenshot from 2021-09-29 22-05-31](https://user-images.githubusercontent.com/32963518/135332650-83787bc4-fa8e-417e-8d53-a9fdb1c8bfc9.png)

This PR makes widget layout densed at startup.

Fixes #428.