### PR TITLE
Point out position of invalid characters in Bech32 addresses

### DIFF
--- a/src/qt/bitcoinaddressvalidator.h
+++ b/src/qt/bitcoinaddressvalidator.h
@@ -7,6 +7,8 @@
 
 #include <QValidator>
 
+#include <vector>
+
 /** Base58 entry widget validator, checks for valid characters and
  * removes some whitespace.
  */
@@ -17,19 +19,20 @@ class BitcoinAddressEntryValidator : public QValidator
 public:
     explicit BitcoinAddressEntryValidator(QObject *parent);
 
-    State validate(QString &input, int &pos) const override;
+    virtual State validate(QString &input, std::vector<int>&error_locations) const;
+    virtual State validate(QString &input, int &pos) const override;
 };
 
 /** Bitcoin address widget validator, checks for a valid bitcoin address.
  */
-class BitcoinAddressCheckValidator : public QValidator
+class BitcoinAddressCheckValidator : public BitcoinAddressEntryValidator
 {
     Q_OBJECT
 
 public:
     explicit BitcoinAddressCheckValidator(QObject *parent);
 
-    State validate(QString &input, int &pos) const override;
+    State validate(QString &input, std::vector<int>&error_locations) const override;
 };
 
 #endif // BITCOIN_QT_BITCOINADDRESSVALIDATOR_H

--- a/src/qt/guiconstants.h
+++ b/src/qt/guiconstants.h
@@ -26,6 +26,8 @@ static const bool DEFAULT_SPLASHSCREEN = true;
 
 /* Invalid field background style */
 #define STYLE_INVALID "background:#FF8080"
+/* "Warning" field background style */
+#define STYLE_INCORRECT "background:#FFFF80"
 
 /* Transaction list -- unconfirmed transaction */
 #define COLOR_UNCONFIRMED QColor(128, 128, 128)

--- a/src/qt/qvalidatedlineedit.cpp
+++ b/src/qt/qvalidatedlineedit.cpp
@@ -7,6 +7,13 @@
 #include <qt/bitcoinaddressvalidator.h>
 #include <qt/guiconstants.h>
 
+#include <QColor>
+#include <QCoreApplication>
+#include <QFont>
+#include <QInputMethodEvent>
+#include <QList>
+#include <QTextCharFormat>
+
 QValidatedLineEdit::QValidatedLineEdit(QWidget *parent) :
     QLineEdit(parent),
     valid(true),
@@ -26,14 +33,16 @@ void QValidatedLineEdit::setText(const QString& text)
     checkValidity();
 }
 
-void QValidatedLineEdit::setValid(bool _valid, bool with_warning)
+void QValidatedLineEdit::setValid(bool _valid, bool with_warning, const std::vector<int>&error_locations)
 {
-    if(_valid == this->valid)
+    if(_valid && this->valid)
     {
-        if (with_warning == m_has_warning || !valid) {
+        if (with_warning == m_has_warning) {
             return;
         }
     }
+
+    QList<QInputMethodEvent::Attribute> attributes;
 
     if(_valid)
     {
@@ -47,7 +56,22 @@ void QValidatedLineEdit::setValid(bool _valid, bool with_warning)
     else
     {
         setStyleSheet("QValidatedLineEdit { " STYLE_INVALID "}");
+        if (!error_locations.empty()) {
+            QTextCharFormat format;
+            format.setFontUnderline(true);
+            format.setUnderlineStyle(QTextCharFormat::SpellCheckUnderline);
+            format.setUnderlineColor(Qt::yellow);
+            format.setForeground(Qt::yellow);
+            format.setFontWeight(QFont::Bold);
+            for (auto error_pos : error_locations) {
+                attributes.append(QInputMethodEvent::Attribute(QInputMethodEvent::TextFormat, error_pos - cursorPosition(), /*length=*/ 1, format));
+            }
+        }
     }
+
+    QInputMethodEvent event(QString(), attributes);
+    QCoreApplication::sendEvent(this, &event);
+
     this->valid = _valid;
 }
 
@@ -109,11 +133,21 @@ void QValidatedLineEdit::checkValidity()
         if (checkValidator)
         {
             QString address = text();
-            int pos = 0;
-            if (checkValidator->validate(address, pos) == QValidator::Acceptable)
+            QValidator::State validation_result;
+            std::vector<int> error_locations;
+            const BitcoinAddressEntryValidator * const address_validator = dynamic_cast<const BitcoinAddressEntryValidator*>(checkValidator);
+            if (address_validator) {
+                validation_result = address_validator->validate(address, error_locations);
+            } else {
+                int pos = 0;
+                validation_result = checkValidator->validate(address, pos);
+                error_locations.push_back(pos);
+            }
+            if (validation_result == QValidator::Acceptable) {
                 setValid(/* valid= */ true, has_warning);
-            else
-                setValid(false);
+            } else {
+                setValid(/* valid= */ false, /* with_warning= */ false, error_locations);
+            }
         }
     }
     else

--- a/src/qt/qvalidatedlineedit.cpp
+++ b/src/qt/qvalidatedlineedit.cpp
@@ -15,22 +15,34 @@ QValidatedLineEdit::QValidatedLineEdit(QWidget *parent) :
     connect(this, &QValidatedLineEdit::textChanged, this, &QValidatedLineEdit::markValid);
 }
 
