### PR TITLE
refactor: Skip manual signal disconnection in descructors

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -228,9 +228,6 @@ BitcoinGUI::BitcoinGUI(interfaces::Node& node, const PlatformStyle *_platformSty
 
 BitcoinGUI::~BitcoinGUI()
 {
-    // Unsubscribe from notifications from core
-    unsubscribeFromCoreSignals();
-
     QSettings settings;
     settings.setValue("MainWindowGeometry", saveGeometry());
     if(trayIcon) // Hide tray icon, as deleting will let it linger until quit (on Ubuntu)

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -69,8 +69,6 @@ ClientModel::ClientModel(interfaces::Node& node, OptionsModel *_optionsModel, QO
 
 ClientModel::~ClientModel()
 {
-    unsubscribeFromCoreSignals();
-
     m_thread->quit();
     m_thread->wait();
 }
@@ -270,17 +268,6 @@ void ClientModel::subscribeToCoreSignals()
         [this](SynchronizationState sync_state, interfaces::BlockTip tip, double verification_progress) {
             TipChanged(sync_state, tip, verification_progress, /*header=*/true);
         });
-}
-
-void ClientModel::unsubscribeFromCoreSignals()
-{
-    m_handler_show_progress->disconnect();
-    m_handler_notify_num_connections_changed->disconnect();
-    m_handler_notify_network_active_changed->disconnect();
-    m_handler_notify_alert_changed->disconnect();
-    m_handler_banned_list_changed->disconnect();
-    m_handler_notify_block_tip->disconnect();
-    m_handler_notify_header_tip->disconnect();
 }
 
 bool ClientModel::getProxyInfo(std::string& ip_port) const

--- a/src/qt/clientmodel.h
+++ b/src/qt/clientmodel.h
@@ -107,7 +107,6 @@ private:
 
     void TipChanged(SynchronizationState sync_state, interfaces::BlockTip tip, double verification_progress, bool header);
     void subscribeToCoreSignals();
-    void unsubscribeFromCoreSignals();
 
 Q_SIGNALS:
     void numConnectionsChanged(int count);

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -266,7 +266,6 @@ TransactionTableModel::TransactionTableModel(const PlatformStyle *_platformStyle
 
 TransactionTableModel::~TransactionTableModel()
 {
-    unsubscribeFromCoreSignals();
     delete priv;
 }
 
@@ -753,11 +752,4 @@ void TransactionTableModel::subscribeToCoreSignals()
         priv->m_loading = progress < 100;
         priv->DispatchNotifications();
     });
-}
-
-void TransactionTableModel::unsubscribeFromCoreSignals()
-{
-    // Disconnect signals from wallet
-    m_handler_transaction_changed->disconnect();
-    m_handler_show_progress->disconnect();
 }

--- a/src/qt/transactiontablemodel.h
+++ b/src/qt/transactiontablemodel.h
@@ -93,7 +93,6 @@ private:
     const PlatformStyle *platformStyle;
 
     void subscribeToCoreSignals();
-    void unsubscribeFromCoreSignals();
 
     QString lookupAddress(const std::string &address, bool tooltip) const;
     QVariant addressColor(const TransactionRecord *wtx) const;

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -60,11 +60,6 @@ WalletModel::WalletModel(std::unique_ptr<interfaces::Wallet> wallet, ClientModel
     subscribeToCoreSignals();
 }
 
-WalletModel::~WalletModel()
-{
-    unsubscribeFromCoreSignals();
-}
-
 void WalletModel::startPollBalance()
 {
     // This timer will be fired repeatedly to update the balance
@@ -418,18 +413,6 @@ void WalletModel::subscribeToCoreSignals()
     m_handler_show_progress = m_wallet->handleShowProgress(std::bind(ShowProgress, this, std::placeholders::_1, std::placeholders::_2));
     m_handler_watch_only_changed = m_wallet->handleWatchOnlyChanged(std::bind(NotifyWatchonlyChanged, this, std::placeholders::_1));
     m_handler_can_get_addrs_changed = m_wallet->handleCanGetAddressesChanged(std::bind(NotifyCanGetAddressesChanged, this));
-}
-
-void WalletModel::unsubscribeFromCoreSignals()
-{
-    // Disconnect signals from wallet
-    m_handler_unload->disconnect();
-    m_handler_status_changed->disconnect();
-    m_handler_address_book_changed->disconnect();
-    m_handler_transaction_changed->disconnect();
-    m_handler_show_progress->disconnect();
-    m_handler_watch_only_changed->disconnect();
-    m_handler_can_get_addrs_changed->disconnect();
 }
 
 // WalletModel::UnlockContext implementation

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -14,9 +14,11 @@
 
 #include <qt/walletmodeltransaction.h>
 
+#include <interfaces/handler.h>
 #include <interfaces/wallet.h>
 #include <support/allocators/secure.h>
 
+#include <memory>
 #include <vector>
 
 #include <QObject>
@@ -55,7 +57,6 @@ class WalletModel : public QObject
 
 public:
     explicit WalletModel(std::unique_ptr<interfaces::Wallet> wallet, ClientModel& client_model, const PlatformStyle *platformStyle, QObject *parent = nullptr);
-    ~WalletModel();
 
     enum StatusCode // Returned by sendCoins
     {
@@ -111,7 +112,7 @@ public:
     bool setWalletLocked(bool locked, const SecureString &passPhrase=SecureString());
     bool changePassphrase(const SecureString &oldPass, const SecureString &newPass);
 
-    // RAI object for unlocking wallet, returned by requestUnlock()
+    // RAII object for unlocking wallet, returned by requestUnlock()
     class UnlockContext
     {
     public:
@@ -187,7 +188,6 @@ private:
     uint256 m_cached_last_update_tip{};
 
     void subscribeToCoreSignals();
-    void unsubscribeFromCoreSignals();
     void checkBalanceChanged(const interfaces::WalletBalances& new_balances);
 
 Q_SIGNALS:


### PR DESCRIPTION
Internally, `interfaces::HandlerImpl` keeps a member of the `boost::signals2::scoped_connection` type https://github.com/bitcoin-core/gui/blob/192d639a6b1bd0feaa52e6ea4e63e33982704c32/src/interfaces/handler.cpp#L21  [which](https://www.boost.org/doc/libs/1_64_0/doc/html/boost/signals2/scoped_connection.html) automatically disconnects on destruction.

Therefore, manual disconnections are redundant in class destructors.