### PR TITLE
Getting ready to Qt 6 (7/n). Pass `WalletModel*` pointer to signal only when `ENABLE_WALLET` defined

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -84,9 +84,10 @@ static void RegisterMetaTypes()
     // Register meta types used for QMetaObject::invokeMethod and Qt::QueuedConnection
     qRegisterMetaType<bool*>();
     qRegisterMetaType<SynchronizationState>();
-  #ifdef ENABLE_WALLET
+#ifdef ENABLE_WALLET
     qRegisterMetaType<WalletModel*>();
-  #endif
+    qRegisterMetaType<const WalletModel*>();
+#endif
     // Register typedefs (see https://doc.qt.io/qt-5/qmetatype.html#qRegisterMetaType)
     // IMPORTANT: if CAmount is no longer a typedef use the normal variant above (see https://doc.qt.io/qt-5/qmetatype.html#qRegisterMetaType-1)
     qRegisterMetaType<CAmount>("CAmount");

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -97,7 +97,11 @@ public:
     explicit RPCExecutor(interfaces::Node& node) : m_node(node) {}
 
 public Q_SLOTS:
-    void request(const QString &command, const WalletModel* wallet_model);
+#ifdef ENABLE_WALLET
+    void request(const QString& command, const WalletModel* wallet_model);
+#else
+    void request(const QString& command);
+#endif // ENABLE_WALLET
 
 Q_SIGNALS:
     void reply(int category, const QString &command);
@@ -416,7 +420,11 @@ bool RPCConsole::RPCParseCommandLine(interfaces::Node* node, std::string &strRes
     }
 }
 
-void RPCExecutor::request(const QString &command, const WalletModel* wallet_model)
+#ifdef ENABLE_WALLET
+void RPCExecutor::request(const QString& command, const WalletModel* wallet_model)
+#else
+void RPCExecutor::request(const QString& command)
+#endif // ENABLE_WALLET
 {
     try
     {
@@ -446,7 +454,12 @@ void RPCExecutor::request(const QString &command, const WalletModel* wallet_mode
                 "   example:    getblock(getblockhash(0),1)[tx][0]\n\n")));
             return;
         }
+
+#ifdef ENABLE_WALLET
         if (!RPCConsole::RPCExecuteCommandLine(m_node, result, executableCommand, nullptr, wallet_model)) {
+#else
+        if (!RPCConsole::RPCExecuteCommandLine(m_node, result, executableCommand)) {
+#endif // ENABLE_WALLET
             Q_EMIT reply(RPCConsole::CMD_ERROR, QString("Parse error: unbalanced ' or \""));
             return;
         }
@@ -1049,7 +1062,12 @@ void RPCConsole::on_lineEdit_returnPressed()
     //: A console message indicating an entered command is currently being executed.
     message(CMD_REPLY, tr("Executing…"));
     m_is_executing = true;
+
+#ifdef ENABLE_WALLET
     Q_EMIT cmdRequest(cmd, m_last_wallet_model);
+#else
+    Q_EMIT cmdRequest(cmd);
+#endif // ENABLE_WALLET
 
     cmd = QString::fromStdString(strFilteredCmd);
 

--- a/src/qt/rpcconsole.h
+++ b/src/qt/rpcconsole.h
@@ -49,8 +49,11 @@ public:
     }
 
     void setClientModel(ClientModel *model = nullptr, int bestblock_height = 0, int64_t bestblock_date = 0, double verification_progress = 0.0);
-    void addWallet(WalletModel * const walletModel);
+
+#ifdef ENABLE_WALLET
+    void addWallet(WalletModel* const walletModel);
     void removeWallet(WalletModel* const walletModel);
+#endif // ENABLE_WALLET
 
     enum MessageClass {
         MC_ERROR,

--- a/src/qt/rpcconsole.h
+++ b/src/qt/rpcconsole.h
@@ -134,7 +134,11 @@ public Q_SLOTS:
 
 Q_SIGNALS:
     // For RPC command executor
-    void cmdRequest(const QString &command, const WalletModel* wallet_model);
+#ifdef ENABLE_WALLET
+    void cmdRequest(const QString& command, const WalletModel* wallet_model);
+#else
+    void cmdRequest(const QString& command);
+#endif // ENABLE_WALLET
 
 private:
     struct TranslatedStrings {

--- a/src/qt/test/apptests.cpp
+++ b/src/qt/test/apptests.cpp
@@ -13,6 +13,9 @@
 #include <shutdown.h>
 #include <test/util/setup_common.h>
 #include <validation.h>
+#ifdef ENABLE_WALLET
+#include <qt/walletmodel.h>
+#endif // ENABLE_WALLET
 
 #if defined(HAVE_CONFIG_H)
 #include <config/bitcoin-config.h>
@@ -76,6 +79,9 @@ void AppTests::appTests()
     }());
 
     qRegisterMetaType<interfaces::BlockAndHeaderTipInfo>("interfaces::BlockAndHeaderTipInfo");
+#ifdef ENABLE_WALLET
+    qRegisterMetaType<const WalletModel*>();
+#endif // ENABLE_WALLET
     m_app.parameterSetup();
     m_app.createOptionsModel(true /* reset settings */);
     QScopedPointer<const NetworkStyle> style(NetworkStyle::instantiate(Params().NetworkIDString()));

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -19,6 +19,7 @@
 
 #include <vector>
 
+#include <QMetaType>
 #include <QObject>
 
 enum class OutputType;
@@ -239,5 +240,7 @@ public Q_SLOTS:
     /* Current, immature or unconfirmed balance might have changed - emit 'balanceChanged' if so */
     void pollBalanceChanged();
 };
+
+Q_DECLARE_METATYPE(const WalletModel*)
 
 #endif // BITCOIN_QT_WALLETMODEL_H


### PR DESCRIPTION
On master (094d9fda5ccee7d78a2e3d8b1eec17b8b6a33466), the following queued connection https://github.com/bitcoin-core/gui/blob/094d9fda5ccee7d78a2e3d8b1eec17b8b6a33466/src/qt/rpcconsole.cpp#L1107 uses a `const WalletModel*` parameter regardless whether the `ENABLE_WALLET` macro is defined.

Although this code works in Qt 5, it is flawed. On Qt 6, the code gets broken because the fully defined `WalletModel` type is required which is not the case if `ENABLE_WALLET` is undefined.

This PR fixes the issue described above.