### PR TITLE
QRImageWidget: Sizing and font fixups

### DIFF
--- a/src/qt/qrimagewidget.cpp
+++ b/src/qt/qrimagewidget.cpp
@@ -83,7 +83,14 @@ bool QRImageWidget::setQR(const QString& data, const QString& text)
         // Plan how many lines are needed
         QFontMetrics fm(font);
         const int text_width = GUIUtil::TextWidth(fm, text);
-        text_lines = (text_width + max_text_width - 1) / max_text_width;
+        if (text_width > max_text_width && text_width < max_text_width * 5 / 4) {
+            // Allow the image to grow up to 25% wider
+            qr_image_width = text_width + (2 * QR_IMAGE_TEXT_MARGIN);
+            qr_image_x_margin = (qr_image_width - QR_IMAGE_SIZE) / 2;
+            text_lines = 1;
+        } else {
+            text_lines = (text_width + max_text_width - 1) / max_text_width;
+        }
         qr_image_height += (fm.height() * text_lines) + QR_IMAGE_TEXT_MARGIN;
     }
     QImage qrAddrImage(qr_image_width, qr_image_height, QImage::Format_RGB32);

--- a/src/qt/qrimagewidget.h
+++ b/src/qt/qrimagewidget.h
@@ -12,9 +12,9 @@
 static const int MAX_URI_LENGTH = 255;
 
 /* Size of exported QR Code image */
-static constexpr int QR_IMAGE_SIZE = 300;
-static constexpr int QR_IMAGE_TEXT_MARGIN = 10;
-static constexpr int QR_IMAGE_MARGIN = 2 * QR_IMAGE_TEXT_MARGIN;
+static constexpr int QR_IMAGE_SIZE = 252;
+static constexpr int QR_IMAGE_TEXT_MARGIN = 8;
+static constexpr int QR_IMAGE_MARGIN = 24;
 
 QT_BEGIN_NAMESPACE
 class QMenu;


### PR DESCRIPTION
- Margin of QRCode should be constant, not change based on complexity of QRCode
- Text region should be sized based on height of actual text, not a constant guess
- Width of image should not be adjusted based on vertical text size/margins
- Adjusted constant QRCode and margin sizes to visually match what we had previously
- If text won't fit, grow up to 25% wider, or split across multiple lines

(Note: Out of scope for this PR, after #497, I think we should allow customising the font used here and default to the embedded monospace for better privacy)