### PR TITLE
Make error message layout consistent

### DIFF
--- a/src/qt/editaddressdialog.cpp
+++ b/src/qt/editaddressdialog.cpp
@@ -3,9 +3,10 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <qt/editaddressdialog.h>
-#include <qt/forms/ui_editaddressdialog.h>
 
+#include <key_io.h>
 #include <qt/addresstablemodel.h>
+#include <qt/forms/ui_editaddressdialog.h>
 #include <qt/guiutil.h>
 
 #include <QDataWidgetMapper>
@@ -43,6 +44,8 @@ EditAddressDialog::EditAddressDialog(Mode _mode, QWidget *parent) :
     GUIUtil::ItemDelegate* delegate = new GUIUtil::ItemDelegate(mapper);
     connect(delegate, &GUIUtil::ItemDelegate::keyEscapePressed, this, &EditAddressDialog::reject);
     mapper->setItemDelegate(delegate);
+
+    connect(ui->addressEdit, &QValidatedLineEdit::textEdited, this, &EditAddressDialog::addressEdited);
 
     GUIUtil::handleCloseWindowShortcut(this);
 }
@@ -163,4 +166,16 @@ void EditAddressDialog::setAddress(const QString &_address)
 {
     this->address = _address;
     ui->addressEdit->setText(_address);
+}
+
+// Address changed
+void EditAddressDialog::addressEdited(const QString& address)
+{
+    ui->addressErrorLabel->setStyleSheet("QLabel{color:red;}");
+
+    if (!address.isEmpty() && !IsValidDestination(DecodeDestination(address.toStdString()))) {
+        ui->addressErrorLabel->setText(tr("Warning: Invalid Bitcoin address"));
+    } else {
+        ui->addressErrorLabel->setText("");
+    }
 }

--- a/src/qt/editaddressdialog.h
+++ b/src/qt/editaddressdialog.h
@@ -42,6 +42,9 @@ public:
 public Q_SLOTS:
     void accept() override;
 
+private Q_SLOTS:
+    void addressEdited(const QString& address);
+
 private:
     bool saveCurrentRow();
 

--- a/src/qt/forms/editaddressdialog.ui
+++ b/src/qt/forms/editaddressdialog.ui
@@ -13,49 +13,49 @@
   <property name="windowTitle">
    <string>Edit Address</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
-   <item>
-    <layout class="QFormLayout" name="formLayout">
-     <property name="fieldGrowthPolicy">
-      <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="0">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>&amp;Label</string>
      </property>
-     <item row="0" column="0">
-      <widget class="QLabel" name="label">
-       <property name="text">
-        <string>&amp;Label</string>
-       </property>
-       <property name="buddy">
-        <cstring>labelEdit</cstring>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="1">
-      <widget class="QLineEdit" name="labelEdit">
-       <property name="toolTip">
-        <string>The label associated with this address list entry</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="0">
-      <widget class="QLabel" name="label_2">
-       <property name="text">
-        <string>&amp;Address</string>
-       </property>
-       <property name="buddy">
-        <cstring>addressEdit</cstring>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="1">
-      <widget class="QValidatedLineEdit" name="addressEdit">
-       <property name="toolTip">
-        <string>The address associated with this address list entry. This can only be modified for sending addresses.</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
+     <property name="buddy">
+      <cstring>labelEdit</cstring>
+     </property>
+    </widget>
    </item>
-   <item>
+   <item row="0" column="1" colspan="2">
+    <widget class="QLineEdit" name="labelEdit">
+     <property name="toolTip">
+      <string>The label associated with this address list entry</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>&amp;Address</string>
+     </property>
+     <property name="buddy">
+      <cstring>addressEdit</cstring>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="QValidatedLineEdit" name="addressEdit">
+     <property name="toolTip">
+      <string>The address associated with this address list entry. This can only be modified for sending addresses.</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="2">
+    <widget class="QLabel" name="addressErrorLabel">
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0" colspan="3">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>

