### PR TITLE
Add translatable address error message 

### DIFF
--- a/src/qt/editaddressdialog.cpp
+++ b/src/qt/editaddressdialog.cpp
@@ -3,9 +3,10 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <qt/editaddressdialog.h>
-#include <qt/forms/ui_editaddressdialog.h>
 
+#include <key_io.h>
 #include <qt/addresstablemodel.h>
+#include <qt/forms/ui_editaddressdialog.h>
 #include <qt/guiutil.h>
 
 #include <QDataWidgetMapper>
@@ -43,6 +44,8 @@ EditAddressDialog::EditAddressDialog(Mode _mode, QWidget *parent) :
     GUIUtil::ItemDelegate* delegate = new GUIUtil::ItemDelegate(mapper);
     connect(delegate, &GUIUtil::ItemDelegate::keyEscapePressed, this, &EditAddressDialog::reject);
     mapper->setItemDelegate(delegate);
+
+    connect(ui->addressEdit, &QValidatedLineEdit::textEdited, this, &EditAddressDialog::addressEdited);
 
     GUIUtil::handleCloseWindowShortcut(this);
 }
@@ -163,4 +166,14 @@ void EditAddressDialog::setAddress(const QString &_address)
 {
     this->address = _address;
     ui->addressEdit->setText(_address);
+}
+
+// Address changed
+void EditAddressDialog::addressEdited(const QString& address)
+{
+    if (!address.isEmpty() && !IsValidDestination(DecodeDestination(address.toStdString()))) {
+        ui->errorMessage->setText(tr("Warning: Invalid Bitcoin address"));
+    } else {
+        ui->errorMessage->setText("");
+    }
 }

--- a/src/qt/editaddressdialog.h
+++ b/src/qt/editaddressdialog.h
@@ -42,6 +42,9 @@ public:
 public Q_SLOTS:
     void accept() override;
 
+private Q_SLOTS:
+    void addressEdited(const QString& address);
+
 private:
     bool saveCurrentRow();
 

--- a/src/qt/forms/editaddressdialog.ui
+++ b/src/qt/forms/editaddressdialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>457</width>
-    <height>126</height>
+    <height>138</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -50,6 +50,16 @@
       <widget class="QValidatedLineEdit" name="addressEdit">
        <property name="toolTip">
         <string>The address associated with this address list entry. This can only be modified for sending addresses.</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QLabel" name="errorMessage">
+       <property name="styleSheet">
+        <string notr="true">color:red;</string>
+       </property>
+       <property name="text">
+        <string/>
        </property>
       </widget>
      </item>

--- a/src/qt/forms/sendcoinsentry.ui
+++ b/src/qt/forms/sendcoinsentry.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>729</width>
-    <height>150</height>
+    <height>172</height>
    </rect>
   </property>
   <property name="focusPolicy">
@@ -33,7 +33,17 @@
     <property name="verticalSpacing">
      <number>8</number>
     </property>
-    <item row="0" column="0">
+    <item row="0" column="1">
+     <widget class="QLabel" name="errorMessage">
+      <property name="styleSheet">
+       <string notr="true">color:red;</string>
+      </property>
+      <property name="text">
+       <string/>
+      </property>
+     </widget>
+    </item>
+    <item row="1" column="0">
      <widget class="QLabel" name="payToLabel">
       <property name="text">
        <string>Pay &amp;To:</string>
@@ -46,7 +56,7 @@
       </property>
      </widget>
     </item>
-    <item row="0" column="1">
+    <item row="1" column="1">
      <layout class="QHBoxLayout" name="payToLayout">
       <property name="spacing">
        <number>0</number>
@@ -126,7 +136,7 @@
       </item>
      </layout>
     </item>
-    <item row="1" column="0">
+    <item row="2" column="0">
      <widget class="QLabel" name="labellLabel">
       <property name="text">
        <string>&amp;Label:</string>
@@ -139,7 +149,7 @@
       </property>
      </widget>
     </item>
-    <item row="1" column="1">
+    <item row="2" column="1">
      <widget class="QLineEdit" name="addAsLabel">
       <property name="toolTip">
        <string>Enter a label for this address to add it to the list of used addresses</string>
@@ -149,7 +159,7 @@
       </property>
      </widget>
     </item>
-    <item row="2" column="0">
+    <item row="3" column="0">
      <widget class="QLabel" name="amountLabel">
       <property name="text">
        <string>A&amp;mount:</string>
@@ -162,7 +172,7 @@
       </property>
      </widget>
     </item>
-    <item row="2" column="1">
+    <item row="3" column="1">
      <layout class="QHBoxLayout" name="horizontalLayoutAmount" stretch="0,1,0">
       <item>
        <widget class="BitcoinAmountField" name="payAmount">
