### PR TITLE
Enable users to configure their monospace font specifically

### DIFF
--- a/src/qt/forms/optionsdialog.ui
+++ b/src/qt/forms/optionsdialog.ui
@@ -772,104 +772,29 @@
         </layout>
        </item>
        <item>
-        <widget class="QGroupBox" name="font_groupBox">
-         <property name="title">
-          <string>Monospaced font in the Overview tab:</string>
-         </property>
-         <layout class="QVBoxLayout" name="font_verticalLayout">
-          <item>
-           <layout class="QHBoxLayout" name="embeddedFont_horizontalLayout">
-            <item>
-             <widget class="QRadioButton" name="embeddedFont_radioButton">
-              <property name="text">
-               <string>embedded &quot;%1&quot;</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <spacer name="embeddedFont_horizontalSpacer">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-            <item>
-             <layout class="QVBoxLayout" name="embeddedFont_verticalLayout">
-              <item>
-               <widget class="QLabel" name="embeddedFont_label_1">
-                <property name="text">
-                 <string notr="true">111.11111111 BTC</string>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QLabel" name="embeddedFont_label_9">
-                <property name="text">
-                 <string notr="true">909.09090909 BTC</string>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <widget class="Line" name="font_line">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <layout class="QHBoxLayout" name="systemFont_horizontalLayout">
-            <item>
-             <widget class="QRadioButton" name="systemFont_radioButton">
-              <property name="text">
-               <string>closest matching &quot;%1&quot;</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <spacer name="systemFont_horizontalSpacer">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-            <item>
-             <layout class="QVBoxLayout" name="systemFont_verticalLayout">
-              <item>
-               <widget class="QLabel" name="systemFont_label_1">
-                <property name="text">
-                 <string notr="true">111.11111111 BTC</string>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QLabel" name="systemFont_label_9">
-                <property name="text">
-                 <string notr="true">909.09090909 BTC</string>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </item>
-           </layout>
-          </item>
-         </layout>
-        </widget>
+        <layout class="QHBoxLayout" name="horizontalLayout_4_Display">
+         <item>
+          <widget class="QLabel" name="moneyFontLabel">
+           <property name="text">
+            <string>Font in the Overview tab: </string>
+           </property>
+           <property name="buddy">
+            <cstring>moneyFont</cstring>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QComboBox" name="moneyFont"/>
+         </item>
+         <item>
+          <widget class="QLabel" name="moneyFont_preview">
+           <property name="text">
+            <string notr="true">111.11111111 BTC
+909.09090909 BTC</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </item>
        <item>
         <spacer name="verticalSpacer_Display">

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -198,6 +198,15 @@ void OptionsDialog::setModel(OptionsModel *_model)
         setMapper();
         mapper->toFirst();
 
+        const auto& font_for_money = _model->data(_model->index(OptionsModel::FontForMoney, 0), Qt::EditRole).value<OptionsModel::FontChoice>();
+        if (std::holds_alternative<OptionsModel::FontChoiceAbstract>(font_for_money)) {
+            ui->embeddedFont_radioButton->setChecked(font_for_money != OptionsModel::UseBestSystemFont);
+            ui->systemFont_radioButton->setChecked(font_for_money == OptionsModel::UseBestSystemFont);
+        } else {
+            ui->embeddedFont_radioButton->setChecked(false);
+            ui->systemFont_radioButton->setChecked(false);
+        }
+
         updateDefaultProxyNets();
     }
 
@@ -275,7 +284,6 @@ void OptionsDialog::setMapper()
     mapper->addMapping(ui->lang, OptionsModel::Language);
     mapper->addMapping(ui->unit, OptionsModel::DisplayUnit);
     mapper->addMapping(ui->thirdPartyTxUrls, OptionsModel::ThirdPartyTxUrls);
-    mapper->addMapping(ui->embeddedFont_radioButton, OptionsModel::UseEmbeddedMonospacedFont);
 }
 
 void OptionsDialog::setOkButtonState(bool fState)
