### PR TITLE
Getting ready to Qt 6 (8/n). Use `QRegularExpression` in `AddressBookSortFilterProxyModel` class

### DIFF
--- a/src/qt/addressbookpage.cpp
+++ b/src/qt/addressbookpage.cpp
@@ -46,12 +46,9 @@ protected:
 
         auto address = model->index(row, AddressTableModel::Address, parent);
 
-        if (filterRegExp().indexIn(model->data(address).toString()) < 0 &&
-            filterRegExp().indexIn(model->data(label).toString()) < 0) {
-            return false;
-        }
-
-        return true;
+        const auto pattern = filterRegExp();
+        return (model->data(address).toString().contains(pattern) ||
+                model->data(label).toString().contains(pattern));
     }
 };
 
@@ -143,7 +140,9 @@ void AddressBookPage::setModel(AddressTableModel *_model)
     proxyModel = new AddressBookSortFilterProxyModel(type, this);
     proxyModel->setSourceModel(_model);
 
-    connect(ui->searchLineEdit, &QLineEdit::textChanged, proxyModel, &QSortFilterProxyModel::setFilterWildcard);
+    connect(ui->searchLineEdit, &QLineEdit::textChanged, [this](const QString& pattern) {
+        proxyModel->setFilterFixedString(pattern);
+    });
 
     ui->tableView->setModel(proxyModel);
     ui->tableView->sortByColumn(0, Qt::AscendingOrder);

--- a/src/qt/addressbookpage.cpp
+++ b/src/qt/addressbookpage.cpp
@@ -46,7 +46,11 @@ protected:
 
         auto address = model->index(row, AddressTableModel::Address, parent);
 
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 12, 0))
+        const auto pattern = filterRegularExpression().pattern();
+#else
         const auto pattern = filterRegExp();
+#endif
         return (model->data(address).toString().contains(pattern) ||
                 model->data(label).toString().contains(pattern));
     }
@@ -141,7 +145,11 @@ void AddressBookPage::setModel(AddressTableModel *_model)
     proxyModel->setSourceModel(_model);
 
     connect(ui->searchLineEdit, &QLineEdit::textChanged, [this](const QString& pattern) {
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 12, 0))
+        proxyModel->setFilterRegularExpression(pattern);
+#else
         proxyModel->setFilterFixedString(pattern);
+#endif
     });
 
     ui->tableView->setModel(proxyModel);

--- a/src/qt/test/addressbooktests.cpp
+++ b/src/qt/test/addressbooktests.cpp
@@ -24,6 +24,7 @@
 #include <chrono>
 
 #include <QApplication>
+#include <QLineEdit>
 #include <QMessageBox>
 #include <QTableView>
 #include <QTimer>
@@ -102,11 +103,13 @@ void TestAddAddressesToSendBook(interfaces::Node& node)
     QString s_label("already here (s)");
 
     // Define a new address (which should add to the address book successfully).
-    QString new_address;
+    QString new_address_a;
+    QString new_address_b;
 
     std::tie(r_key_dest, preexisting_r_address) = build_address();
     std::tie(s_key_dest, preexisting_s_address) = build_address();
-    std::tie(std::ignore, new_address) = build_address();
+    std::tie(std::ignore, new_address_a) = build_address();
+    std::tie(std::ignore, new_address_b) = build_address();
 
     {
         LOCK(wallet->cs_wallet);
@@ -159,9 +162,52 @@ void TestAddAddressesToSendBook(interfaces::Node& node)
     // Submit a new address which should add successfully - we expect the
     // warning message to be blank.
     EditAddressAndSubmit(
-        &editAddressDialog, QString("new"), new_address, QString(""));
+        &editAddressDialog, QString("io - new A"), new_address_a, QString(""));
     check_addbook_size(3);
     QCOMPARE(table_view->model()->rowCount(), 2);