@@ -174,7 +184,7 @@
       <item>
        <widget class="QCheckBox" name="checkboxSubtractFeeFromAmount">
         <property name="toolTip">
-         <string>The fee will be deducted from the amount being sent. The recipient will receive less bitcoins than you enter in the amount field. If multiple recipients are selected, the fee is split equally.</string>
+         <string>The fee will be deducted from the amount being sent. The recipient will receive less bitcoin than you enter in the amount field. If multiple recipients are selected, the fee is split equally.</string>
         </property>
         <property name="text">
          <string>S&amp;ubtract fee from amount</string>
@@ -190,7 +200,7 @@
       </item>
      </layout>
     </item>
-    <item row="3" column="0">
+    <item row="4" column="0">
      <widget class="QLabel" name="messageLabel">
       <property name="text">
        <string>Message:</string>
@@ -200,7 +210,7 @@
       </property>
      </widget>
     </item>
-    <item row="3" column="1">
+    <item row="4" column="1">
      <widget class="QLabel" name="messageTextLabel">
       <property name="toolTip">
        <string>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</string>
@@ -210,7 +220,7 @@
       </property>
      </widget>
     </item>
-    <item row="4" column="0" colspan="2">
+    <item row="5" column="0" colspan="2">
      <widget class="Line" name="line">
       <property name="orientation">
        <enum>Qt::Horizontal</enum>

--- a/src/qt/sendcoinsentry.cpp
+++ b/src/qt/sendcoinsentry.cpp
@@ -7,10 +7,13 @@
 #endif
 
 #include <qt/sendcoinsentry.h>
-#include <qt/forms/ui_sendcoinsentry.h>
+
+#include <key_io.h>
+
 
 #include <qt/addressbookpage.h>
 #include <qt/addresstablemodel.h>
+#include <qt/forms/ui_sendcoinsentry.h>
 #include <qt/guiutil.h>
 #include <qt/optionsmodel.h>
 #include <qt/platformstyle.h>
@@ -50,6 +53,7 @@ SendCoinsEntry::SendCoinsEntry(const PlatformStyle *_platformStyle, QWidget *par
     connect(ui->deleteButton_is, &QPushButton::clicked, this, &SendCoinsEntry::deleteClicked);
     connect(ui->deleteButton_s, &QPushButton::clicked, this, &SendCoinsEntry::deleteClicked);
     connect(ui->useAvailableBalanceButton, &QPushButton::clicked, this, &SendCoinsEntry::useAvailableBalanceClicked);
+    connect(ui->payTo, &QValidatedLineEdit::textEdited, this, &SendCoinsEntry::addressEdited);
 }
 
 SendCoinsEntry::~SendCoinsEntry()
@@ -265,4 +269,14 @@ bool SendCoinsEntry::updateLabel(const QString &address)
     }
 
     return false;
+}
+
+// Address changed
+void SendCoinsEntry::addressEdited(const QString& address)
+{
+    if (!address.isEmpty() && !IsValidDestination(DecodeDestination(address.toStdString()))) {
+        ui->errorMessage->setText(tr("Warning: Invalid Bitcoin address"));
+    } else {
+        ui->errorMessage->setText("");
+    }
 }

--- a/src/qt/sendcoinsentry.h
+++ b/src/qt/sendcoinsentry.h
@@ -68,6 +68,7 @@ private Q_SLOTS:
     void on_addressBookButton_clicked();
     void on_pasteButton_clicked();
     void updateDisplayUnit();
+    void addressEdited(const QString &);
 
 protected:
     void changeEvent(QEvent* e) override;


### PR DESCRIPTION
This PR is an alternative to https://github.com/bitcoin-core/gui/pull/533 that addresses https://github.com/bitcoin-core/gui/pull/533#pullrequestreview-860261164 .

While this PR no longer provides a detailed error message, it still brings some UI improvements:

. Improve user experience by showing an error message instead of just changing the color of `QLineEdit`
. Currently, when an invalid address is entered in `custom change address`, an error message is displayed. But the same does not happen in the `Pay To` field or when adding a new address in the address manager. This PR standardizes error handling for all address fields.
. The message added in this PR is the same as used in the `custom change address`, which is already translated into several languages.

| PR  | 
| -------------| 
| ![invalid_new_address](https://user-images.githubusercontent.com/94266259/150670534-5f1252bc-2cd4-4dc2-a5fd-1a3db3ea3ea7.png) | 
| ![invalid_pay_to](https://user-images.githubusercontent.com/94266259/150670546-1c520b90-6022-45ba-b748-9c3355681a32.png) | 