@@ -337,6 +345,12 @@ void OptionsDialog::on_openBitcoinConfButton_clicked()
 
 void OptionsDialog::on_okButton_clicked()
 {
+    if (ui->embeddedFont_radioButton->isChecked()) {
+        model->setData(model->index(OptionsModel::FontForMoney, 0), QVariant::fromValue(OptionsModel::FontChoice{OptionsModel::FontChoiceAbstract::EmbeddedFont}));
+    } else if (ui->systemFont_radioButton->isChecked()) {
+        model->setData(model->index(OptionsModel::FontForMoney, 0), QVariant::fromValue(OptionsModel::FontChoice{OptionsModel::FontChoiceAbstract::BestSystemFont}));
+    }
+
     mapper->submit();
     accept();
     updateDefaultProxyNets();

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -23,13 +23,69 @@
 
 #include <chrono>
 
+#include <QApplication>
 #include <QDataWidgetMapper>
 #include <QDir>
+#include <QFontDialog>
 #include <QIntValidator>
 #include <QLocale>
 #include <QMessageBox>
 #include <QSystemTrayIcon>
 #include <QTimer>
+
+int setFontChoice(QComboBox* cb, const OptionsModel::FontChoice& fc)
+{
+    int i;
+    for (i = cb->count(); --i >= 0; ) {
+        QVariant item_data = cb->itemData(i);
+        if (!item_data.canConvert<OptionsModel::FontChoice>()) continue;
+        if (item_data.value<OptionsModel::FontChoice>() == fc) {
+            break;
+        }
+    }
+    if (i == -1) {
+        // New item needed
+        QFont chosen_font = OptionsModel::getFontForChoice(fc);
+        QSignalBlocker block_currentindexchanged_signal(cb);  // avoid triggering QFontDialog
+        cb->insertItem(0, QFontInfo(chosen_font).family(), QVariant::fromValue(fc));
+        i = 0;
+    }
+
+    cb->setCurrentIndex(i);
+    return i;
+}
+
+void setupFontOptions(QComboBox* cb, QLabel* preview)
+{
+    QFont embedded_font{GUIUtil::fixedPitchFont(true)};
+    QFont system_font{GUIUtil::fixedPitchFont(false)};
+    cb->addItem(QObject::tr("Embedded \"%1\"").arg(QFontInfo(embedded_font).family()), QVariant::fromValue(OptionsModel::FontChoice{OptionsModel::FontChoiceAbstract::EmbeddedFont}));
+    cb->addItem(QObject::tr("Default system font \"%1\"").arg(QFontInfo(system_font).family()), QVariant::fromValue(OptionsModel::FontChoice{OptionsModel::FontChoiceAbstract::BestSystemFont}));
+    cb->addItem(QObject::tr("Custom…"));
+
+    const auto& on_font_choice_changed = [cb, preview](int index) {
+        static int previous_index = -1;
+        QVariant item_data = cb->itemData(index);
+        QFont f;
+        if (item_data.canConvert<OptionsModel::FontChoice>()) {
+            f = OptionsModel::getFontForChoice(item_data.value<OptionsModel::FontChoice>());
+        } else {
+            bool ok;
+            f = QFontDialog::getFont(&ok, GUIUtil::fixedPitchFont(false), cb->parentWidget());
+            if (!ok) {
+                cb->setCurrentIndex(previous_index);
+                return;
+            }
+            index = setFontChoice(cb, OptionsModel::FontChoice{f});
+        }
+        if (preview) {
+            preview->setFont(f);
+        }
+        previous_index = index;
+    };
+    QObject::connect(cb, QOverload<int>::of(&QComboBox::currentIndexChanged), on_font_choice_changed);
+    on_font_choice_changed(cb->currentIndex());
+}
 
 OptionsDialog::OptionsDialog(QWidget* parent, bool enableWallet)
     : QDialog(parent, GUIUtil::dialog_flags),
@@ -148,19 +204,7 @@ OptionsDialog::OptionsDialog(QWidget* parent, bool enableWallet)
         ui->minimizeToTray->setEnabled(false);
     }
 
-    QFont embedded_font{GUIUtil::fixedPitchFont(true)};
-    ui->embeddedFont_radioButton->setText(ui->embeddedFont_radioButton->text().arg(QFontInfo(embedded_font).family()));
-    embedded_font.setWeight(QFont::Bold);
-    ui->embeddedFont_label_1->setFont(embedded_font);
-    ui->embeddedFont_label_9->setFont(embedded_font);
-
-    QFont system_font{GUIUtil::fixedPitchFont(false)};
-    ui->systemFont_radioButton->setText(ui->systemFont_radioButton->text().arg(QFontInfo(system_font).family()));
-    system_font.setWeight(QFont::Bold);
-    ui->systemFont_label_1->setFont(system_font);
-    ui->systemFont_label_9->setFont(system_font);
-    // Checking the embeddedFont_radioButton automatically unchecks the systemFont_radioButton.
-    ui->systemFont_radioButton->setChecked(true);
+    setupFontOptions(ui->moneyFont, ui->moneyFont_preview);
 
     GUIUtil::handleCloseWindowShortcut(this);
 }
