### PR TITLE
Scale network graph based on time interval

### DIFF
--- a/src/qt/forms/debugwindow.ui
+++ b/src/qt/forms/debugwindow.ui
@@ -639,7 +639,7 @@
               <number>12</number>
              </property>
              <property name="value">
-              <number>6</number>
+              <number>1</number>
              </property>
              <property name="orientation">
               <enum>Qt::Horizontal</enum>

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -54,6 +54,8 @@
 #include <QTimer>
 #include <QVariant>
 
+#include <chrono>
+
 const int CONSOLE_HISTORY = 50;
 const int INITIAL_TRAFFIC_GRAPH_MINS = 30;
 const QSize FONT_RANGE(4, 40);
@@ -1140,7 +1142,7 @@ void RPCConsole::on_sldGraphRange_valueChanged(int value)
 
 void RPCConsole::setTrafficGraphRange(int mins)
 {
-    ui->trafficGraph->setGraphRangeMins(mins);
+    ui->trafficGraph->setGraphRange(std::chrono::minutes{mins});
     ui->lblGraphRange->setText(GUIUtil::formatDurationStr(std::chrono::minutes{mins}));
 }
 

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -57,7 +57,7 @@
 #include <chrono>
 
 const int CONSOLE_HISTORY = 50;
-const int INITIAL_TRAFFIC_GRAPH_MINS = 30;
+const int INITIAL_TRAFFIC_GRAPH_MINS = 5;
 const QSize FONT_RANGE(4, 40);
 const char fontSizeSettingsKey[] = "consoleFontSize";
 

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -1228,6 +1228,22 @@ void RPCConsole::updateDetailWidget()
 void RPCConsole::resizeEvent(QResizeEvent *event)
 {
     QWidget::resizeEvent(event);
+    if (width()<=minimumWidth()*2){
+        ui->groupBox->hide();
+    }else{
+        ui->groupBox->show();
+    }
+    if (height()==minimumHeight()){
+        ui->sldGraphRange->hide();
+        ui->lblGraphRange->hide();
+        ui->btnClearTrafficGraph->hide();
+    }else{
+        ui->sldGraphRange->show();
+        ui->lblGraphRange->show();
+        ui->btnClearTrafficGraph->show();
+    }
+
+
 }
 
 void RPCConsole::showEvent(QShowEvent *event)

--- a/src/qt/trafficgraphwidget.cpp
+++ b/src/qt/trafficgraphwidget.cpp
@@ -55,7 +55,7 @@ void TrafficGraphWidget::paintPath(QPainterPath &path, QQueue<float> &samples)
         int x = XMARGIN + w;
         path.moveTo(x, YMARGIN + h);
         for(int i = 0; i < sampleCount; ++i) {
-            x = XMARGIN + w - w * i / DESIRED_SAMPLES;
+            x = XMARGIN + w - w * i / DESIRED_SAMPLES / (getGraphRangeMins()/5);
             int y = YMARGIN + h - (int)(h * samples.at(i) / fMax);
             path.lineTo(x, y);
         }
@@ -135,10 +135,10 @@ void TrafficGraphWidget::updateRates()
     nLastBytesIn = bytesIn;
     nLastBytesOut = bytesOut;
 
-    while(vSamplesIn.size() > DESIRED_SAMPLES) {
+    while(vSamplesIn.size() > DESIRED_SAMPLES * (getGraphRangeMins() / 5)) {
         vSamplesIn.pop_back();
     }
-    while(vSamplesOut.size() > DESIRED_SAMPLES) {
+    while(vSamplesOut.size() > DESIRED_SAMPLES * (getGraphRangeMins() / 5)) {
         vSamplesOut.pop_back();
     }
 
@@ -159,6 +159,7 @@ void TrafficGraphWidget::setGraphRangeMins(int mins)
     int msecsPerSample = nMins * 60 * 1000 / DESIRED_SAMPLES;
     timer->stop();
     timer->setInterval(msecsPerSample);
+    update();
     timer->start();
 }
 

--- a/src/qt/trafficgraphwidget.cpp
+++ b/src/qt/trafficgraphwidget.cpp
@@ -159,8 +159,7 @@ void TrafficGraphWidget::setGraphRangeMins(int mins)
     int msecsPerSample = nMins * 60 * 1000 / DESIRED_SAMPLES;
     timer->stop();
     timer->setInterval(msecsPerSample);
-
-    clear();
+    timer->start();
 }
 
 void TrafficGraphWidget::clear()

--- a/src/qt/trafficgraphwidget.cpp
+++ b/src/qt/trafficgraphwidget.cpp
@@ -12,6 +12,7 @@
 #include <QTimer>
 
 #include <cmath>
