### PR TITLE
Remove unnecessary validation

### DIFF
--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -263,7 +263,7 @@ bool SendCoinsDialog::PrepareSendText(QString& question_string, QString& informa
             {
                 recipients.append(entry->getValue());
             }
-            else if (valid)
+            else
             {
                 ui->scrollArea->ensureWidgetVisible(entry);
                 valid = false;


### PR DESCRIPTION
`if (valid)` validation in line 266 seems unnecessary.
`valid` is initialized as `true` in line 255 and is still unchanged when line 266 is reached.