@@ -199,13 +243,7 @@ void OptionsDialog::setModel(OptionsModel *_model)
         mapper->toFirst();
 
         const auto& font_for_money = _model->data(_model->index(OptionsModel::FontForMoney, 0), Qt::EditRole).value<OptionsModel::FontChoice>();
-        if (std::holds_alternative<OptionsModel::FontChoiceAbstract>(font_for_money)) {
-            ui->embeddedFont_radioButton->setChecked(font_for_money != OptionsModel::UseBestSystemFont);
-            ui->systemFont_radioButton->setChecked(font_for_money == OptionsModel::UseBestSystemFont);
-        } else {
-            ui->embeddedFont_radioButton->setChecked(false);
-            ui->systemFont_radioButton->setChecked(false);
-        }
+        setFontChoice(ui->moneyFont, font_for_money);
 
         updateDefaultProxyNets();
     }
@@ -345,11 +383,7 @@ void OptionsDialog::on_openBitcoinConfButton_clicked()
 
 void OptionsDialog::on_okButton_clicked()
 {
-    if (ui->embeddedFont_radioButton->isChecked()) {
-        model->setData(model->index(OptionsModel::FontForMoney, 0), QVariant::fromValue(OptionsModel::FontChoice{OptionsModel::FontChoiceAbstract::EmbeddedFont}));
-    } else if (ui->systemFont_radioButton->isChecked()) {
-        model->setData(model->index(OptionsModel::FontForMoney, 0), QVariant::fromValue(OptionsModel::FontChoice{OptionsModel::FontChoiceAbstract::BestSystemFont}));
-    }
+    model->setData(model->index(OptionsModel::FontForMoney, 0), ui->moneyFont->itemData(ui->moneyFont->currentIndex()));
 
     mapper->submit();
     accept();

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -122,6 +122,18 @@ static const QLatin1String fontchoice_str_embedded{"embedded"};
 static const QLatin1String fontchoice_str_best_system{"best_system"};
 static const QString fontchoice_str_custom_prefix{QStringLiteral("custom, ")};
 
+QString OptionsModel::FontChoiceToString(const OptionsModel::FontChoice& f)
+{
+    if (std::holds_alternative<FontChoiceAbstract>(f)) {
+        if (f == UseBestSystemFont) {
+            return fontchoice_str_best_system;
+        } else {
+            return fontchoice_str_embedded;
+        }
+    }
+    return fontchoice_str_custom_prefix + std::get<QFont>(f).toString();
+}
+
 OptionsModel::FontChoice OptionsModel::FontChoiceFromString(const QString& s)
 {
     if (s == fontchoice_str_best_system) {
@@ -451,8 +463,8 @@ QVariant OptionsModel::getOption(OptionID option, const std::string& suffix) con
         return strThirdPartyTxUrls;
     case Language:
         return QString::fromStdString(SettingToString(setting(), ""));
-    case UseEmbeddedMonospacedFont:
-        return (m_font_money != UseBestSystemFont);
+    case FontForMoney:
+        return QVariant::fromValue(m_font_money);
     case CoinControlFeatures:
         return fCoinControlFeatures;
     case EnablePSBTControls:
@@ -622,20 +634,12 @@ bool OptionsModel::setOption(OptionID option, const QVariant& value, const std::
             setRestartRequired(true);
         }
         break;
-    case UseEmbeddedMonospacedFont:
+    case FontForMoney:
     {
-        const bool use_embedded_monospaced_font = value.toBool();
-        if (use_embedded_monospaced_font) {
-            if (m_font_money != UseBestSystemFont) {
-                // Leave it as-is
-                break;
-            }
-            m_font_money = FontChoiceAbstract::EmbeddedFont;
-        } else {
-            m_font_money = FontChoiceAbstract::BestSystemFont;
-        }
-        settings.setValue("UseEmbeddedMonospacedFont", use_embedded_monospaced_font);
-        settings.remove("FontForMoney");
+        const auto& new_font = value.value<FontChoice>();
+        if (m_font_money == new_font) break;
+        settings.setValue("FontForMoney", FontChoiceToString(new_font));
+        m_font_money = new_font;
         Q_EMIT fontForMoneyChanged(getFontForMoney());
         break;
     }

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -219,7 +219,7 @@ bool OptionsModel::Init(bilingual_str& error)
         settings.setValue("UseEmbeddedMonospacedFont", "true");
     }
     m_use_embedded_monospaced_font = settings.value("UseEmbeddedMonospacedFont").toBool();
-    Q_EMIT useEmbeddedMonospacedFontChanged(m_use_embedded_monospaced_font);
+    Q_EMIT fontForMoneyChanged(getFontForMoney());
 
     m_mask_values = settings.value("mask_values", false).toBool();
 
@@ -454,6 +454,13 @@ QVariant OptionsModel::getOption(OptionID option, const std::string& suffix) con
     }
 }
 
