### PR TITLE
Change 'Show' icon

### DIFF
--- a/src/qt/forms/receivecoinsdialog.ui
+++ b/src/qt/forms/receivecoinsdialog.ui
@@ -308,7 +308,7 @@
           </property>
           <property name="icon">
            <iconset resource="../bitcoin.qrc">
-            <normaloff>:/icons/edit</normaloff>:/icons/edit</iconset>
+            <normaloff>:/icons/eye</normaloff>:/icons/eye</iconset>
           </property>
           <property name="autoDefault">
            <bool>false</bool>

--- a/src/qt/receivecoinsdialog.cpp
+++ b/src/qt/receivecoinsdialog.cpp
@@ -38,7 +38,7 @@ ReceiveCoinsDialog::ReceiveCoinsDialog(const PlatformStyle *_platformStyle, QWid
     } else {
         ui->clearButton->setIcon(_platformStyle->SingleColorIcon(":/icons/remove"));
         ui->receiveButton->setIcon(_platformStyle->SingleColorIcon(":/icons/receiving_addresses"));
-        ui->showRequestButton->setIcon(_platformStyle->SingleColorIcon(":/icons/edit"));
+        ui->showRequestButton->setIcon(_platformStyle->SingleColorIcon(":/icons/eye"));
         ui->removeRequestButton->setIcon(_platformStyle->SingleColorIcon(":/icons/remove"));
     }
 


### PR DESCRIPTION
This PR changes the 'Show' icon in `receivecoinsdialog.{ui,cpp}`.

The current icon for the 'Show' button is the edit icon, which makes it look like records can be edited on this screen (which is not the case).



The icon already available that seems to be the most suitable for this case is the "eye", so this PR makes this change.

| PR  | Master |
| ------------- | ------------- |
| <img width="209" alt="PR" src="https://user-images.githubusercontent.com/94266259/147833993-0758291c-af87-49a8-ae20-7fb9f944cb38.png"> |  <img width="209" alt="master" src="https://user-images.githubusercontent.com/94266259/147833992-30d7549d-be7b-4479-8bca-314810e3adb8.png">  |

