### PR TITLE
Replace `QRegExp` with `QRegularExpression`

### DIFF
--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -292,6 +292,16 @@ QString getDefaultDataDirectory()
     return PathToQString(GetDefaultDataDir());
 }
 
+QString ExtractFirstSuffixFromFilter(const QString& filter)
+{
+    QRegExp filter_re(".* \\(\\*\\.(.*)[ \\)]");
+    QString suffix;
+    if (filter_re.exactMatch(filter)) {
+        suffix = filter_re.cap(1);
+    }
+    return suffix;
+}
+
 QString getSaveFileName(QWidget *parent, const QString &caption, const QString &dir,
     const QString &filter,
     QString *selectedSuffixOut)
@@ -309,13 +319,7 @@ QString getSaveFileName(QWidget *parent, const QString &caption, const QString &
     /* Directly convert path to native OS path separators */
     QString result = QDir::toNativeSeparators(QFileDialog::getSaveFileName(parent, caption, myDir, filter, &selectedFilter));
 
-    /* Extract first suffix from filter pattern "Description (*.foo)" or "Description (*.foo *.bar ...) */
-    QRegExp filter_re(".* \\(\\*\\.(.*)[ \\)]");
-    QString selectedSuffix;
-    if(filter_re.exactMatch(selectedFilter))
-    {
-        selectedSuffix = filter_re.cap(1);
-    }
+    QString selectedSuffix = ExtractFirstSuffixFromFilter(selectedFilter);
 
     /* Add suffix if needed */
     QFileInfo info(result);
@@ -357,14 +361,8 @@ QString getOpenFileName(QWidget *parent, const QString &caption, const QString &
 
     if(selectedSuffixOut)
     {
-        /* Extract first suffix from filter pattern "Description (*.foo)" or "Description (*.foo *.bar ...) */
-        QRegExp filter_re(".* \\(\\*\\.(.*)[ \\)]");
-        QString selectedSuffix;
-        if(filter_re.exactMatch(selectedFilter))
-        {
-            selectedSuffix = filter_re.cap(1);
-        }
-        *selectedSuffixOut = selectedSuffix;
+        *selectedSuffixOut = ExtractFirstSuffixFromFilter(selectedFilter);
+        ;
     }
     return result;
 }

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -56,6 +56,7 @@
 #include <QMouseEvent>
 #include <QPluginLoader>
 #include <QProgressDialog>
+#include <QRegularExpression>
 #include <QScreen>
 #include <QSettings>
 #include <QShortcut>
@@ -294,10 +295,11 @@ QString getDefaultDataDirectory()
 
 QString ExtractFirstSuffixFromFilter(const QString& filter)
 {
-    QRegExp filter_re(".* \\(\\*\\.(.*)[ \\)]");
+    QRegularExpression filter_re(QStringLiteral(".* \\(\\*\\.(.*)[ \\)]"), QRegularExpression::InvertedGreedinessOption);
     QString suffix;
-    if (filter_re.exactMatch(filter)) {
-        suffix = filter_re.cap(1);
+    QRegularExpressionMatch m = filter_re.match(filter);
+    if (m.hasMatch()) {
+        suffix = m.captured(1);
     }
     return suffix;
 }

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -123,6 +123,14 @@ namespace GUIUtil
      */
     QString getDefaultDataDirectory();
 
+    /**
+     * Extract first suffix from filter pattern "Description (*.foo)" or "Description (*.foo *.bar ...).
+     *
+     * @param[in] filter Filter specification such as "Comma Separated Files (*.csv)"
+     * @return QString
+     */
+    QString ExtractFirstSuffixFromFilter(const QString& filter);
+
     /** Get save filename, mimics QFileDialog::getSaveFileName, except that it appends a default suffix
         when no suffix is provided by the user.
 

--- a/src/qt/test/optiontests.cpp
+++ b/src/qt/test/optiontests.cpp
@@ -4,6 +4,7 @@
 
 #include <init.h>
 #include <qt/bitcoin.h>
+#include <qt/guiutil.h>
 #include <qt/test/optiontests.h>
 #include <test/util/setup_common.h>
 #include <util/system.h>
@@ -121,4 +122,13 @@ void OptionTests::parametersInteraction()
     settings.remove("fListen");
     QVERIFY(!settings.contains("fListen"));
     gArgs.ClearPathCache();
+}
+
+void OptionTests::extractFilter()
+{
+    QString filter = QString("Partially Signed Transaction (Binary) (*.psbt)");
+    QCOMPARE(GUIUtil::ExtractFirstSuffixFromFilter(filter), "psbt");
+
+    filter = QString("Image (*.png *.jpg)");
+    QCOMPARE(GUIUtil::ExtractFirstSuffixFromFilter(filter), "png");
 }

--- a/src/qt/test/optiontests.h
+++ b/src/qt/test/optiontests.h
@@ -22,6 +22,7 @@ private Q_SLOTS:
     void migrateSettings();
     void integerGetArgBug();
     void parametersInteraction();
+    void extractFilter();
 
 private:
     interfaces::Node& m_node;

--- a/src/qt/utilitydialog.cpp
+++ b/src/qt/utilitydialog.cpp
@@ -22,7 +22,8 @@
 #include <QCloseEvent>
 #include <QLabel>
 #include <QMainWindow>
-#include <QRegExp>
+#include <QRegularExpression>
+#include <QString>
 #include <QTextCursor>
 #include <QTextTable>
 #include <QVBoxLayout>
@@ -44,9 +45,8 @@ HelpMessageDialog::HelpMessageDialog(QWidget *parent, bool about) :
         /// HTML-format the license message from the core
         QString licenseInfoHTML = QString::fromStdString(LicenseInfo());
         // Make URLs clickable
-        QRegExp uri("<(.*)>", Qt::CaseSensitive, QRegExp::RegExp2);
-        uri.setMinimal(true); // use non-greedy matching
-        licenseInfoHTML.replace(uri, "<a href=\"\\1\">\\1</a>");
+        QRegularExpression uri(QStringLiteral("<(.*)>"), QRegularExpression::InvertedGreedinessOption);
+        licenseInfoHTML.replace(uri, QStringLiteral("<a href=\"\\1\">\\1</a>"));
         // Replace newlines with HTML breaks
         licenseInfoHTML.replace("\n", "<br>");
 


### PR DESCRIPTION
Picking up https://github.com/bitcoin-core/gui/pull/606 (labeled "Up for grabs") and applying https://github.com/bitcoin-core/gui/pull/606#pullrequestreview-984607067 and https://github.com/bitcoin-core/gui/pull/606#issuecomment-1137149907.

Replaces occurrences of `QRegExp` usage with `QRegularExpression` as part of the roadmap for Qt6 integration.

Fixes https://github.com/bitcoin-core/gui/issues/578