### PR TITLE
Enable a non-linear network traffic option (click to toggle between linear and non-linear)

### DIFF
--- a/src/qt/trafficgraphwidget.cpp
+++ b/src/qt/trafficgraphwidget.cpp
@@ -47,16 +47,22 @@ int TrafficGraphWidget::getGraphRangeMins() const
     return nMins;
 }
 
+int TrafficGraphWidget::y_value(float value)
+{
+    int h = height() - YMARGIN * 2;
+    return YMARGIN + h - (h * 1.0 * value / fMax);
+}
+
 void TrafficGraphWidget::paintPath(QPainterPath &path, QQueue<float> &samples)
 {
     int sampleCount = samples.size();
-    if(sampleCount > 0) {
+    if(sampleCount > 0 && fMax > 0) {
         int h = height() - YMARGIN * 2, w = width() - XMARGIN * 2;
         int x = XMARGIN + w;
         path.moveTo(x, YMARGIN + h);
         for(int i = 0; i < sampleCount; ++i) {
             x = XMARGIN + w - w * i / DESIRED_SAMPLES;
-            int y = YMARGIN + h - (int)(h * samples.at(i) / fMax);
+            int y = y_value(samples.at(i));
             path.lineTo(x, y);
         }
         path.lineTo(x, YMARGIN + h);
@@ -84,7 +90,7 @@ void TrafficGraphWidget::paintEvent(QPaintEvent *)
 
     // draw lines
     painter.setPen(axisCol);
-    painter.drawText(XMARGIN, YMARGIN + h - h * val / fMax-yMarginText, QString("%1 %2").arg(val).arg(units));
+    painter.drawText(XMARGIN, y_value(val)-yMarginText, QString("%1 %2").arg(val).arg(units));
     for(float y = val; y < fMax; y += val) {
         int yy = YMARGIN + h - h * y / fMax;
         painter.drawLine(XMARGIN, yy, width() - XMARGIN, yy);
@@ -94,13 +100,13 @@ void TrafficGraphWidget::paintEvent(QPaintEvent *)
         axisCol = axisCol.darker();
         val = pow(10.0f, base - 1);
         painter.setPen(axisCol);
-        painter.drawText(XMARGIN, YMARGIN + h - h * val / fMax-yMarginText, QString("%1 %2").arg(val).arg(units));
+        painter.drawText(XMARGIN, y_value(val)-yMarginText, QString("%1 %2").arg(val).arg(units));
         int count = 1;
         for(float y = val; y < fMax; y += val, count++) {
             // don't overwrite lines drawn above
             if(count % 10 == 0)
                 continue;
-            int yy = YMARGIN + h - h * y / fMax;
+            int yy = y_value(y);
             painter.drawLine(XMARGIN, yy, width() - XMARGIN, yy);
         }
     }

--- a/src/qt/trafficgraphwidget.h
+++ b/src/qt/trafficgraphwidget.h
@@ -26,6 +26,7 @@ public:
 
 protected:
     void paintEvent(QPaintEvent *) override;
+    int y_value(float value);
 
 public Q_SLOTS:
     void updateRates();

--- a/src/qt/trafficgraphwidget.h
+++ b/src/qt/trafficgraphwidget.h
@@ -27,6 +27,8 @@ public:
 protected:
     void paintEvent(QPaintEvent *) override;
     int y_value(float value);
+    void mousePressEvent(QMouseEvent *event) override;
+    bool fToggle = true;
 
 public Q_SLOTS:
     void updateRates();


### PR DESCRIPTION
Helps to make visible the low bandwidth traffic and high bandwidth (or spikes) concurrently. (Previously the low bandwidth traffic becomes invisible in the presence of spikes).

Old format: 
![image](https://user-images.githubusercontent.com/1530283/142721203-6702a8ff-2bc0-4189-bd06-0ccc6270c406.png)

New format:
![image](https://user-images.githubusercontent.com/1530283/142721208-1b931b19-5cb9-461f-8c9d-a960694cf49b.png)

Old format:
![image](https://user-images.githubusercontent.com/1530283/143551111-4513e716-5e8c-4dc6-a272-9aa36cd3b92e.png)

New format:
![image](https://user-images.githubusercontent.com/1530283/143551132-e6fc4a74-581f-42ca-9182-fdb48e49b08a.png)

(clicking on the graph will toggle between the new format and the old format).