### PR TITLE
Drop no longer supported Android architecture

### DIFF
--- a/src/qt/android/res/values/libs.xml
+++ b/src/qt/android/res/values/libs.xml
@@ -10,8 +10,5 @@
         <item>
             x86_64;libbitcoin-qt_x86_64.so
         </item>
-        <item>
-            x86;libbitcoin-qt_x86.so
-        </item>
     </array>
 </resources>


### PR DESCRIPTION
The `i686-linux-android` arch support has been dropped since bitcoin/bitcoin#23744.