### PR TITLE
Monospaced output in Console on macOS

### DIFF
--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -866,7 +866,11 @@ void RPCConsole::clear(bool keep_prompt)
     }
 
     // Set default style sheet
+#ifdef Q_OS_MAC
+    QFontInfo fixedFontInfo(GUIUtil::fixedPitchFont(/*use_embedded_font=*/true));
+#else
     QFontInfo fixedFontInfo(GUIUtil::fixedPitchFont());
+#endif
     ui->messagesWidget->document()->setDefaultStyleSheet(
         QString(
                 "table { }"


### PR DESCRIPTION
This PR addresses issue https://github.com/bitcoin-core/gui/issues/273 
A monospace font is used on Linux and Windows for the console output - but not on MacOS.
This change forces the MacOS GUI to use the embedded RobotoMono-Bold.ttf font,
which is defined as the GUIUtil::fixedPitchFont()