### PR TITLE
refactor: Add `transactionoverviewwidget.cpp` source file

### DIFF
--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -270,6 +270,7 @@ BITCOIN_QT_WALLET_CPP = \
   qt/transactiondesc.cpp \
   qt/transactiondescdialog.cpp \
   qt/transactionfilterproxy.cpp \
+  qt/transactionoverviewwidget.cpp \
   qt/transactionrecord.cpp \
   qt/transactiontablemodel.cpp \
   qt/transactionview.cpp \

--- a/src/qt/transactionoverviewwidget.cpp
+++ b/src/qt/transactionoverviewwidget.cpp
@@ -1,0 +1,27 @@
+// Copyright (c) 2021 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <qt/transactionoverviewwidget.h>
+
+#include <qt/transactiontablemodel.h>
+
+#include <QListView>
+#include <QSize>
+#include <QSizePolicy>
+
+TransactionOverviewWidget::TransactionOverviewWidget(QWidget* parent)
+    : QListView(parent) {}
+
+QSize TransactionOverviewWidget::sizeHint() const
+{
+    return {sizeHintForColumn(TransactionTableModel::ToAddress), QListView::sizeHint().height()};
+}
+
+void TransactionOverviewWidget::showEvent(QShowEvent* event)
+{
+    Q_UNUSED(event);
+    QSizePolicy sp = sizePolicy();
+    sp.setHorizontalPolicy(QSizePolicy::Minimum);
+    setSizePolicy(sp);
+}

--- a/src/qt/transactionoverviewwidget.h
+++ b/src/qt/transactionoverviewwidget.h
@@ -5,11 +5,8 @@
 #ifndef BITCOIN_QT_TRANSACTIONOVERVIEWWIDGET_H
 #define BITCOIN_QT_TRANSACTIONOVERVIEWWIDGET_H
 
-#include <qt/transactiontablemodel.h>
-
 #include <QListView>
 #include <QSize>
-#include <QSizePolicy>
 
 QT_BEGIN_NAMESPACE
 class QShowEvent;
@@ -21,21 +18,11 @@ class TransactionOverviewWidget : public QListView
     Q_OBJECT
 
 public:
-    explicit TransactionOverviewWidget(QWidget* parent = nullptr) : QListView(parent) {}
-
-    QSize sizeHint() const override
-    {
-        return {sizeHintForColumn(TransactionTableModel::ToAddress), QListView::sizeHint().height()};
-    }
+    explicit TransactionOverviewWidget(QWidget* parent = nullptr);
+    QSize sizeHint() const override;
 
 protected:
-    void showEvent(QShowEvent* event) override
-    {
-        Q_UNUSED(event);
-        QSizePolicy sp = sizePolicy();
-        sp.setHorizontalPolicy(QSizePolicy::Minimum);
-        setSizePolicy(sp);
-    }
+    void showEvent(QShowEvent* event) override;
 };
 
 #endif // BITCOIN_QT_TRANSACTIONOVERVIEWWIDGET_H


### PR DESCRIPTION
The `TransactionOverviewWidget` class was added in bitcoin-core/gui#176 as a header-only one.

Apparently, in upcoming [CMake project](https://github.com/hebasto/bitcoin/pull/3), CMake [AUTOMOC](https://cmake.org/cmake/help/latest/prop_tgt/AUTOMOC.html) could be integrated better/simpler, if `QObject`-derived class implementation been placed into a source file.