### PR TITLE
Do not require restart if overridden option is modified

### DIFF
--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -200,21 +200,75 @@ void OptionsDialog::setModel(OptionsModel *_model)
     /* warn when one of the following settings changes by user action (placed here so init via mapper doesn't trigger them) */
 
     /* Main */
-    connect(ui->prune, &QCheckBox::clicked, this, &OptionsDialog::showRestartWarning);
+    connect(ui->prune, &QCheckBox::clicked, [this] {
+        if (!model->getOverriddenByCommandLine().contains("-prune")) {
+            showRestartWarning();
+        }
+    });
     connect(ui->prune, &QCheckBox::clicked, this, &OptionsDialog::togglePruneWarning);
-    connect(ui->pruneSize, qOverload<int>(&QSpinBox::valueChanged), this, &OptionsDialog::showRestartWarning);
-    connect(ui->databaseCache, qOverload<int>(&QSpinBox::valueChanged), this, &OptionsDialog::showRestartWarning);
-    connect(ui->externalSignerPath, &QLineEdit::textChanged, [this]{ showRestartWarning(); });
-    connect(ui->threadsScriptVerif, qOverload<int>(&QSpinBox::valueChanged), this, &OptionsDialog::showRestartWarning);
+    connect(ui->pruneSize, qOverload<int>(&QSpinBox::valueChanged), [this] {
+        if (!model->getOverriddenByCommandLine().contains("-prune")) {
+            showRestartWarning();
+        }
+    });
+
+    connect(ui->databaseCache, qOverload<int>(&QSpinBox::valueChanged), [this] {
+        if (!model->getOverriddenByCommandLine().contains("-dbcache")) {
+            showRestartWarning();
+        }
+    });
+
+    connect(ui->externalSignerPath, &QLineEdit::textChanged, [this] {
+        if (!model->getOverriddenByCommandLine().contains("-signer")) {
+            showRestartWarning();
+        }
+    });
+
+    connect(ui->threadsScriptVerif, qOverload<int>(&QSpinBox::valueChanged), [this] {
+        if (!model->getOverriddenByCommandLine().contains("-par")) {
+            showRestartWarning();
+        }
+    });
+
     /* Wallet */
-    connect(ui->spendZeroConfChange, &QCheckBox::clicked, this, &OptionsDialog::showRestartWarning);
+    connect(ui->spendZeroConfChange, &QCheckBox::clicked, [this] {
+        if (!model->getOverriddenByCommandLine().contains("-spendzeroconfchange")) {
+            showRestartWarning();
+        }
+    });
+
     /* Network */
-    connect(ui->allowIncoming, &QCheckBox::clicked, this, &OptionsDialog::showRestartWarning);
-    connect(ui->enableServer, &QCheckBox::clicked, this, &OptionsDialog::showRestartWarning);
-    connect(ui->connectSocks, &QCheckBox::clicked, this, &OptionsDialog::showRestartWarning);
-    connect(ui->connectSocksTor, &QCheckBox::clicked, this, &OptionsDialog::showRestartWarning);
+    connect(ui->allowIncoming, &QCheckBox::clicked, [this] {
+        if (!model->getOverriddenByCommandLine().contains("-listen")) {
+            showRestartWarning();
+        }
+    });
+
+    connect(ui->enableServer, &QCheckBox::clicked, [this] {
+        if (!model->getOverriddenByCommandLine().contains("-server")) {
+            showRestartWarning();
+        }
+    });
+
+    connect(ui->connectSocks, &QCheckBox::clicked, [this] {
+        if (!model->getOverriddenByCommandLine().contains("-proxy")) {
+            showRestartWarning();
+        }
+    });
+
+    connect(ui->connectSocksTor, &QCheckBox::clicked, [this] {
+        if (!model->getOverriddenByCommandLine().contains("-onion")) {
+            showRestartWarning();
+        }
+    });
+
     /* Display */
-    connect(ui->lang, qOverload<>(&QValueComboBox::valueChanged), [this]{ showRestartWarning(); });
+    connect(ui->lang, qOverload<>(&QValueComboBox::valueChanged), [this] {
+        if (!model->getOverriddenByCommandLine().contains("-lang")) {
+            showRestartWarning();
+        }
+    });
+
     connect(ui->thirdPartyTxUrls, &QLineEdit::textChanged, [this]{ showRestartWarning(); });
 }
 

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -218,14 +218,14 @@ void OptionsDialog::setModel(OptionsModel *_model)
         }
     });
 