--- a/src/qt/forms/sendcoinsentry.ui
+++ b/src/qt/forms/sendcoinsentry.ui
@@ -55,6 +55,16 @@
        <widget class="QValidatedLineEdit" name="payTo">
         <property name="toolTip">
          <string>The Bitcoin address to send the payment to</string>
+         </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="PayToLabel">
+        <property name="text">
+         <string/>
+        </property>
+        <property name="margin">
+         <number>2</number>
         </property>
        </widget>
       </item>

--- a/src/qt/sendcoinsentry.cpp
+++ b/src/qt/sendcoinsentry.cpp
@@ -7,10 +7,11 @@
 #endif
 
 #include <qt/sendcoinsentry.h>
-#include <qt/forms/ui_sendcoinsentry.h>
 
+#include <key_io.h>
 #include <qt/addressbookpage.h>
 #include <qt/addresstablemodel.h>
+#include <qt/forms/ui_sendcoinsentry.h>
 #include <qt/guiutil.h>
 #include <qt/optionsmodel.h>
 #include <qt/platformstyle.h>
@@ -50,6 +51,7 @@ SendCoinsEntry::SendCoinsEntry(const PlatformStyle *_platformStyle, QWidget *par
     connect(ui->deleteButton_is, &QPushButton::clicked, this, &SendCoinsEntry::deleteClicked);
     connect(ui->deleteButton_s, &QPushButton::clicked, this, &SendCoinsEntry::deleteClicked);
     connect(ui->useAvailableBalanceButton, &QPushButton::clicked, this, &SendCoinsEntry::useAvailableBalanceClicked);
+    connect(ui->payTo, &QValidatedLineEdit::textEdited, this, &SendCoinsEntry::addressEdited);
 }
 
 SendCoinsEntry::~SendCoinsEntry()
@@ -265,4 +267,16 @@ bool SendCoinsEntry::updateLabel(const QString &address)
     }
 
     return false;
+}
+
+// Address changed
+void SendCoinsEntry::addressEdited(const QString& address)
+{
+    ui->PayToLabel->setStyleSheet("QLabel{color:red;}");
+
+    if (!address.isEmpty() && !IsValidDestination(DecodeDestination(address.toStdString()))) {
+        ui->PayToLabel->setText(tr("Warning: Invalid Bitcoin address"));
+    } else {
+        ui->PayToLabel->setText("");
+    }
 }

--- a/src/qt/sendcoinsentry.h
+++ b/src/qt/sendcoinsentry.h
@@ -68,6 +68,7 @@ private Q_SLOTS:
     void on_addressBookButton_clicked();
     void on_pasteButton_clicked();
     void updateDisplayUnit();
+    void addressEdited(const QString& address);
 
 protected:
     void changeEvent(QEvent* e) override;


### PR DESCRIPTION
Currently, the error message for invalid change address is displayed on the right while in the "Pay to" and "Address" fields do not show the error message, as commented in https://github.com/bitcoin-core/gui/pull/553#issuecomment-1047306976.

This PR makes the address error feedback consistent across all fields.

Supersede https://github.com/bitcoin-core/gui/pull/534

master |
--- |
![master_pay_to](https://user-images.githubusercontent.com/94266259/155827874-dc9aa1de-633b-4aca-87e2-55316a8ea9d2.png) |
![master_addr_edit](https://user-images.githubusercontent.com/94266259/155827873-7f5f016c-089c-4039-a137-9d32ab70803f.png) |

PR |
--- |
![pr_pay_to](https://user-images.githubusercontent.com/94266259/155827893-9da2092e-eced-4a2c-a606-1423c43e305a.png) |
<img width="524" alt="pr_addr_edit" src="https://user-images.githubusercontent.com/94266259/155827989-837ccafc-b7da-4c73-89ff-148fbb09ca39.png"> |

