### PR TITLE
Drop wildcard support for address/label search in `AddressBookPage`

### DIFF
--- a/src/qt/addressbookpage.cpp
+++ b/src/qt/addressbookpage.cpp
@@ -46,12 +46,9 @@ protected:
 
         auto address = model->index(row, AddressTableModel::Address, parent);
 
-        if (filterRegExp().indexIn(model->data(address).toString()) < 0 &&
-            filterRegExp().indexIn(model->data(label).toString()) < 0) {
-            return false;
-        }
-
-        return true;
+        const auto pattern = filterRegExp();
+        return (model->data(address).toString().contains(pattern) ||
+                model->data(label).toString().contains(pattern));
     }
 };
 
@@ -143,7 +140,9 @@ void AddressBookPage::setModel(AddressTableModel *_model)
     proxyModel = new AddressBookSortFilterProxyModel(type, this);
     proxyModel->setSourceModel(_model);
 
-    connect(ui->searchLineEdit, &QLineEdit::textChanged, proxyModel, &QSortFilterProxyModel::setFilterWildcard);
+    connect(ui->searchLineEdit, &QLineEdit::textChanged, [this](const QString& pattern) {
+        proxyModel->setFilterFixedString(pattern);
+    });
 
     ui->tableView->setModel(proxyModel);
     ui->tableView->sortByColumn(0, Qt::AscendingOrder);

--- a/src/qt/test/addressbooktests.cpp
+++ b/src/qt/test/addressbooktests.cpp
@@ -24,6 +24,7 @@
 #include <chrono>
 
 #include <QApplication>
+#include <QLineEdit>
 #include <QMessageBox>
 #include <QTableView>
 #include <QTimer>
@@ -102,11 +103,13 @@ void TestAddAddressesToSendBook(interfaces::Node& node)
     QString s_label("already here (s)");
 
     // Define a new address (which should add to the address book successfully).
-    QString new_address;
+    QString new_address_a;
+    QString new_address_b;
 
     std::tie(r_key_dest, preexisting_r_address) = build_address();
     std::tie(s_key_dest, preexisting_s_address) = build_address();
-    std::tie(std::ignore, new_address) = build_address();
+    std::tie(std::ignore, new_address_a) = build_address();
+    std::tie(std::ignore, new_address_b) = build_address();
 
     {
         LOCK(wallet->cs_wallet);
@@ -159,9 +162,52 @@ void TestAddAddressesToSendBook(interfaces::Node& node)
     // Submit a new address which should add successfully - we expect the
     // warning message to be blank.
     EditAddressAndSubmit(
-        &editAddressDialog, QString("new"), new_address, QString(""));
+        &editAddressDialog, QString("io - new A"), new_address_a, QString(""));
     check_addbook_size(3);
     QCOMPARE(table_view->model()->rowCount(), 2);
+
+    EditAddressAndSubmit(
+        &editAddressDialog, QString("io - new B"), new_address_b, QString(""));
+    check_addbook_size(4);
+    QCOMPARE(table_view->model()->rowCount(), 3);
+
+    auto search_line = address_book.findChild<QLineEdit*>("searchLineEdit");
+
+    search_line->setText(r_label);
+    QCOMPARE(table_view->model()->rowCount(), 0);
+
+    search_line->setText(s_label);
+    QCOMPARE(table_view->model()->rowCount(), 1);
+
+    search_line->setText("io");
+    QCOMPARE(table_view->model()->rowCount(), 2);
+
+    // Check wilcard "?".
+    search_line->setText("io?new");
+    QCOMPARE(table_view->model()->rowCount(), 0);
+    search_line->setText("io???new");
+    QCOMPARE(table_view->model()->rowCount(), 0);
+
+    // Check wilcard "*".
+    search_line->setText("io*new");
+    QCOMPARE(table_view->model()->rowCount(), 0);
+    search_line->setText("*");
+    QCOMPARE(table_view->model()->rowCount(), 0);
+
+    search_line->setText(preexisting_r_address);
+    QCOMPARE(table_view->model()->rowCount(), 0);
+
+    search_line->setText(preexisting_s_address);
+    QCOMPARE(table_view->model()->rowCount(), 1);
+
+    search_line->setText(new_address_a);
+    QCOMPARE(table_view->model()->rowCount(), 1);
+
+    search_line->setText(new_address_b);
+    QCOMPARE(table_view->model()->rowCount(), 1);
+
+    search_line->setText("");
+    QCOMPARE(table_view->model()->rowCount(), 3);
 }
 
 } // namespace


### PR DESCRIPTION
Wildcard support for address/label search in `AddressBookPage` was introduced in bitcoin/bitcoin#12080, and it is available in release binaries since v0.17.

But this feature has never being [documented](https://github.com/bitcoin/bitcoin/blob/master/doc/release-notes/release-notes-0.17.0.md) or mentioned in the GUI.

Thus, there are no reasons to believe that users rely on this feature.

Required for [migration](https://github.com/bitcoin/bitcoin/pull/24798) to Qt 6, [because](https://doc.qt.io/qt-6/qregexp.html#porting-to-qregularexpression):
> There is no direct way to do wildcard matching in `QRegularExpression`.

Tests included.

~Based on bitcoin-core/gui#591, so only last 2 commits belong to this PR.~