+QFont OptionsModel::getFontForMoney() const
+{
+    QFont f = GUIUtil::fixedPitchFont(m_use_embedded_monospaced_font);
+    f.setWeight(QFont::Bold);
+    return f;
+}
+
 bool OptionsModel::setOption(OptionID option, const QVariant& value, const std::string& suffix)
 {
     auto changed = [&] { return value.isValid() && value != getOption(option, suffix); };
@@ -589,7 +596,7 @@ bool OptionsModel::setOption(OptionID option, const QVariant& value, const std::
     case UseEmbeddedMonospacedFont:
         m_use_embedded_monospaced_font = value.toBool();
         settings.setValue("UseEmbeddedMonospacedFont", m_use_embedded_monospaced_font);
-        Q_EMIT useEmbeddedMonospacedFontChanged(m_use_embedded_monospaced_font);
+        Q_EMIT fontForMoneyChanged(getFontForMoney());
         break;
     case CoinControlFeatures:
         fCoinControlFeatures = value.toBool();

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -490,16 +490,21 @@ QVariant OptionsModel::getOption(OptionID option, const std::string& suffix) con
     }
 }
 
-QFont OptionsModel::getFontForMoney() const
+QFont OptionsModel::getFontForChoice(const FontChoice& fc)
 {
     QFont f;
-    if (std::holds_alternative<FontChoiceAbstract>(m_font_money)) {
-        f = GUIUtil::fixedPitchFont(m_font_money != UseBestSystemFont);
+    if (std::holds_alternative<FontChoiceAbstract>(fc)) {
+        f = GUIUtil::fixedPitchFont(fc != UseBestSystemFont);
         f.setWeight(QFont::Bold);
     } else {
-        f = std::get<QFont>(m_font_money);
+        f = std::get<QFont>(fc);
     }
     return f;
+}
+
+QFont OptionsModel::getFontForMoney() const
+{
+    return getFontForChoice(m_font_money);
 }
 
 bool OptionsModel::setOption(OptionID option, const QVariant& value, const std::string& suffix)

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -129,7 +129,7 @@ private:
     QString language;
     BitcoinUnit m_display_bitcoin_unit;
     QString strThirdPartyTxUrls;
-    FontChoice m_font_money;
+    FontChoice m_font_money{FontChoiceAbstract::EmbeddedFont};
     bool fCoinControlFeatures;
     bool m_sub_fee_from_amount;
     bool m_enable_psbt_controls;
@@ -137,6 +137,8 @@ private:
 
     /* settings that were overridden by command-line */
     QString strOverriddenByCommandLine;
+
+    static FontChoice FontChoiceFromString(const QString&);
 
     // Add option to list of GUI options overridden through command line/config file
     void addOverriddenOption(const std::string &option);

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -62,7 +62,7 @@ public:
         DisplayUnit,            // BitcoinUnit
         ThirdPartyTxUrls,       // QString
         Language,               // QString
-        UseEmbeddedMonospacedFont, // bool
+        FontForMoney,           // FontChoice
         CoinControlFeatures,    // bool
         SubFeeFromAmount,       // bool
         ThreadsScriptVerif,     // int
@@ -138,6 +138,7 @@ private:
     /* settings that were overridden by command-line */
     QString strOverriddenByCommandLine;
 
+    static QString FontChoiceToString(const OptionsModel::FontChoice&);
     static FontChoice FontChoiceFromString(const QString&);
 
     // Add option to list of GUI options overridden through command line/config file
@@ -152,5 +153,7 @@ Q_SIGNALS:
     void showTrayIconChanged(bool);
     void fontForMoneyChanged(const QFont&);
 };
+
+Q_DECLARE_METATYPE(OptionsModel::FontChoice)
 
 #endif // BITCOIN_QT_OPTIONSMODEL_H

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -10,8 +10,10 @@
 #include <qt/guiconstants.h>
 
 #include <QAbstractListModel>
