### PR TITLE
Restore "S" accelerator for "Start on system login" option

### DIFF
--- a/src/qt/forms/optionsdialog.ui
+++ b/src/qt/forms/optionsdialog.ui
@@ -33,7 +33,7 @@
           <string>Automatically start %1 after logging in to the system.</string>
          </property>
          <property name="text">
-          <string>Start %1 on system &amp;login</string>
+          <string>&amp;Start %1 on system login</string>
          </property>
         </widget>
        </item>
@@ -186,7 +186,7 @@
           <string extracomment="Tooltip text for Options window setting that enables the RPC server.">This allows you or a third party tool to communicate with the node through command-line and JSON-RPC commands.</string>
          </property>
          <property name="text">
-          <string extracomment="An Options window setting to enable the RPC server.">Enable RPC &amp;server</string>
+          <string extracomment="An Options window setting to enable the RPC server.">Enable R&amp;PC server</string>
          </property>
         </widget>
        </item>


### PR DESCRIPTION
bitcoin-core/gui#416 changed the option assigned to accelerator key "S", but there's no rationale given.

Best to leave it alone, and give the new option a new accelerator key.

Since "R" is already taken for Reset, this shifts the new RPC server option to use "P" instead
