### PR TITLE
Revert "qt: Do not use QObject::tr plural syntax for numbers with a unit symbol"

### DIFF
--- a/src/qt/intro.cpp
+++ b/src/qt/intro.cpp
@@ -298,12 +298,12 @@ void Intro::setStatus(int status, const QString &message, quint64 bytesAvailable
 
 void Intro::UpdateFreeSpaceLabel()
 {
-    QString freeString = tr("%1 GB of space available").arg(m_bytes_available / GB_BYTES);
+    QString freeString = tr("%n GB of space available", "", m_bytes_available / GB_BYTES);
     if (m_bytes_available < m_required_space_gb * GB_BYTES) {
-        freeString += " " + tr("(of %1 GB needed)").arg(m_required_space_gb);
+        freeString += " " + tr("(of %n GB needed)", "", m_required_space_gb);
         ui->freeSpace->setStyleSheet("QLabel { color: #800000 }");
     } else if (m_bytes_available / GB_BYTES - m_required_space_gb < 10) {
-        freeString += " " + tr("(%1 GB needed for full chain)").arg(m_required_space_gb);
+        freeString += " " + tr("(%n GB needed for full chain)", "", m_required_space_gb);
         ui->freeSpace->setStyleSheet("QLabel { color: #999900 }");
     } else {
         ui->freeSpace->setStyleSheet("");


### PR DESCRIPTION
Apparently this got forgotten. Maybe too late for 23.x (it's a bugfix, but changes translation strings).

This reverts commit 3adde72bc99215062c8dabd38f8c34ad093452b5 (#296)

per [GChuf](https://github.com/bitcoin-core/gui/pull/296#issuecomment-962516055)

>I can confirm for slovenian and other slavic languages that we do have 3 or 4 different ways of saying "%n GB needed%, depending on the actual number of gigabytes. Similar to english "is/are". There's no way to cover all cases ... this is exactly why transifex allows you to have more than 2 options.