+#include <QFont>
 
 #include <assert.h>
+#include <variant>
 
 struct bilingual_str;
 namespace interfaces {
@@ -76,6 +78,13 @@ public:
         OptionIDRowCount,
     };
 
+    enum class FontChoiceAbstract {
+        EmbeddedFont,
+        BestSystemFont,
+    };
+    typedef std::variant<FontChoiceAbstract, QFont> FontChoice;
+    static inline const FontChoice UseBestSystemFont{FontChoiceAbstract::BestSystemFont};
+
     bool Init(bilingual_str& error);
     void Reset();
 
@@ -120,7 +129,7 @@ private:
     QString language;
     BitcoinUnit m_display_bitcoin_unit;
     QString strThirdPartyTxUrls;
-    bool m_use_embedded_monospaced_font;
+    FontChoice m_font_money;
     bool fCoinControlFeatures;
     bool m_sub_fee_from_amount;
     bool m_enable_psbt_controls;

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -84,6 +84,7 @@ public:
     };
     typedef std::variant<FontChoiceAbstract, QFont> FontChoice;
     static inline const FontChoice UseBestSystemFont{FontChoiceAbstract::BestSystemFont};
+    static QFont getFontForChoice(const FontChoice& fc);
 
     bool Init(bilingual_str& error);
     void Reset();

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -93,7 +93,7 @@ public:
     bool getMinimizeOnClose() const { return fMinimizeOnClose; }
     BitcoinUnit getDisplayUnit() const { return m_display_bitcoin_unit; }
     QString getThirdPartyTxUrls() const { return strThirdPartyTxUrls; }
-    bool getUseEmbeddedMonospacedFont() const { return m_use_embedded_monospaced_font; }
+    QFont getFontForMoney() const;
     bool getCoinControlFeatures() const { return fCoinControlFeatures; }
     bool getSubFeeFromAmount() const { return m_sub_fee_from_amount; }
     bool getEnablePSBTControls() const { return m_enable_psbt_controls; }
@@ -139,7 +139,7 @@ Q_SIGNALS:
     void displayUnitChanged(BitcoinUnit unit);
     void coinControlFeaturesChanged(bool);
     void showTrayIconChanged(bool);
-    void useEmbeddedMonospacedFontChanged(bool);
+    void fontForMoneyChanged(const QFont&);
 };
 
 #endif // BITCOIN_QT_OPTIONSMODEL_H

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -250,8 +250,8 @@ void OverviewPage::setClientModel(ClientModel *model)
         connect(model, &ClientModel::alertsChanged, this, &OverviewPage::updateAlerts);
         updateAlerts(model->getStatusBarWarnings());
 
-        connect(model->getOptionsModel(), &OptionsModel::useEmbeddedMonospacedFontChanged, this, &OverviewPage::setMonospacedFont);
-        setMonospacedFont(model->getOptionsModel()->getUseEmbeddedMonospacedFont());
+        connect(model->getOptionsModel(), &OptionsModel::fontForMoneyChanged, this, &OverviewPage::setMonospacedFont);
+        setMonospacedFont(clientModel->getOptionsModel()->getFontForMoney());
     }
 }
 
@@ -340,10 +340,8 @@ void OverviewPage::showOutOfSyncWarning(bool fShow)
     ui->labelTransactionsStatus->setVisible(fShow);
 }
 
-void OverviewPage::setMonospacedFont(bool use_embedded_font)
+void OverviewPage::setMonospacedFont(const QFont& f)
 {
-    QFont f = GUIUtil::fixedPitchFont(use_embedded_font);
-    f.setWeight(QFont::Bold);
     ui->labelBalance->setFont(f);
     ui->labelUnconfirmed->setFont(f);
     ui->labelImmature->setFont(f);

--- a/src/qt/overviewpage.h
+++ b/src/qt/overviewpage.h
@@ -65,7 +65,7 @@ private Q_SLOTS:
     void handleTransactionClicked(const QModelIndex &index);
     void updateAlerts(const QString &warnings);
     void updateWatchOnlyLabels(bool showWatchOnly);
-    void setMonospacedFont(bool use_embedded_font);
+    void setMonospacedFont(const QFont&);
 };
 
 #endif // BITCOIN_QT_OVERVIEWPAGE_H


### PR DESCRIPTION
This replaces the overly-verbose radio-button font setting (which only allows embedded or autodetected from system) with a simple combobox providing both existing options as well as a custom option to allow the user to select any font of their choice/style.