### PR TITLE
test: Add tests for `tableView` in `AddressBookPage` dialog

### DIFF
--- a/src/qt/test/addressbooktests.cpp
+++ b/src/qt/test/addressbooktests.cpp
@@ -8,6 +8,7 @@
 
 #include <interfaces/chain.h>
 #include <interfaces/node.h>
+#include <qt/addressbookpage.h>
 #include <qt/clientmodel.h>
 #include <qt/editaddressdialog.h>
 #include <qt/optionsmodel.h>
@@ -23,8 +24,9 @@
 #include <chrono>
 
 #include <QApplication>
-#include <QTimer>
 #include <QMessageBox>
+#include <QTableView>
+#include <QTimer>
 
 using wallet::AddWallet;
 using wallet::CWallet;
@@ -131,14 +133,19 @@ void TestAddAddressesToSendBook(interfaces::Node& node)
     EditAddressDialog editAddressDialog(EditAddressDialog::NewSendingAddress);
     editAddressDialog.setModel(walletModel.getAddressTableModel());
 
+    AddressBookPage address_book{platformStyle.get(), AddressBookPage::ForEditing, AddressBookPage::SendingTab};
+    address_book.setModel(walletModel.getAddressTableModel());
+    auto table_view = address_book.findChild<QTableView*>("tableView");
+    QCOMPARE(table_view->model()->rowCount(), 1);
+
     EditAddressAndSubmit(
         &editAddressDialog, QString("uhoh"), preexisting_r_address,
         QString(
             "Address \"%1\" already exists as a receiving address with label "
             "\"%2\" and so cannot be added as a sending address."
             ).arg(preexisting_r_address).arg(r_label));
-
     check_addbook_size(2);
+    QCOMPARE(table_view->model()->rowCount(), 1);
 
     EditAddressAndSubmit(
         &editAddressDialog, QString("uhoh, different"), preexisting_s_address,
@@ -146,15 +153,15 @@ void TestAddAddressesToSendBook(interfaces::Node& node)
             "The entered address \"%1\" is already in the address book with "
             "label \"%2\"."
             ).arg(preexisting_s_address).arg(s_label));
-
     check_addbook_size(2);
+    QCOMPARE(table_view->model()->rowCount(), 1);
 
     // Submit a new address which should add successfully - we expect the
     // warning message to be blank.
     EditAddressAndSubmit(
         &editAddressDialog, QString("new"), new_address, QString(""));
-
     check_addbook_size(3);
+    QCOMPARE(table_view->model()->rowCount(), 2);
 }
 
 } // namespace

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -369,7 +369,7 @@ static void NotifyAddressBookChanged(WalletModel *walletmodel,
     QString strPurpose = QString::fromStdString(purpose);
 
     qDebug() << "NotifyAddressBookChanged: " + strAddress + " " + strLabel + " isMine=" + QString::number(isMine) + " purpose=" + strPurpose + " status=" + QString::number(status);
-    bool invoked = QMetaObject::invokeMethod(walletmodel, "updateAddressBook", Qt::QueuedConnection,
+    bool invoked = QMetaObject::invokeMethod(walletmodel, "updateAddressBook",
                               Q_ARG(QString, strAddress),
                               Q_ARG(QString, strLabel),
                               Q_ARG(bool, isMine),


### PR DESCRIPTION
This PR is a prerequisite for more thorough testing of filtering in the `AddressBookPage` class in context of bitcoin-core/gui#578 and bitcoin-core/gui#585.

Required for bitcoin-core/gui#592.