### PR TITLE
Add address error location to GUI

### DIFF
--- a/src/qt/bitcoinaddressvalidator.cpp
+++ b/src/qt/bitcoinaddressvalidator.cpp
@@ -95,3 +95,8 @@ QValidator::State BitcoinAddressCheckValidator::validate(QString &input, int &po
 
     return QValidator::Invalid;
 }
+
+void BitcoinAddressErrorLocator::locateErrors(const QString& str, std::string& error_message, std::vector<int>* error_locations) const
+{
+    DecodeDestination(str.toStdString(), error_message, error_locations);
+}

--- a/src/qt/bitcoinaddressvalidator.h
+++ b/src/qt/bitcoinaddressvalidator.h
@@ -32,4 +32,20 @@ public:
     State validate(QString &input, int &pos) const override;
 };
 
+class ErrorLocator
+{
+public:
+    virtual void locateErrors(const QString& str, std::string& error_message, std::vector<int>* error_locations) const = 0;
+    virtual ~ErrorLocator() {};
+};
+
+/** Bitcoin address error locator.
+ */
+class BitcoinAddressErrorLocator : public ErrorLocator
+{
+public:
+    void locateErrors(const QString& str, std::string& error_message, std::vector<int>* error_locations) const override;
+    ~BitcoinAddressErrorLocator() override {};
+};
+
 #endif // BITCOIN_QT_BITCOINADDRESSVALIDATOR_H

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -123,6 +123,7 @@ void setupAddressWidget(QValidatedLineEdit *widget, QWidget *parent)
         QString::fromStdString(DummyAddress(Params()))));
     widget->setValidator(new BitcoinAddressEntryValidator(parent));
     widget->setCheckValidator(new BitcoinAddressCheckValidator(parent));
+    widget->setErrorLocator(new BitcoinAddressErrorLocator());
 }
 
 void AddButtonShortcut(QAbstractButton* button, const QKeySequence& shortcut)

--- a/src/qt/qvalidatedlineedit.h
+++ b/src/qt/qvalidatedlineedit.h
@@ -7,6 +7,8 @@
 
 #include <QLineEdit>
 
+class ErrorLocator;
+
 /** Line edit that can be marked as "invalid" to show input validation feedback. When marked as invalid,
    it will get a red background until it is focused.
  */
@@ -16,17 +18,21 @@ class QValidatedLineEdit : public QLineEdit
 
 public:
     explicit QValidatedLineEdit(QWidget *parent);
+    ~QValidatedLineEdit();
     void clear();
     void setCheckValidator(const QValidator *v);
+    void setErrorLocator(const ErrorLocator *e);
     bool isValid();
 
 protected:
     void focusInEvent(QFocusEvent *evt) override;
     void focusOutEvent(QFocusEvent *evt) override;
+    void contextMenuEvent(QContextMenuEvent *event) override;
 
 private:
     bool valid;
     const QValidator *checkValidator;
+    const ErrorLocator *errorLocator;
 
 public Q_SLOTS:
     void setValid(bool valid);
@@ -38,6 +44,7 @@ Q_SIGNALS:
 private Q_SLOTS:
     void markValid();
     void checkValidity();
+    void locateErrors();
 };
 
 #endif // BITCOIN_QT_QVALIDATEDLINEEDIT_H


### PR DESCRIPTION
Closes #527. May supersede #533, depending on whether people feel the error reason is better displayed immediately or in this validation dialog.

This is an alternative to #537: I believe we should only show the user potential errors if they ask for it, as the errors are not guaranteed to be correct and enabling/encouraging the user to bruteforce the errors may lead to loss of funds.

Adds a context menu item "Attempt error location" to the address inputs:
<img width="203" alt="image" src="https://user-images.githubusercontent.com/3211283/150777849-aa19ef95-da53-4ff0-864c-7e290287e995.png">

Which, when clicked, opens a dialog with the error message and highlighted detected errors in red:
<img width="499" alt="image" src="https://user-images.githubusercontent.com/3211283/150777754-44f6fab8-d16f-4d34-abc0-29278223e2c3.png">

