### PR TITLE
Getting ready to Qt 6 (6/n). Replace `QCoreApplication::quit()` with `QCoreApplication::exit(0)`

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -308,7 +308,9 @@ void BitcoinApplication::startThread()
 
     /*  communication to and from thread */
     connect(&m_executor.value(), &InitExecutor::initializeResult, this, &BitcoinApplication::initializeResult);
-    connect(&m_executor.value(), &InitExecutor::shutdownResult, this, &QCoreApplication::quit);
+    connect(&m_executor.value(), &InitExecutor::shutdownResult, this, [] {
+        QCoreApplication::exit(0);
+    });
     connect(&m_executor.value(), &InitExecutor::runawayException, this, &BitcoinApplication::handleRunawayException);
     connect(this, &BitcoinApplication::requestedInitialize, &m_executor.value(), &InitExecutor::initialize);
     connect(this, &BitcoinApplication::requestedShutdown, &m_executor.value(), &InitExecutor::shutdown);

--- a/src/qt/test/apptests.cpp
+++ b/src/qt/test/apptests.cpp
@@ -119,6 +119,6 @@ AppTests::HandleCallback::~HandleCallback()
     assert(it != callbacks.end());
     callbacks.erase(it);
     if (callbacks.empty()) {
-        m_app_tests.m_app.quit();
+        m_app_tests.m_app.exit(0);
     }
 }


### PR DESCRIPTION
### Qt 5:
 - no behavior change.

See https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/kernel/qcoreapplication.cpp?h=5.15#n2012:
```cpp
void QCoreApplication::quit()
{
    exit(0);
}
```

### Qt 6:
 - this change avoids sending a duplicated `QEvent::Quit`

We use `QEvent::Quit` to [handle](https://github.com/bitcoin-core/gui/pull/547) macOS dock menu events. Qt 6 uses `QEvent::Quit` more [widely](https://github.com/qt/qtbase/commit/89f7a2759c6b51343d0a1ca5a82d575abba04e0c). We do not want a duplicated `QEvent::Quit` which fires `Assert(node.args);` in the [`Shutdown()`](https://github.com/bitcoin-core/gui/blob/d1b3dfb275fd98e37cfe8a0f7cea7d03595af2e8/src/init.cpp#L200) function.