### PR TITLE
Make network graph slider easier to use

### DIFF
--- a/src/qt/forms/debugwindow.ui
+++ b/src/qt/forms/debugwindow.ui
@@ -633,10 +633,10 @@
               <number>1</number>
              </property>
              <property name="maximum">
-              <number>288</number>
+              <number>12</number>
              </property>
              <property name="pageStep">
-              <number>12</number>
+              <number>2</number>
              </property>
              <property name="value">
               <number>6</number>

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -1129,8 +1129,8 @@ void RPCConsole::scrollToEnd()
 
 void RPCConsole::on_sldGraphRange_valueChanged(int value)
 {
-    const int multiplier = 5; // each position on the slider represents 5 min
-    int mins = value * multiplier;
+    static const std::vector<int> values{1, 2, 5, 10, 20, 30, 60, 2*60, 3*60, 6*60, 12*60, 24*60};
+    int mins = values[value-1];
     setTrafficGraphRange(mins);
 }
 


### PR DESCRIPTION
Currently the network graph slider has 288 possible positions, and most of these are likely never used, due to obscure durations.

This pull request simplifies the slider to have only 12 positions, making it much easier to use, and setting the durations to more likely-wanted settings: 1m, 2m, 5m, 10m, 20m, 30m, 1h, 2h, 3h, 6h, 12h, 24h.

This change also allows easier rearranging of the window, for example, adding an extra button next to the reset button, shrinking the slider, and therefore making it still easy to use when smaller in length.