### PR TITLE
qt: Handle Android back key in the Node window

### DIFF
--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -428,6 +428,15 @@ namespace GUIUtil
      */
     void ShowModalDialogAndDeleteOnClose(QDialog* dialog);
 
+    inline bool IsEscapeOrBack(int key)
+    {
+        if (key == Qt::Key_Escape) return true;
+#ifdef Q_OS_ANDROID
+        if (key == Qt::Key_Back) return true;
+#endif // Q_OS_ANDROID
+        return false;
+    }
+
 } // namespace GUIUtil
 
 #endif // BITCOIN_QT_GUIUTIL_H

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -14,6 +14,7 @@
 #include <netbase.h>
 #include <qt/bantablemodel.h>
 #include <qt/clientmodel.h>
+#include <qt/guiutil.h>
 #include <qt/peertablesortproxy.h>
 #include <qt/platformstyle.h>
 #include <qt/walletmodel.h>
@@ -910,8 +911,7 @@ void RPCConsole::clear(bool keep_prompt)
 
 void RPCConsole::keyPressEvent(QKeyEvent *event)
 {
-    if(windowType() != Qt::Widget && event->key() == Qt::Key_Escape)
-    {
+    if (windowType() != Qt::Widget && GUIUtil::IsEscapeOrBack(event->key())) {
         close();
     }
 }


### PR DESCRIPTION
On master (4633199cc8a466b8a2cfa14ba9d7793dd4c469f4) there are no means to return from the Node window to the main one on Android.

This PR assigns this functionality to the Android back key:

![Screenshot_1638395318](https://user-images.githubusercontent.com/32963518/144320316-af5599ac-0379-40e6-9887-7f5ee30b97ae.png)
