### PR TITLE
qt: Equalize notifySystray and notifyDBus interface

### DIFF
--- a/src/qt/notificator.cpp
+++ b/src/qt/notificator.cpp
@@ -147,6 +147,27 @@ QVariant FreedesktopImage::toVariant(const QImage &img)
     return QVariant(FreedesktopImage::metaType(), &fimg);
 }
 
+/** If no icon specified, return default icon based on class. */
+static QIcon defaultIconForClass(Notificator::Class cls, const QIcon &icon)
+{
+    if(icon.isNull())
+    {
+        QStyle::StandardPixmap sicon = QStyle::SP_MessageBoxQuestion;
+        switch(cls)
+        {
+        case Notificator::Information: sicon = QStyle::SP_MessageBoxInformation; break;
+        case Notificator::Warning: sicon = QStyle::SP_MessageBoxWarning; break;
+        case Notificator::Critical: sicon = QStyle::SP_MessageBoxCritical; break;
+        default: break;
+        }
+        return QApplication::style()->standardIcon(sicon);
+    }
+    else
+    {
+        return icon;
+    }
+}
+
 void Notificator::notifyDBus(Class cls, const QString &title, const QString &text, const QIcon &icon, int millisTimeout)
 {
     // https://developer.gnome.org/notification-spec/
@@ -175,24 +196,8 @@ void Notificator::notifyDBus(Class cls, const QString &title, const QString &tex
     // Hints
     QVariantMap hints;
 
-    // If no icon specified, set icon based on class
-    QIcon tmpicon;
-    if(icon.isNull())
-    {
-        QStyle::StandardPixmap sicon = QStyle::SP_MessageBoxQuestion;
-        switch(cls)
-        {
-        case Information: sicon = QStyle::SP_MessageBoxInformation; break;
-        case Warning: sicon = QStyle::SP_MessageBoxWarning; break;
-        case Critical: sicon = QStyle::SP_MessageBoxCritical; break;
-        default: break;
-        }
-        tmpicon = QApplication::style()->standardIcon(sicon);
-    }
-    else
-    {
-        tmpicon = icon;
-    }
+    // Icon
+    QIcon tmpicon = defaultIconForClass(cls, icon);
     hints["icon_data"] = FreedesktopImage::toVariant(tmpicon.pixmap(FREEDESKTOP_NOTIFICATION_ICON_SIZE).toImage());
     args.append(hints);
 
@@ -204,16 +209,9 @@ void Notificator::notifyDBus(Class cls, const QString &title, const QString &tex
 }
 #endif
 
-void Notificator::notifySystray(Class cls, const QString &title, const QString &text, int millisTimeout)
+void Notificator::notifySystray(Class cls, const QString &title, const QString &text, const QIcon &icon, int millisTimeout)
 {
-    QSystemTrayIcon::MessageIcon sicon = QSystemTrayIcon::NoIcon;
-    switch(cls) // Set icon based on class
-    {
-    case Information: sicon = QSystemTrayIcon::Information; break;
-    case Warning: sicon = QSystemTrayIcon::Warning; break;
-    case Critical: sicon = QSystemTrayIcon::Critical; break;
-    }
-    trayIcon->showMessage(title, text, sicon, millisTimeout);
+    trayIcon->showMessage(title, text, defaultIconForClass(cls, icon), millisTimeout);
 }
 
 #ifdef Q_OS_MAC
@@ -234,7 +232,7 @@ void Notificator::notify(Class cls, const QString &title, const QString &text, c
         break;
 #endif
     case QSystemTray:
-        notifySystray(cls, title, text, millisTimeout);
+        notifySystray(cls, title, text, icon, millisTimeout);
         break;
 #ifdef Q_OS_MAC
     case UserNotificationCenter:

--- a/src/qt/notificator.h
+++ b/src/qt/notificator.h
@@ -68,7 +68,7 @@ private:
 
     void notifyDBus(Class cls, const QString &title, const QString &text, const QIcon &icon, int millisTimeout);
 #endif
-    void notifySystray(Class cls, const QString &title, const QString &text, int millisTimeout);
+    void notifySystray(Class cls, const QString &title, const QString &text, const QIcon &icon, int millisTimeout);
 #ifdef Q_OS_MAC
     void notifyMacUserNotificationCenter(const QString &title, const QString &text);
 #endif


### PR DESCRIPTION
Make `notifySystray` and `notifyDBus` feature-equivalent by making `notifySystray` support custom icons. This uses the `QSystemTrayIcon::showMessage` overload introduced in Qt 5.9.

This is an initial step towards bitcoin-core/gui#573.