### PR TITLE
Don't clear traffic graph when changing interval

### DIFF
--- a/src/qt/trafficgraphwidget.cpp
+++ b/src/qt/trafficgraphwidget.cpp
@@ -159,8 +159,7 @@ void TrafficGraphWidget::setGraphRangeMins(int mins)
     int msecsPerSample = nMins * 60 * 1000 / DESIRED_SAMPLES;
     timer->stop();
     timer->setInterval(msecsPerSample);
-
-    clear();
+    timer->start();
 }
 
 void TrafficGraphWidget::clear()


### PR DESCRIPTION
This change stops the graph from being reset when the duration is changed. If the user wants it to be cleared, then they can click the reset button that is already present.