+
+    EditAddressAndSubmit(
+        &editAddressDialog, QString("io - new B"), new_address_b, QString(""));
+    check_addbook_size(4);
+    QCOMPARE(table_view->model()->rowCount(), 3);
+
+    auto search_line = address_book.findChild<QLineEdit*>("searchLineEdit");
+
+    search_line->setText(r_label);
+    QCOMPARE(table_view->model()->rowCount(), 0);
+
+    search_line->setText(s_label);
+    QCOMPARE(table_view->model()->rowCount(), 1);
+
+    search_line->setText("io");
+    QCOMPARE(table_view->model()->rowCount(), 2);
+
+    // Check wilcard "?".
+    search_line->setText("io?new");
+    QCOMPARE(table_view->model()->rowCount(), 0);
+    search_line->setText("io???new");
+    QCOMPARE(table_view->model()->rowCount(), 0);
+
+    // Check wilcard "*".
+    search_line->setText("io*new");
+    QCOMPARE(table_view->model()->rowCount(), 0);
+    search_line->setText("*");
+    QCOMPARE(table_view->model()->rowCount(), 0);
+
+    search_line->setText(preexisting_r_address);
+    QCOMPARE(table_view->model()->rowCount(), 0);
+
+    search_line->setText(preexisting_s_address);
+    QCOMPARE(table_view->model()->rowCount(), 1);
+
+    search_line->setText(new_address_a);
+    QCOMPARE(table_view->model()->rowCount(), 1);
+
+    search_line->setText(new_address_b);
+    QCOMPARE(table_view->model()->rowCount(), 1);
+
+    search_line->setText("");
+    QCOMPARE(table_view->model()->rowCount(), 3);
 }
 
 } // namespace

--- a/src/qt/test/addressbooktests.cpp
+++ b/src/qt/test/addressbooktests.cpp
@@ -8,6 +8,7 @@
 
 #include <interfaces/chain.h>
 #include <interfaces/node.h>
+#include <qt/addressbookpage.h>
 #include <qt/clientmodel.h>
 #include <qt/editaddressdialog.h>
 #include <qt/optionsmodel.h>
@@ -23,8 +24,9 @@
 #include <chrono>
 
 #include <QApplication>
-#include <QTimer>
 #include <QMessageBox>
+#include <QTableView>
+#include <QTimer>
 
 using wallet::AddWallet;
 using wallet::CWallet;
@@ -131,14 +133,19 @@ void TestAddAddressesToSendBook(interfaces::Node& node)
     EditAddressDialog editAddressDialog(EditAddressDialog::NewSendingAddress);
     editAddressDialog.setModel(walletModel.getAddressTableModel());
 
+    AddressBookPage address_book{platformStyle.get(), AddressBookPage::ForEditing, AddressBookPage::SendingTab};
+    address_book.setModel(walletModel.getAddressTableModel());
+    auto table_view = address_book.findChild<QTableView*>("tableView");
+    QCOMPARE(table_view->model()->rowCount(), 1);
+
     EditAddressAndSubmit(
         &editAddressDialog, QString("uhoh"), preexisting_r_address,
         QString(
             "Address \"%1\" already exists as a receiving address with label "
             "\"%2\" and so cannot be added as a sending address."
             ).arg(preexisting_r_address).arg(r_label));
-
     check_addbook_size(2);
+    QCOMPARE(table_view->model()->rowCount(), 1);
 
     EditAddressAndSubmit(
         &editAddressDialog, QString("uhoh, different"), preexisting_s_address,
@@ -146,15 +153,15 @@ void TestAddAddressesToSendBook(interfaces::Node& node)
             "The entered address \"%1\" is already in the address book with "
             "label \"%2\"."
             ).arg(preexisting_s_address).arg(s_label));
-
     check_addbook_size(2);
+    QCOMPARE(table_view->model()->rowCount(), 1);
 
     // Submit a new address which should add successfully - we expect the
     // warning message to be blank.
     EditAddressAndSubmit(
         &editAddressDialog, QString("new"), new_address, QString(""));
-
     check_addbook_size(3);
+    QCOMPARE(table_view->model()->rowCount(), 2);
 }
 
 } // namespace

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -369,7 +369,7 @@ static void NotifyAddressBookChanged(WalletModel *walletmodel,
     QString strPurpose = QString::fromStdString(purpose);
 
     qDebug() << "NotifyAddressBookChanged: " + strAddress + " " + strLabel + " isMine=" + QString::number(isMine) + " purpose=" + strPurpose + " status=" + QString::number(status);
-    bool invoked = QMetaObject::invokeMethod(walletmodel, "updateAddressBook", Qt::QueuedConnection,
+    bool invoked = QMetaObject::invokeMethod(walletmodel, "updateAddressBook",
                               Q_ARG(QString, strAddress),
                               Q_ARG(QString, strLabel),
                               Q_ARG(bool, isMine),


### PR DESCRIPTION
This is a step in [migration](bitcoin/bitcoin/pull/24798) to Qt 6.

Related:
- bitcoin-core/gui#578
- bitcoin-core/gui#585

Based on https://github.com/bitcoin-core/gui/pull/591 and https://github.com/bitcoin-core/gui/pull/591, so only the last commit belongs to this PR.