+QValidatedLineEdit::~QValidatedLineEdit()
+{
+    delete m_warning_validator;
+}
+
 void QValidatedLineEdit::setText(const QString& text)
 {
     QLineEdit::setText(text);
     checkValidity();
 }
 
-void QValidatedLineEdit::setValid(bool _valid)
+void QValidatedLineEdit::setValid(bool _valid, bool with_warning)
 {
     if(_valid == this->valid)
     {
-        return;
+        if (with_warning == m_has_warning || !valid) {
+            return;
+        }
     }
 
     if(_valid)
     {
-        setStyleSheet("");
+        m_has_warning = with_warning;
+        if (with_warning) {
+            setStyleSheet("QValidatedLineEdit { " STYLE_INCORRECT "}");
+        } else {
+            setStyleSheet("");
+        }
     }
     else
     {
@@ -84,13 +96,14 @@ void QValidatedLineEdit::setEnabled(bool enabled)
 
 void QValidatedLineEdit::checkValidity()
 {
+    const bool has_warning = checkWarning();
     if (text().isEmpty())
     {
         setValid(true);
     }
     else if (hasAcceptableInput())
     {
-        setValid(true);
+        setValid(/* valid= */ true, has_warning);
 
         // Check contents on focus out
         if (checkValidator)
@@ -98,7 +111,7 @@ void QValidatedLineEdit::checkValidity()
             QString address = text();
             int pos = 0;
             if (checkValidator->validate(address, pos) == QValidator::Acceptable)
-                setValid(true);
+                setValid(/* valid= */ true, has_warning);
             else
                 setValid(false);
         }
@@ -127,4 +140,29 @@ bool QValidatedLineEdit::isValid()
     }
 
     return valid;
+}
+
+void QValidatedLineEdit::setWarningValidator(const QValidator *v)
+{
+    delete m_warning_validator;
+    m_warning_validator = v;
+    checkValidity();
+}
+
+bool QValidatedLineEdit::checkWarning() const
+{
+    if (m_warning_validator && !text().isEmpty()) {
+        QString address = text();
+        int pos = 0;
+        if (m_warning_validator->validate(address, pos) != QValidator::Acceptable) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool QValidatedLineEdit::hasWarning() const
+{
+    return m_has_warning;
 }

--- a/src/qt/qvalidatedlineedit.h
+++ b/src/qt/qvalidatedlineedit.h
@@ -16,9 +16,12 @@ class QValidatedLineEdit : public QLineEdit
 
 public:
     explicit QValidatedLineEdit(QWidget *parent);
+    ~QValidatedLineEdit();
     void clear();
     void setCheckValidator(const QValidator *v);
     bool isValid();
+    void setWarningValidator(const QValidator *);
+    bool hasWarning() const;
 
 protected:
     void focusInEvent(QFocusEvent *evt) override;
@@ -27,10 +30,12 @@ protected:
 private:
     bool valid;
     const QValidator *checkValidator;
+    bool m_has_warning{false};
+    const QValidator *m_warning_validator{nullptr};
 
 public Q_SLOTS:
     void setText(const QString&);
-    void setValid(bool valid);
+    void setValid(bool valid, bool with_warning=false);
     void setEnabled(bool enabled);
 
 Q_SIGNALS:
@@ -39,6 +44,7 @@ Q_SIGNALS:
 private Q_SLOTS:
     void markValid();
     void checkValidity();
+    bool checkWarning() const;
 };
 
 #endif // BITCOIN_QT_QVALIDATEDLINEEDIT_H

--- a/src/qt/qvalidatedlineedit.h
+++ b/src/qt/qvalidatedlineedit.h
@@ -35,7 +35,7 @@ private:
 
 public Q_SLOTS:
     void setText(const QString&);
-    void setValid(bool valid, bool with_warning=false);
+    void setValid(bool valid, bool with_warning=false, const std::vector<int>&error_locations=std::vector<int>());
     void setEnabled(bool enabled);
 
 Q_SIGNALS:


### PR DESCRIPTION
Implements #527

![gui_bech32_errpos](https://user-images.githubusercontent.com/1095675/150843052-09dcb3eb-cb83-443a-824e-01eafa4ccc1d.png)
