### PR TITLE
Replace testnet with signet as a default network for Android

### DIFF
--- a/src/qt/android/AndroidManifest.xml
+++ b/src/qt/android/AndroidManifest.xml
@@ -22,7 +22,7 @@
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
 
-            <meta-data android:name="android.app.arguments" android:value="-testnet"/>
+            <meta-data android:name="android.app.arguments" android:value="-signet"/>
             <meta-data android:name="android.app.lib_name" android:value="bitcoin-qt"/>
             <meta-data android:name="android.app.repository" android:value="default"/>
             <meta-data android:name="android.app.bundle_local_qt_libs" android:value="1"/>


### PR DESCRIPTION
Signet looks a more proper testing network, and it requires less resources.