### PR TITLE
Getting ready to Qt 6 (2/n). Remove `QApplication::globalStrut()`

### DIFF
--- a/src/qt/bitcoinamountfield.cpp
+++ b/src/qt/bitcoinamountfield.cpp
@@ -141,8 +141,7 @@ public:
 
             opt.rect = rect();
 
-            cachedMinimumSizeHint = style()->sizeFromContents(QStyle::CT_SpinBox, &opt, hint, this)
-                                    .expandedTo(QApplication::globalStrut());
+            cachedMinimumSizeHint = style()->sizeFromContents(QStyle::CT_SpinBox, &opt, hint, this);
         }
         return cachedMinimumSizeHint;
     }


### PR DESCRIPTION
This function has been deprecated in Qt 5.15.0, and has been [removed](https://github.com/qt/qtbase/commit/033d01bd6e2aef740ad1408a04d3ca0ae3b9ba9b) in Qt 6.