### PR TITLE
Replace int with std::chrono in for the timer->setInterval() argument

### DIFF
--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -54,6 +54,8 @@
 #include <QTimer>
 #include <QVariant>
 
+#include <chrono>
+
 const int CONSOLE_HISTORY = 50;
 const int INITIAL_TRAFFIC_GRAPH_MINS = 30;
 const QSize FONT_RANGE(4, 40);
@@ -1140,7 +1142,7 @@ void RPCConsole::on_sldGraphRange_valueChanged(int value)
 
 void RPCConsole::setTrafficGraphRange(int mins)
 {
-    ui->trafficGraph->setGraphRangeMins(mins);
+    ui->trafficGraph->setGraphRange(std::chrono::minutes{mins});
     ui->lblGraphRange->setText(GUIUtil::formatDurationStr(std::chrono::minutes{mins}));
 }
 

--- a/src/qt/trafficgraphwidget.cpp
+++ b/src/qt/trafficgraphwidget.cpp
@@ -11,6 +11,7 @@
 #include <QColor>
 #include <QTimer>
 
+#include <chrono>
 #include <cmath>
 
 #define DESIRED_SAMPLES         800
@@ -22,7 +23,6 @@ TrafficGraphWidget::TrafficGraphWidget(QWidget *parent) :
     QWidget(parent),
     timer(nullptr),
     fMax(0.0f),
-    nMins(0),
     vSamplesIn(),
     vSamplesOut(),
     nLastBytesIn(0),
@@ -42,10 +42,7 @@ void TrafficGraphWidget::setClientModel(ClientModel *model)
     }
 }
 
-int TrafficGraphWidget::getGraphRangeMins() const
-{
-    return nMins;
-}
+std::chrono::minutes TrafficGraphWidget::getGraphRange() const { return m_range; }
 
 void TrafficGraphWidget::paintPath(QPainterPath &path, QQueue<float> &samples)
 {
@@ -153,12 +150,12 @@ void TrafficGraphWidget::updateRates()
     update();
 }
 
-void TrafficGraphWidget::setGraphRangeMins(int mins)
+void TrafficGraphWidget::setGraphRange(std::chrono::minutes new_range)
 {
-    nMins = mins;
-    int msecsPerSample = nMins * 60 * 1000 / DESIRED_SAMPLES;
+    m_range = new_range;
+    const auto msecs_per_sample{std::chrono::duration_cast<std::chrono::milliseconds>(m_range) / DESIRED_SAMPLES};
     timer->stop();
-    timer->setInterval(msecsPerSample);
+    timer->setInterval(msecs_per_sample);
 
     clear();
 }

--- a/src/qt/trafficgraphwidget.h
+++ b/src/qt/trafficgraphwidget.h
@@ -8,6 +8,8 @@
 #include <QWidget>
 #include <QQueue>
 
+#include <chrono>
+
 class ClientModel;
 
 QT_BEGIN_NAMESPACE
@@ -22,14 +24,14 @@ class TrafficGraphWidget : public QWidget
 public:
     explicit TrafficGraphWidget(QWidget *parent = nullptr);
     void setClientModel(ClientModel *model);
-    int getGraphRangeMins() const;
+    std::chrono::minutes getGraphRange() const;
 
 protected:
     void paintEvent(QPaintEvent *) override;
 
 public Q_SLOTS:
     void updateRates();
-    void setGraphRangeMins(int mins);
+    void setGraphRange(std::chrono::minutes new_range);
     void clear();
 
 private:
@@ -37,7 +39,7 @@ private:
 
     QTimer *timer;
     float fMax;
-    int nMins;
+    std::chrono::minutes m_range{0};
     QQueue<float> vSamplesIn;
     QQueue<float> vSamplesOut;
     quint64 nLastBytesIn;


### PR DESCRIPTION
The PR is a follow-up to #517

- It addresses the change suggested in [this](https://github.com/bitcoin-core/gui/pull/517#pullrequestreview-850260826) comment.
- This PR changes the type of `msecsPerSample` from **int** to **std::chrono::minutes** and makes other relevant subsequent changes that were limited to the **trafficgraphwidget** file.