-    connect(ui->externalSignerPath, &QLineEdit::textChanged, [this] {
-        if (!model->getOverriddenByCommandLine().contains("-signer")) {
+    connect(ui->threadsScriptVerif, qOverload<int>(&QSpinBox::valueChanged), [this] {
+        if (!model->getOverriddenByCommandLine().contains("-par")) {
             showRestartWarning();
         }
     });
 
-    connect(ui->threadsScriptVerif, qOverload<int>(&QSpinBox::valueChanged), [this] {
-        if (!model->getOverriddenByCommandLine().contains("-par")) {
+    connect(ui->enableServer, &QCheckBox::clicked, [this] {
+        if (!model->getOverriddenByCommandLine().contains("-server")) {
             showRestartWarning();
         }
     });
@@ -237,15 +237,15 @@ void OptionsDialog::setModel(OptionsModel *_model)
         }
     });
 
-    /* Network */
-    connect(ui->allowIncoming, &QCheckBox::clicked, [this] {
-        if (!model->getOverriddenByCommandLine().contains("-listen")) {
+    connect(ui->externalSignerPath, &QLineEdit::textChanged, [this] {
+        if (!model->getOverriddenByCommandLine().contains("-signer")) {
             showRestartWarning();
         }
     });
 
-    connect(ui->enableServer, &QCheckBox::clicked, [this] {
-        if (!model->getOverriddenByCommandLine().contains("-server")) {
+    /* Network */
+    connect(ui->allowIncoming, &QCheckBox::clicked, [this] {
+        if (!model->getOverriddenByCommandLine().contains("-listen")) {
             showRestartWarning();
         }
     });

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -415,7 +415,7 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
         case ProxyUse:
             if (settings.value("fUseProxy") != value) {
                 settings.setValue("fUseProxy", value.toBool());
-                setRestartRequired(true);
+                MaybeRestartRequired("-proxy");
             }
             break;
         case ProxyIP: {
@@ -423,7 +423,7 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
             if (!ip_port.is_set || ip_port.ip != value.toString()) {
                 ip_port.ip = value.toString();
                 SetProxySetting(settings, "addrProxy", ip_port);
-                setRestartRequired(true);
+                MaybeRestartRequired("-proxy");
             }
         }
         break;
@@ -432,7 +432,7 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
             if (!ip_port.is_set || ip_port.port != value.toString()) {
                 ip_port.port = value.toString();
                 SetProxySetting(settings, "addrProxy", ip_port);
-                setRestartRequired(true);
+                MaybeRestartRequired("-proxy");
             }
         }
         break;
@@ -441,7 +441,7 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
         case ProxyUseTor:
             if (settings.value("fUseSeparateProxyTor") != value) {
                 settings.setValue("fUseSeparateProxyTor", value.toBool());
-                setRestartRequired(true);
+                MaybeRestartRequired("-onion");
             }
             break;
         case ProxyIPTor: {
@@ -449,7 +449,7 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
             if (!ip_port.is_set || ip_port.ip != value.toString()) {
                 ip_port.ip = value.toString();
                 SetProxySetting(settings, "addrSeparateProxyTor", ip_port);
-                setRestartRequired(true);
+                MaybeRestartRequired("-onion");
             }
         }
         break;
@@ -458,7 +458,7 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
             if (!ip_port.is_set || ip_port.port != value.toString()) {
                 ip_port.port = value.toString();
                 SetProxySetting(settings, "addrSeparateProxyTor", ip_port);
-                setRestartRequired(true);
+                MaybeRestartRequired("-onion");
             }
         }
         break;
@@ -467,13 +467,13 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
         case SpendZeroConfChange:
             if (settings.value("bSpendZeroConfChange") != value) {
                 settings.setValue("bSpendZeroConfChange", value);
-                setRestartRequired(true);
+                MaybeRestartRequired("-spendzeroconfchange");
             }
             break;
         case ExternalSignerPath:
             if (settings.value("external_signer_path") != value.toString()) {
                 settings.setValue("external_signer_path", value.toString());
-                setRestartRequired(true);
+                MaybeRestartRequired("-signer");
             }
             break;
         case SubFeeFromAmount:
@@ -494,7 +494,7 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
         case Language:
             if (settings.value("language") != value) {
                 settings.setValue("language", value);
-                setRestartRequired(true);
+                MaybeRestartRequired("-lang");
             }
             break;
         case UseEmbeddedMonospacedFont:
@@ -510,37 +510,37 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
         case Prune:
             if (settings.value("bPrune") != value) {
                 settings.setValue("bPrune", value);
-                setRestartRequired(true);
+                MaybeRestartRequired("-prune");
             }
             break;
         case PruneSize:
             if (settings.value("nPruneSize") != value) {
                 settings.setValue("nPruneSize", value);
-                setRestartRequired(true);
+                MaybeRestartRequired("-prune");
             }
             break;
         case DatabaseCache:
             if (settings.value("nDatabaseCache") != value) {
                 settings.setValue("nDatabaseCache", value);
-                setRestartRequired(true);
+                MaybeRestartRequired("-dbcache");
             }
             break;
         case ThreadsScriptVerif:
             if (settings.value("nThreadsScriptVerif") != value) {
                 settings.setValue("nThreadsScriptVerif", value);
-                setRestartRequired(true);
+                MaybeRestartRequired("-par");
             }
             break;
         case Listen:
             if (settings.value("fListen") != value) {
                 settings.setValue("fListen", value);
-                setRestartRequired(true);
+                MaybeRestartRequired("-listen");
             }
             break;
         case Server:
             if (settings.value("server") != value) {
                 settings.setValue("server", value);
-                setRestartRequired(true);
+                MaybeRestartRequired("-server");
             }
             break;
         default:
@@ -562,6 +562,13 @@ void OptionsModel::setDisplayUnit(const QVariant &value)
         nDisplayUnit = value.toInt();
         settings.setValue("nDisplayUnit", nDisplayUnit);
         Q_EMIT displayUnitChanged(nDisplayUnit);
+    }
+}
+
+void OptionsModel::MaybeRestartRequired(const QString& option)
+{
+    if (!strOverriddenByCommandLine.contains(option)) {
+        setRestartRequired(true);
     }
 }
 

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -98,6 +98,7 @@ public:
     void SetPruneTargetGB(int prune_target_gb, bool force = false);
 
     /* Restart flag helper */
+    void MaybeRestartRequired(const QString& option);
     void setRestartRequired(bool fRequired);
     bool isRestartRequired() const;
 


### PR DESCRIPTION
The options set via the GUI can be overridden by settings in the `bitcoin.conf` or by command-line options. If such an option is overridden, its modification in the GUI has no effect. Therefore, no need to require the client restart.