### PR TITLE
Override BitcoinApplication::event() to handle QEvent::Quit

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -450,6 +450,16 @@ WId BitcoinApplication::getMainWinId() const
     return window->winId();
 }
 
+bool BitcoinApplication::event(QEvent* e)
+{
+    if (e->type() == QEvent::Quit) {
+        requestShutdown();
+        return true;
+    }
+
+    return QApplication::event(e);
+}
+
 static void SetupUIArgs(ArgsManager& argsman)
 {
     argsman.AddArg("-choosedatadir", strprintf("Choose data directory on startup (default: %u)", DEFAULT_CHOOSE_DATADIR), ArgsManager::ALLOW_ANY, OptionsCategory::GUI);

--- a/src/qt/bitcoin.h
+++ b/src/qt/bitcoin.h
@@ -92,6 +92,9 @@ Q_SIGNALS:
     void splashFinished();
     void windowShown(BitcoinGUI* window);
 
+protected:
+    bool event(QEvent* e) override;
+
 private:
     std::optional<InitExecutor> m_executor;
     OptionsModel *optionsModel;


### PR DESCRIPTION
bitcoin-core/gui#336 introduced a regression when termination requests from a platform are not handled properly.

This PR fixes this regression. On macOS shutdown after clicking "Quit" in Dock icon menu, and during logout works again.

Fixes bitcoin-core/gui#545.