### PR TITLE
refactor: Replace `GUIUtil::ObjectInvoke()` with `QMetaObject::invokeMethod()`

### DIFF
--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -361,18 +361,6 @@ namespace GUIUtil
     #endif
     }
 
-    /**
-     * Queue a function to run in an object's event loop. This can be
-     * replaced by a call to the QMetaObject::invokeMethod functor overload after Qt 5.10, but
-     * for now use a QObject::connect for compatibility with older Qt versions, based on
-     * https://stackoverflow.com/questions/21646467/how-to-execute-a-functor-or-a-lambda-in-a-given-thread-in-qt-gcd-style
-     */
-    template <typename Fn>
-    void ObjectInvoke(QObject* object, Fn&& function, Qt::ConnectionType connection = Qt::QueuedConnection)
-    {
-        QObject source;
-        QObject::connect(&source, &QObject::destroyed, object, std::forward<Fn>(function), connection);
-    }
 
     /**
      * Replaces a plain text link with an HTML tagged one.

--- a/src/qt/initexecutor.cpp
+++ b/src/qt/initexecutor.cpp
@@ -5,13 +5,13 @@
 #include <qt/initexecutor.h>
 
 #include <interfaces/node.h>
-#include <qt/guiutil.h>
 #include <util/system.h>
 #include <util/threadnames.h>
 
 #include <exception>
 
 #include <QDebug>
+#include <QMetaObject>
 #include <QObject>
 #include <QString>
 #include <QThread>
@@ -39,7 +39,7 @@ void InitExecutor::handleRunawayException(const std::exception* e)
 
 void InitExecutor::initialize()
 {
-    GUIUtil::ObjectInvoke(&m_context, [this] {
+    QMetaObject::invokeMethod(&m_context, [this] {
         try {
             util::ThreadRename("qt-init");
             qDebug() << "Running initialization in thread";
@@ -56,7 +56,7 @@ void InitExecutor::initialize()
 
 void InitExecutor::shutdown()
 {
-    GUIUtil::ObjectInvoke(&m_context, [this] {
+    QMetaObject::invokeMethod(&m_context, [this] {
         try {
             qDebug() << "Running Shutdown in thread";
             m_node.appShutdown();

--- a/src/qt/walletcontroller.cpp
+++ b/src/qt/walletcontroller.cpp
@@ -24,6 +24,7 @@
 
 #include <QApplication>
 #include <QMessageBox>
+#include <QMetaObject>
 #include <QMutexLocker>
 #include <QThread>
 #include <QTimer>
@@ -135,7 +136,7 @@ WalletModel* WalletController::getOrCreateWallet(std::unique_ptr<interfaces::Wal
     // handled on the GUI event loop.
     wallet_model->moveToThread(thread());
     // setParent(parent) must be called in the thread which created the parent object. More details in #18948.
-    GUIUtil::ObjectInvoke(this, [wallet_model, this] {
+    QMetaObject::invokeMethod(this, [wallet_model, this] {
         wallet_model->setParent(this);
     }, GUIUtil::blockingGUIThreadConnection());
 


### PR DESCRIPTION
A comment in 5659e73493fcdfb5d0cb9d686c24c4fbe1c217ed states that `GUIUtil::ObjectInvoke`
> can be replaced by a call to the QMetaObject::invokeMethod functor overload after Qt 5.10