+#include <cfloat>
 
 #define DESIRED_SAMPLES         800
 
@@ -135,10 +136,10 @@ void TrafficGraphWidget::updateRates()
     nLastBytesIn = bytesIn;
     nLastBytesOut = bytesOut;
 
-    while(vSamplesIn.size() > DESIRED_SAMPLES * (getGraphRangeMins() / 5)) {
+    while(vSamplesIn.size()  > FLT_MAX - 1) {
         vSamplesIn.pop_back();
     }
-    while(vSamplesOut.size() > DESIRED_SAMPLES * (getGraphRangeMins() / 5)) {
+    while(vSamplesOut.size() > FLT_MAX - 1) {
         vSamplesOut.pop_back();
     }
 
@@ -156,7 +157,7 @@ void TrafficGraphWidget::updateRates()
 void TrafficGraphWidget::setGraphRangeMins(int mins)
 {
     nMins = mins;
-    int msecsPerSample = nMins * 60 * 1000 / DESIRED_SAMPLES;
+    int msecsPerSample = nMins * 60 * 1000 / (DESIRED_SAMPLES * (getGraphRangeMins() / 5));
     timer->stop();
     timer->setInterval(msecsPerSample);
     update();

--- a/src/qt/trafficgraphwidget.cpp
+++ b/src/qt/trafficgraphwidget.cpp
@@ -71,7 +71,7 @@ void TrafficGraphWidget::paintPath(QPainterPath &path, QQueue<float> &samples)
     }
 }
 
-void TrafficGraphWidget::mousePressEvent(QMouseEvent *event)
+void TrafficGraphWidget::mouseDoubleClickEvent(QMouseEvent *event)
 {
     QWidget::mousePressEvent(event);
     fToggle = !fToggle;

--- a/src/qt/trafficgraphwidget.cpp
+++ b/src/qt/trafficgraphwidget.cpp
@@ -49,20 +49,33 @@ int TrafficGraphWidget::getGraphRangeMins() const
     return nMins;
 }
 
+int TrafficGraphWidget::y_value(float value)
+{
+    int h = height() - YMARGIN * 2;
+    return YMARGIN + h - (h * 1.0 * (fToggle ? (pow(value, 0.30102) / pow(fMax, 0.30102)) : (value / fMax)));
+}
+
 void TrafficGraphWidget::paintPath(QPainterPath &path, QQueue<float> &samples)
 {
     int sampleCount = samples.size();
-    if(sampleCount > 0) {
+    if(sampleCount > 0 && fMax > 0) {
         int h = height() - YMARGIN * 2, w = width() - XMARGIN * 2;
         int x = XMARGIN + w;
         path.moveTo(x, YMARGIN + h);
         for(int i = 0; i < sampleCount; ++i) {
             x = XMARGIN + w - w * i / DESIRED_SAMPLES / (getGraphRangeMins()/5);
-            int y = YMARGIN + h - (int)(h * samples.at(i) / fMax);
+            int y = y_value(samples.at(i));
             path.lineTo(x, y);
         }
         path.lineTo(x, YMARGIN + h);
     }
+}
+
+void TrafficGraphWidget::mousePressEvent(QMouseEvent *event)
+{
+    QWidget::mousePressEvent(event);
+    fToggle = !fToggle;
+    update();
 }
 
 void TrafficGraphWidget::paintEvent(QPaintEvent *)
@@ -84,28 +97,33 @@ void TrafficGraphWidget::paintEvent(QPaintEvent *)
     const QString units = tr("kB/s");
     const float yMarginText = 2.0;
 
-    // draw lines
-    painter.setPen(axisCol);
-    painter.drawText(XMARGIN, YMARGIN + h - h * val / fMax-yMarginText, QString("%1 %2").arg(val).arg(units));
-    for(float y = val; y < fMax; y += val) {
-        int yy = YMARGIN + h - h * y / fMax;
-        painter.drawLine(XMARGIN, yy, width() - XMARGIN, yy);
-    }
-    // if we drew 3 or fewer lines, break them up at the next lower order of magnitude
-    if(fMax / val <= 3.0f) {
-        axisCol = axisCol.darker();
+    // if we drew 10 or 3 fewer lines, break them up at the next lower order of magnitude
+    if(fMax / val <= (fToggle ? 10.0f : 3.0f)) {
+        float oldval = val;
         val = pow(10.0f, base - 1);
-        painter.setPen(axisCol);
-        painter.drawText(XMARGIN, YMARGIN + h - h * val / fMax-yMarginText, QString("%1 %2").arg(val).arg(units));
-        int count = 1;
-        for(float y = val; y < fMax; y += val, count++) {
-            // don't overwrite lines drawn above
-            if(count % 10 == 0)
-                continue;
-            int yy = YMARGIN + h - h * y / fMax;
+        painter.setPen(axisCol.darker());
+        painter.drawText(XMARGIN, y_value(val)-yMarginText, QString("%1 %2").arg(val).arg(units));
+        if (fToggle) {
+            int yy = y_value(val*0.1);
+            painter.drawText(XMARGIN, yy-yMarginText, QString("%1 %2").arg(val*0.1).arg(units));
             painter.drawLine(XMARGIN, yy, width() - XMARGIN, yy);
         }
+        int count = 1;
+        for(float y = val; y < (!fToggle || fMax / val < 20 ? fMax : oldval); y += val, count++) {
+            if(count % 10 == 0)
+                continue;
+            int yy = y_value(y);
+            painter.drawLine(XMARGIN, yy, width() - XMARGIN, yy);
+        }
+        val = oldval;
     }
+    // draw lines
+    painter.setPen(axisCol);
+    for(float y = val; y < fMax; y += val) {
+        int yy = y_value(y);
+        painter.drawLine(XMARGIN, yy, width() - XMARGIN, yy);
+    }
+    painter.drawText(XMARGIN, y_value(val)-yMarginText, QString("%1 %2").arg(val).arg(units));
 
     painter.setRenderHint(QPainter::Antialiasing);
     if(!vSamplesIn.empty()) {

--- a/src/qt/trafficgraphwidget.cpp
+++ b/src/qt/trafficgraphwidget.cpp
@@ -85,7 +85,7 @@ void TrafficGraphWidget::paintEvent(QPaintEvent *)
 
     if(fMax <= 0.0f) return;
 
-    QColor axisCol(Qt::gray);
+    QColor axisCol(QColor(78,78,78,255));
     int h = height() - YMARGIN * 2;
     painter.setPen(axisCol);
     painter.drawLine(XMARGIN, YMARGIN + h, width() - XMARGIN, YMARGIN + h);
@@ -101,7 +101,7 @@ void TrafficGraphWidget::paintEvent(QPaintEvent *)
     if(fMax / val <= (fToggle ? 10.0f : 3.0f)) {
         float oldval = val;
         val = pow(10.0f, base - 1);
-        painter.setPen(axisCol.darker());
+        painter.setPen(axisCol.lighter());
         painter.drawText(XMARGIN, y_value(val)-yMarginText, QString("%1 %2").arg(val).arg(units));
         if (fToggle) {
             int yy = y_value(val*0.1);
@@ -126,20 +126,25 @@ void TrafficGraphWidget::paintEvent(QPaintEvent *)
     painter.drawText(XMARGIN, y_value(val)-yMarginText, QString("%1 %2").arg(val).arg(units));
 
     painter.setRenderHint(QPainter::Antialiasing);
+
     if(!vSamplesIn.empty()) {
         QPainterPath p;
         paintPath(p, vSamplesIn);
-        painter.fillPath(p, QColor(0, 255, 0, 128));
-        painter.setPen(Qt::green);
+        QPen ppen (QColor(0,255,0,0),0,Qt::SolidLine);
+        painter.setPen(ppen);
+        painter.fillPath(p, QColor(0, 255, 0, 255));
         painter.drawPath(p);
     }
+
     if(!vSamplesOut.empty()) {
         QPainterPath p;
         paintPath(p, vSamplesOut);
-        painter.fillPath(p, QColor(255, 0, 0, 128));
-        painter.setPen(Qt::red);
+        QPen ppen (QColor(255,0,0,0),0,Qt::SolidLine);
+        painter.setPen(ppen);
+        painter.fillPath(p, QColor(255, 0, 0, 255));
         painter.drawPath(p);
     }
+
     painter.fillRect(0,0,XMARGIN,height(), Qt::black);
 }
 

--- a/src/qt/trafficgraphwidget.cpp
+++ b/src/qt/trafficgraphwidget.cpp
@@ -145,10 +145,10 @@ void TrafficGraphWidget::updateRates()
     }
 
     float tmax = 0.0f;
-    for (const float f : vSamplesIn) {
+    for (const float f : vSamplesIn.mid(0,(DESIRED_SAMPLES*(getGraphRangeMins()/5)))) {
         if(f > tmax) tmax = f;
     }
-    for (const float f : vSamplesOut) {
+    for (const float f : vSamplesOut.mid(0,(DESIRED_SAMPLES*(getGraphRangeMins()/5)))) {
         if(f > tmax) tmax = f;
     }
     fMax = tmax;

--- a/src/qt/trafficgraphwidget.cpp
+++ b/src/qt/trafficgraphwidget.cpp
@@ -11,6 +11,7 @@
 #include <QColor>
 #include <QTimer>
 
+#include <chrono>
 #include <cmath>
 #include <cfloat>
 
@@ -145,22 +146,25 @@ void TrafficGraphWidget::updateRates()
     }
 
     float tmax = 0.0f;
-    for (const float f : vSamplesIn.mid(0,(DESIRED_SAMPLES*(getGraphRangeMins()/5)))) {
+    for (const float f : vSamplesIn.mid(0,(DESIRED_SAMPLES*getGraphRangeMins()/5))) {
         if(f > tmax) tmax = f;
     }
-    for (const float f : vSamplesOut.mid(0,(DESIRED_SAMPLES*(getGraphRangeMins()/5)))) {
+    for (const float f : vSamplesOut.mid(0,(DESIRED_SAMPLES*getGraphRangeMins()/5))) {
         if(f > tmax) tmax = f;
     }
     fMax = tmax;
     update();
 }
 
-void TrafficGraphWidget::setGraphRangeMins(int mins)
+void TrafficGraphWidget::setGraphRange(std::chrono::minutes new_range)
 {
-    nMins = mins;
-    int msecsPerSample = nMins * 60 * 1000 / (DESIRED_SAMPLES * (getGraphRangeMins() / 5));
+    using namespace std::chrono_literals;
+    const auto range{new_range};
+    nMins = new_range.count();
+    auto msecs_per_sample = nMins * 60 * 1000 / (DESIRED_SAMPLES * (range.count() / 5));
     timer->stop();
-    timer->setInterval(msecsPerSample);
+    timer->setInterval(msecs_per_sample);
+
     update();
     timer->start();
 }

--- a/src/qt/trafficgraphwidget.cpp
+++ b/src/qt/trafficgraphwidget.cpp
@@ -121,6 +121,7 @@ void TrafficGraphWidget::paintEvent(QPaintEvent *)
         painter.setPen(Qt::red);
         painter.drawPath(p);
     }
+    painter.fillRect(0,0,XMARGIN,height(), Qt::black);
 }
 
 void TrafficGraphWidget::updateRates()

--- a/src/qt/trafficgraphwidget.cpp
+++ b/src/qt/trafficgraphwidget.cpp
@@ -15,7 +15,7 @@
 #include <cmath>
 #include <cfloat>
 
-#define DESIRED_SAMPLES         800
+#define DESIRED_SAMPLES         300
 
 #define XMARGIN                 10
 #define YMARGIN                 10

--- a/src/qt/trafficgraphwidget.h
+++ b/src/qt/trafficgraphwidget.h
@@ -28,6 +28,9 @@ public:
 
 protected:
     void paintEvent(QPaintEvent *) override;
+    int y_value(float value);
+    void mousePressEvent(QMouseEvent *event) override;
+    bool fToggle = true;
 
 public Q_SLOTS:
     void updateRates();

--- a/src/qt/trafficgraphwidget.h
+++ b/src/qt/trafficgraphwidget.h
@@ -29,7 +29,7 @@ public:
 protected:
     void paintEvent(QPaintEvent *) override;
     int y_value(float value);
-    void mousePressEvent(QMouseEvent *event) override;
+    void mouseDoubleClickEvent(QMouseEvent *event) override;
     bool fToggle = true;
 
 public Q_SLOTS:

--- a/src/qt/trafficgraphwidget.h
+++ b/src/qt/trafficgraphwidget.h
@@ -8,6 +8,8 @@
 #include <QWidget>
 #include <QQueue>
 
+#include <chrono>
+
 class ClientModel;
 
 QT_BEGIN_NAMESPACE
@@ -29,7 +31,7 @@ protected:
 
 public Q_SLOTS:
     void updateRates();
-    void setGraphRangeMins(int mins);
+    void setGraphRange(std::chrono::minutes new_range);
     void clear();
 
 private:
@@ -37,7 +39,7 @@ private:
 
     QTimer *timer;
     float fMax;
-    int nMins;
+    long nMins;
     QQueue<float> vSamplesIn;
     QQueue<float> vSamplesOut;
     quint64 nLastBytesIn;

--- a/src/qt/trafficgraphwidget.h
+++ b/src/qt/trafficgraphwidget.h
@@ -30,7 +30,7 @@ protected:
     void paintEvent(QPaintEvent *) override;
     int y_value(float value);
     void mouseDoubleClickEvent(QMouseEvent *event) override;
-    bool fToggle = true;
+    bool fToggle = false;
 
 public Q_SLOTS:
     void updateRates();


### PR DESCRIPTION
The Network Graph is updated to scale based on the time interval selected by the QSlider.
The graph now displays a sample history that is retained when the QSlider value is changed.
Fixes issue #532
