### PR TITLE
Address type dropdown, add Taproot (Receive tab)

### DIFF
--- a/doc/release-notes-gui-459.md
+++ b/doc/release-notes-gui-459.md
@@ -1,0 +1,4 @@
+GUI changes
+-----------
+
+- The Bech32 checkbox has been replaced with a dropdown for all address types, including the new Bech32m (BIP-350) standard for Taproot enabled wallets.

--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -256,6 +256,9 @@ public:
     // Return whether private keys enabled.
     virtual bool privateKeysDisabled() = 0;
 
+    // Return whether the wallet contains a Taproot scriptPubKeyMan
+    virtual bool taprootEnabled() = 0;
+
     // Return whether wallet uses an external signer.
     virtual bool hasExternalSigner() = 0;
 

--- a/src/qt/forms/receivecoinsdialog.ui
+++ b/src/qt/forms/receivecoinsdialog.ui
@@ -195,7 +195,7 @@
            </widget>
           </item>
           <item>
-           <widget class="QCheckBox" name="useBech32">
+           <widget class="QComboBox" name="addressType">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
               <horstretch>0</horstretch>
@@ -210,12 +210,6 @@
             </property>
             <property name="focusPolicy">
              <enum>Qt::StrongFocus</enum>
-            </property>
-            <property name="toolTip">
-             <string>Native segwit addresses (aka Bech32 or BIP-173) reduce your transaction fees later on and offer better protection against typos, but old wallets don't support them. When unchecked, an address compatible with older wallets will be created instead.</string>
-            </property>
-            <property name="text">
-             <string>Generate native segwit (Bech32) address</string>
             </property>
            </widget>
           </item>
@@ -366,7 +360,7 @@
  <tabstops>
   <tabstop>reqLabel</tabstop>
   <tabstop>reqAmount</tabstop>
-  <tabstop>useBech32</tabstop>
+  <tabstop>addressType</tabstop>
   <tabstop>reqMessage</tabstop>
   <tabstop>receiveButton</tabstop>
   <tabstop>clearButton</tabstop>

--- a/src/qt/receivecoinsdialog.cpp
+++ b/src/qt/receivecoinsdialog.cpp
@@ -87,10 +87,18 @@ void ReceiveCoinsDialog::setModel(WalletModel *_model)
             &QItemSelectionModel::selectionChanged, this,
             &ReceiveCoinsDialog::recentRequestsView_selectionChanged);
 
-        if (model->wallet().getDefaultAddressType() == OutputType::BECH32) {
-            ui->useBech32->setCheckState(Qt::Checked);
-        } else {
-            ui->useBech32->setCheckState(Qt::Unchecked);
+        // Populate address type dropdown and select default
+        auto add_address_type = [&](OutputType type, const QString& text, const QString& tooltip) {
+            const auto index = ui->addressType->count();
+            ui->addressType->addItem(text, (int) type);
+            ui->addressType->setItemData(index, tooltip, Qt::ToolTipRole);
+            if (model->wallet().getDefaultAddressType() == type) ui->addressType->setCurrentIndex(index);
+        };
+        add_address_type(OutputType::LEGACY, "Base58 (Legacy)", "Not recommended due to higher fees and less protection against typos.");
+        add_address_type(OutputType::P2SH_SEGWIT, "Base58 (P2SH-SegWit)", "Generates an address compatible with older wallets.");
+        add_address_type(OutputType::BECH32, "Bech32 (SegWit)", "Generates a native segwit address (BIP-173). Some old wallets don't support it.");
+        if (model->wallet().taprootEnabled()) {
+            add_address_type(OutputType::BECH32M, "Bech32m (Taproot)", "Bech32m (BIP-350) is an upgrade to Bech32, wallet support is still limited.");
         }
 
         // Set the button to be enabled or disabled based on whether the wallet can give out new addresses.
@@ -144,15 +152,7 @@ void ReceiveCoinsDialog::on_receiveButton_clicked()
     QString address;
     QString label = ui->reqLabel->text();
     /* Generate new receiving address */
-    OutputType address_type;
-    if (ui->useBech32->isChecked()) {
-        address_type = OutputType::BECH32;
-    } else {
-        address_type = model->wallet().getDefaultAddressType();
-        if (address_type == OutputType::BECH32) {
-            address_type = OutputType::P2SH_SEGWIT;
-        }
-    }
+    const OutputType address_type = (OutputType)ui->addressType->currentData().toInt();
     address = model->getAddressTableModel()->addRow(AddressTableModel::Receive, label, "", address_type);
 
     switch(model->getAddressTableModel()->getEditStatus())

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -461,6 +461,11 @@ public:
     bool canGetAddresses() override { return m_wallet->CanGetAddresses(); }
     bool hasExternalSigner() override { return m_wallet->IsWalletFlagSet(WALLET_FLAG_EXTERNAL_SIGNER); }
     bool privateKeysDisabled() override { return m_wallet->IsWalletFlagSet(WALLET_FLAG_DISABLE_PRIVATE_KEYS); }
+    bool taprootEnabled() override {
+        if (m_wallet->IsLegacy()) return false;
+        auto spk_man = m_wallet->GetScriptPubKeyMan(OutputType::BECH32M, /*internal=*/false);
+        return spk_man != nullptr;
+    }
     OutputType getDefaultAddressType() override { return m_wallet->m_default_address_type; }
     CAmount getDefaultMaxTxFee() override { return m_wallet->m_default_max_tx_fee; }
     void remove() override


### PR DESCRIPTION
This PR replaces the Bech32 checkbox with an address type dropdown It "Use Taproot" checkbox to the receive screen for any wallet with a Taproot descriptor. The Bech32m option is hidden for wallets that don't have taproot descriptors.

Bech32 is kept as the default even for Taproot enabled wallets until it's more widely supported.

(an earlier attempt of this PR added a second checkbox)

<img width="469" alt="Schermafbeelding 2021-12-21 om 11 44 05" src="https://user-images.githubusercontent.com/10217/146872660-339fae1f-c0b8-4673-b8be-33c25f3933fd.png">

**Suggested testing**
* notice that the Bech32m entry only appears for wallet with a taproot descriptor
* verify that it generates a bc1p instead of bc1q address
1. Legacy wallet
2. Default descriptor wallet (current does not have taproot descriptor)
3. Wallet with taproot descriptor:
   * just create a new descriptor wallet

Replaces https://github.com/bitcoin/bitcoin/pull/22260