### PR TITLE
Refactor `TransactionDesc::FormatTxStatus` and ` TransactionStatus`

### DIFF
--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -34,16 +34,16 @@ using wallet::isminetype;
 
 QString TransactionDesc::FormatTxStatus(const interfaces::WalletTx& wtx, const interfaces::WalletTxStatus& status, bool inMempool, int numBlocks)
 {
-    int nDepth = status.depth_in_main_chain;
-    if (nDepth < 0) {
-        return tr("conflicted with a transaction with %1 confirmations").arg(-nDepth);
-    } else if (nDepth == 0) {
+    int depth = status.depth_in_main_chain;
+    if (depth < 0) {
+        return tr("conflicted with a transaction with %1 confirmations").arg(-depth);
+    } else if (depth == 0) {
         const QString abandoned{status.is_abandoned ? QLatin1String(", ") + tr("abandoned") : QString()};
         return tr("0/unconfirmed, %1").arg(inMempool ? tr("in memory pool") : tr("not in memory pool")) + abandoned;
-    } else if (nDepth < 6) {
-        return tr("%1/unconfirmed").arg(nDepth);
+    } else if (depth < 6) {
+        return tr("%1/unconfirmed").arg(depth);
     } else {
-        return tr("%1 confirmations").arg(nDepth);
+        return tr("%1 confirmations").arg(depth);
     }
 }
 

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -34,18 +34,16 @@ using wallet::isminetype;
 
 QString TransactionDesc::FormatTxStatus(const interfaces::WalletTx& wtx, const interfaces::WalletTxStatus& status, bool inMempool, int numBlocks)
 {
-    {
-        int nDepth = status.depth_in_main_chain;
-        if (nDepth < 0) {
-            return tr("conflicted with a transaction with %1 confirmations").arg(-nDepth);
-        } else if (nDepth == 0) {
-            const QString abandoned{status.is_abandoned ? QLatin1String(", ") + tr("abandoned") : QString()};
-            return tr("0/unconfirmed, %1").arg(inMempool ? tr("in memory pool") : tr("not in memory pool")) + abandoned;
-        } else if (nDepth < 6) {
-            return tr("%1/unconfirmed").arg(nDepth);
-        } else {
-            return tr("%1 confirmations").arg(nDepth);
-        }
+    int nDepth = status.depth_in_main_chain;
+    if (nDepth < 0) {
+        return tr("conflicted with a transaction with %1 confirmations").arg(-nDepth);
+    } else if (nDepth == 0) {
+        const QString abandoned{status.is_abandoned ? QLatin1String(", ") + tr("abandoned") : QString()};
+        return tr("0/unconfirmed, %1").arg(inMempool ? tr("in memory pool") : tr("not in memory pool")) + abandoned;
+    } else if (nDepth < 6) {
+        return tr("%1/unconfirmed").arg(nDepth);
+    } else {
+        return tr("%1 confirmations").arg(nDepth);
     }
 }
 

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -32,7 +32,7 @@ using wallet::ISMINE_SPENDABLE;
 using wallet::ISMINE_WATCH_ONLY;
 using wallet::isminetype;
 
-QString TransactionDesc::FormatTxStatus(const interfaces::WalletTx& wtx, const interfaces::WalletTxStatus& status, bool inMempool, int numBlocks)
+QString TransactionDesc::FormatTxStatus(const interfaces::WalletTxStatus& status, bool inMempool)
 {
     int depth = status.depth_in_main_chain;
     if (depth < 0) {
@@ -93,7 +93,7 @@ QString TransactionDesc::toHTML(interfaces::Node& node, interfaces::Wallet& wall
     CAmount nDebit = wtx.debit;
     CAmount nNet = nCredit - nDebit;
 
-    strHTML += "<b>" + tr("Status") + ":</b> " + FormatTxStatus(wtx, status, inMempool, numBlocks);
+    strHTML += "<b>" + tr("Status") + ":</b> " + FormatTxStatus(status, inMempool);
     strHTML += "<br>";
 
     strHTML += "<b>" + tr("Date") + ":</b> " + (nTime ? GUIUtil::dateTimeStr(nTime) : "") + "<br>";

--- a/src/qt/transactiondesc.h
+++ b/src/qt/transactiondesc.h
@@ -29,7 +29,7 @@ public:
 private:
     TransactionDesc() {}
 
-    static QString FormatTxStatus(const interfaces::WalletTx& wtx, const interfaces::WalletTxStatus& status, bool inMempool, int numBlocks);
+    static QString FormatTxStatus(const interfaces::WalletTxStatus& status, bool inMempool);
 };
 
 #endif // BITCOIN_QT_TRANSACTIONDESC_H

--- a/src/qt/transactionrecord.h
+++ b/src/qt/transactionrecord.h
@@ -53,9 +53,6 @@ public:
        @{*/
     Status status;
     qint64 depth;
-    qint64 open_for; /**< Timestamp if status==OpenUntilDate, otherwise number
-                      of additional blocks that need to be mined before
-                      finalization */
     /**@}*/
 
     /** Current block hash (to know whether cached status is still valid) */

--- a/src/qt/transactionrecord.h
+++ b/src/qt/transactionrecord.h
@@ -20,13 +20,7 @@ struct WalletTxStatus;
 
 /** UI model for transaction status. The transaction status is the part of a transaction that will change over time.
  */
-class TransactionStatus
-{
-public:
-    TransactionStatus() : countsForBalance(false), sortKey(""),
-                          matures_in(0), status(Unconfirmed), depth(0), open_for(0)
-    { }
-
+struct TransactionStatus {
     enum Status {
         Confirmed,          /**< Have 6 or more confirmations (normal tx) or fully mature (mined tx) **/
         /// Normal (sent/received) transactions
@@ -40,25 +34,25 @@ public:
     };
 
     /// Transaction counts towards available balance
-    bool countsForBalance;
+    bool countsForBalance{false};
     /// Sorting key based on status
     std::string sortKey;
 
     /** @name Generated (mined) transactions
        @{*/
-    int matures_in;
+    int matures_in{0};
     /**@}*/
 
     /** @name Reported status
        @{*/
-    Status status;
-    qint64 depth;
+    Status status{Unconfirmed};
+    qint64 depth{0};
     /**@}*/
 
     /** Current block hash (to know whether cached status is still valid) */
     uint256 m_cur_block_hash{};
 
-    bool needsUpdate;
+    bool needsUpdate{false};
 };
 
 /** UI model for a transaction. A core transaction can be represented by multiple UI transactions if it has


### PR DESCRIPTION
This PR implements the changes suggested in https://github.com/bitcoin-core/gui/issues/538#issuecomment-1021913294 .

. remove redundant scope, rename `nDepth` -> `depth`, remove unused parameters and add translator comments in `TransactionDesc::FormatTxStatus()`
.  Use member initializers and remove unused field `qint64 TransactionStatus::open_for` in `TransactionStatus`.

Closes https://github.com/bitcoin-core/gui/issues/538