### PR TITLE
Never disable HD status icon

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -1304,8 +1304,6 @@ void BitcoinGUI::setHDStatus(bool privkeyDisabled, int hdEnabled)
     labelWalletHDStatusIcon->setThemedPixmap(privkeyDisabled ? QStringLiteral(":/icons/eye") : hdEnabled ? QStringLiteral(":/icons/hd_enabled") : QStringLiteral(":/icons/hd_disabled"), STATUSBAR_ICONSIZE, STATUSBAR_ICONSIZE);
     labelWalletHDStatusIcon->setToolTip(privkeyDisabled ? tr("Private key <b>disabled</b>") : hdEnabled ? tr("HD key generation is <b>enabled</b>") : tr("HD key generation is <b>disabled</b>"));
     labelWalletHDStatusIcon->show();
-    // eventually disable the QLabel to set its opacity to 50%
-    labelWalletHDStatusIcon->setEnabled(hdEnabled);
 }
 
 void BitcoinGUI::setEncryptionStatus(int status)


### PR DESCRIPTION
[#8517](https://github.com/bitcoin/bitcoin/pull/8517) introduced the HD status icon in the bottom menu bar. At the time, it may have made sense to disable the HD status icon (which would display the icon at 50% opacity) when the wallet is not HD or watch-only. 
 
Since then, we have had many changes to our UI. Namely, the ability to switch between dark and light mode on macOS. Additionally, since version 0.16, the Bitcoin Core client only [generates HD wallets](https://github.com/bitcoin/bitcoin/issues/12547). Non-HD Wallets cannot be created anymore, only imported.
 
This PR proposes never to disable the HD status icon in the bottom menu bar. Instead, we always leave the HD status icon enabled for a better user interface. There’s no good reason for it to remain disabled, and it’s hard to see the watch-only icon in macOS dark mode. If a user has imported a non-HD wallet, we also want the icon to be as clear as possible in the bottom menu bar.

- on macOS

|                        |      Master      |         PR           |
| ------------- | ------------- | ------------- |
|  Dark Mode    | ![unnamed](https://user-images.githubusercontent.com/44024636/136088058-7eece199-0e6d-4bd3-91d5-8e04b6ccdd32.png)  | ![unnamed-2](https://user-images.githubusercontent.com/44024636/136088203-7704bd25-f822-4489-b023-7acc935698c9.png) |
|  Light Mode   |![unnamed-3](https://user-images.githubusercontent.com/44024636/136088441-a6abcf9d-f2ca-4b6d-96d4-14487dad30c0.png)| ![unnamed-4](https://user-images.githubusercontent.com/44024636/136088539-f61fb93d-63d3-4f3f-908d-1c51e8b0f670.png)|
- on ubuntu 20.04


|      Master      |         PR           |
| ------------- | ------------- |
|   ![Screenshot 2021-10-06 at 3 15 12 AM](https://user-images.githubusercontent.com/44024636/136107153-cc00cefc-1ae5-4923-ab8c-f4e8ca2447a1.png) |  ![Screenshot 2021-10-06 at 3 18 20 AM](https://user-images.githubusercontent.com/44024636/136107479-96cb487d-171f-4e11-b1c2-cb3e4109d56f.png)|