### PR TITLE
Add qt unit test runner summary

### DIFF
--- a/src/qt/test/test_main.cpp
+++ b/src/qt/test/test_main.cpp
@@ -21,8 +21,10 @@
 #endif // ENABLE_WALLET
 
 #include <QApplication>
+#include <QDebug>
 #include <QObject>
 #include <QTest>
+
 #include <functional>
 
 #if defined(QT_STATICPLUGIN)
@@ -113,5 +115,10 @@ int main(int argc, char* argv[])
     }
 #endif
 
+    if (fInvalid) {
+        qWarning("\nThere were errors in some of the tests above.\n");
+    } else {
+        qDebug("\nAll tests passed.\n");
+    }
     return fInvalid;
 }

--- a/src/qt/test/test_main.cpp
+++ b/src/qt/test/test_main.cpp
@@ -86,32 +86,32 @@ int main(int argc, char* argv[])
     app.setApplicationName("Bitcoin-Qt-test");
     app.createNode(*init);
 
-    int fInvalid{0};
+    int num_test_failures{0};
 
     AppTests app_tests(app);
-    fInvalid += QTest::qExec(&app_tests);
+    num_test_failures += QTest::qExec(&app_tests);
 
     OptionTests options_tests(app.node());
-    fInvalid += QTest::qExec(&options_tests);
+    num_test_failures += QTest::qExec(&options_tests);
 
     URITests test1;
-    fInvalid += QTest::qExec(&test1);
+    num_test_failures += QTest::qExec(&test1);
 
     RPCNestedTests test3(app.node());
-    fInvalid += QTest::qExec(&test3);
+    num_test_failures += QTest::qExec(&test3);
 
 #ifdef ENABLE_WALLET
     WalletTests test5(app.node());
-    fInvalid += QTest::qExec(&test5);
+    num_test_failures += QTest::qExec(&test5);
 
     AddressBookTests test6(app.node());
-    fInvalid += QTest::qExec(&test6);
+    num_test_failures += QTest::qExec(&test6);
 #endif
 
-    if (fInvalid) {
-        qWarning("\nFailed tests: %d\n", fInvalid);
+    if (num_test_failures) {
+        qWarning("\nFailed tests: %d\n", num_test_failures);
     } else {
         qDebug("\nAll tests passed.\n");
     }
-    return fInvalid;
+    return num_test_failures;
 }

--- a/src/qt/test/test_main.cpp
+++ b/src/qt/test/test_main.cpp
@@ -71,8 +71,6 @@ int main(int argc, char* argv[])
     gArgs.ForceSetArg("-upnp", "0");
     gArgs.ForceSetArg("-natpmp", "0");
 
-    bool fInvalid = false;
-
     // Prefer the "minimal" platform for the test instead of the normal default
     // platform ("xcb", "windows", or "cocoa") so tests can't unintentionally
     // interfere with any background GUIs and don't require extra resources.
@@ -88,35 +86,30 @@ int main(int argc, char* argv[])
     app.setApplicationName("Bitcoin-Qt-test");
     app.createNode(*init);
 
+    int fInvalid{0};
+
     AppTests app_tests(app);
-    if (QTest::qExec(&app_tests) != 0) {
-        fInvalid = true;
-    }
+    fInvalid += QTest::qExec(&app_tests);
+
     OptionTests options_tests(app.node());
-    if (QTest::qExec(&options_tests) != 0) {
-        fInvalid = true;
-    }
+    fInvalid += QTest::qExec(&options_tests);
+
     URITests test1;
-    if (QTest::qExec(&test1) != 0) {
-        fInvalid = true;
-    }
+    fInvalid += QTest::qExec(&test1);
+
     RPCNestedTests test3(app.node());
-    if (QTest::qExec(&test3) != 0) {
-        fInvalid = true;
-    }
+    fInvalid += QTest::qExec(&test3);
+
 #ifdef ENABLE_WALLET
     WalletTests test5(app.node());
-    if (QTest::qExec(&test5) != 0) {
-        fInvalid = true;
-    }
+    fInvalid += QTest::qExec(&test5);
+
     AddressBookTests test6(app.node());
-    if (QTest::qExec(&test6) != 0) {
-        fInvalid = true;
-    }
+    fInvalid += QTest::qExec(&test6);
 #endif
 
     if (fInvalid) {
-        qWarning("\nThere were errors in some of the tests above.\n");
+        qWarning("\nFailed tests: %d\n", fInvalid);
     } else {
         qDebug("\nAll tests passed.\n");
     }


### PR DESCRIPTION
Append a one-line summary to the output of running `./src/qt/test/test_bitcoin-qt` indicating that all tests passed or showing the number of failing tests. It's currently a bit inconvenient to see this result by eyeballing all of the output.

 