### PR TITLE
Hide peers details

### DIFF
--- a/src/qt/forms/debugwindow.ui
+++ b/src/qt/forms/debugwindow.ui
@@ -984,42 +984,117 @@
            </size>
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_8">
-           <item>
-            <widget class="QLabel" name="peerHeading">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="minimumSize">
-              <size>
-               <width>0</width>
-               <height>32</height>
-              </size>
-             </property>
-             <property name="font">
-              <font>
-               <pointsize>10</pointsize>
-              </font>
-             </property>
-             <property name="cursor">
-              <cursorShape>IBeamCursor</cursorShape>
-             </property>
-             <property name="text">
-              <string>Select a peer to view detailed information.</string>
-             </property>
-             <property name="alignment">
-              <set>Qt::AlignHCenter|Qt::AlignTop</set>
-             </property>
-             <property name="wordWrap">
-              <bool>true</bool>
-             </property>
-             <property name="textInteractionFlags">
-              <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-             </property>
-            </widget>
-           </item>
+            <item>
+              <layout class="QHBoxLayout" name="horizontalLayout_8">
+                <property name="topMargin">
+                  <number>0</number>
+                </property>
+                <property name="bottomMargin">
+                  <number>0</number>
+                </property>
+                <item>
+                  <widget class="QLabel" name="peerHeading">
+                  <property name="sizePolicy">
+                    <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                    </sizepolicy>
+                  </property>
+                  <property name="minimumSize">
+                    <size>
+                    <width>0</width>
+                    <height>32</height>
+                    </size>
+                  </property>
+                  <property name="font">
+                    <font>
+                    <pointsize>10</pointsize>
+                    </font>
+                  </property>
+                  <property name="cursor">
+                    <cursorShape>IBeamCursor</cursorShape>
+                  </property>
+                  <property name="text">
+                    <string>Select a peer to view detailed information.</string>
+                  </property>
+                  <property name="alignment">
+                    <set>Qt::AlignHCenter|Qt::AlignTop</set>
+                  </property>
+                  <property name="wordWrap">
+                    <bool>true</bool>
+                  </property>
+                  <property name="textInteractionFlags">
+                    <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+                  </property>
+                  </widget>
+                </item>
+                <item>
+                  <widget class="QWidget" name="hidePeersDetail" native="true">
+                    <property name="enabled">
+                      <bool>true</bool>
+                    </property>
+                    <property name="minimumSize">
+                      <size>
+                        <width>32</width>
+                        <height>32</height>
+                      </size>
+                    </property>
+                    <property name="maximumSize">
+                      <size>
+                        <width>32</width>
+                        <height>32</height>
+                      </size>
+                    </property>
+                    <widget class="QToolButton" name="hidePeersDetailButton">
+                      <property name="geometry">
+                        <rect>
+                          <x>0</x>
+                          <y>0</y>
+                          <width>32</width>
+                          <height>32</height>
+                        </rect>
+                      </property>
+                      <property name="minimumSize">
+                        <size>
+                          <width>32</width>
+                          <height>32</height>
+                        </size>
+                      </property>
+                      <property name="baseSize">
+                        <size>
+                          <width>32</width>
+                          <height>32</height>
+                        </size>
+                      </property>
+                      <property name="toolTip">
+                        <string>Hide Peers Detail</string>
+                      </property>
+                      <property name="layoutDirection">
+                        <enum>Qt::LeftToRight</enum>
+                      </property>
+                      <property name="text">
+                        <string />
+                      </property>
+                      <property name="icon">
+                        <iconset resource="../bitcoin.qrc">
+                          <normaloff>:/icons/remove</normaloff>
+                          :/icons/remove
+                        </iconset>
+                      </property>
+                      <property name="iconSize">
+                        <size>
+                          <width>22</width>
+                          <height>22</height>
+                        </size>
+                      </property>
+                      <property name="shortcut">
+                        <string>Ctrl+X</string>
+                      </property>
+                    </widget>
+                  </widget>
+                </item>
+              </layout>
+            </item>
            <item>
             <widget class="QScrollArea" name="scrollArea">
              <property name="widgetResizable">

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -550,6 +550,7 @@ RPCConsole::RPCConsole(interfaces::Node& node, const PlatformStyle *_platformSty
     ui->lineEdit->setMaxLength(16 * 1024 * 1024);
     ui->messagesWidget->installEventFilter(this);
 
+    connect(ui->hidePeersDetailButton, &QAbstractButton::clicked, this, &RPCConsole::clearSelectedNode);
     connect(ui->clearButton, &QAbstractButton::clicked, [this] { clear(); });
     connect(ui->fontBiggerButton, &QAbstractButton::clicked, this, &RPCConsole::fontBigger);
     connect(ui->fontSmallerButton, &QAbstractButton::clicked, this, &RPCConsole::fontSmaller);
@@ -1221,6 +1222,7 @@ void RPCConsole::updateDetailWidget()
         ui->peerRelayTxes->setText(stats->nodeStateStats.m_relay_txs ? ts.yes : ts.no);
     }
 
+    ui->hidePeersDetailButton->setIcon(platformStyle->SingleColorIcon(QStringLiteral(":/icons/remove")));
     ui->peersTabRightPanel->show();
 }
 


### PR DESCRIPTION
Add a close (X) button to the Peers Detail panel.
Reuse the same icon used in the Console Tab.
The close button deselects the peer highlighted
in the PeerTableView and hides the detail panel.

fixes #485
    
    Co-authored-by: @w0xlt <w0xlt@users.noreply.github.com>