### PR TITLE
Fix shortcut ambiguities

### DIFF
--- a/src/qt/forms/optionsdialog.ui
+++ b/src/qt/forms/optionsdialog.ui
@@ -752,7 +752,7 @@
             <string>Third-party URLs (e.g. a block explorer) that appear in the transactions tab as context menu items. %s in the URL is replaced by transaction hash. Multiple URLs are separated by vertical bar |.</string>
            </property>
            <property name="text">
-            <string>&amp;Third-party transaction URLs</string>
+            <string>&amp;Third-party transaction URLs:</string>
            </property>
            <property name="buddy">
             <cstring>thirdPartyTxUrls</cstring>

--- a/src/qt/forms/optionsdialog.ui
+++ b/src/qt/forms/optionsdialog.ui
@@ -108,7 +108,7 @@
             <string extracomment="Tooltip text for Options window setting that sets the size of the database cache. Explains the corresponding effects of increasing/decreasing this value.">Maximum database cache size. A larger cache can contribute to faster sync, after which the benefit is less pronounced for most use cases. Lowering the cache size will reduce memory usage. Unused mempool memory is shared for this cache.</string>
            </property>
            <property name="text">
-            <string>Size of &amp;database cache</string>
+            <string>S&amp;ize of database cache</string>
            </property>
            <property name="textFormat">
             <enum>Qt::PlainText</enum>
@@ -238,7 +238,7 @@
              <string>Whether to show coin control features or not.</string>
             </property>
             <property name="text">
-             <string>Enable coin &amp;control features</string>
+             <string>Enable co&amp;in control features</string>
             </property>
            </widget>
           </item>
@@ -351,7 +351,7 @@
           <string>Connect to the Bitcoin network through a SOCKS5 proxy.</string>
          </property>
          <property name="text">
-          <string>&amp;Connect through SOCKS5 proxy (default proxy):</string>
+          <string>Connect through &amp;SOCKS5 proxy (default proxy):</string>
          </property>
         </widget>
        </item>
@@ -662,7 +662,7 @@
           <string>Show only a tray icon after minimizing the window.</string>
          </property>
          <property name="text">
-          <string>&amp;Minimize to the tray instead of the taskbar</string>
+          <string>Minimize to the &amp;tray instead of the taskbar</string>
          </property>
         </widget>
        </item>


### PR DESCRIPTION
Picks up #129 
fixes #126 

- This PR addresses and fixes the shortcut collisions.
- This PR takes reference from [this](https://github.com/bitcoin-core/gui/issues/126#issuecomment-720837550) commit.

Changes done in this PR:

|Option whose shortcut is changed|From -> To|To avoid collision with|
|---------------------------------------------|---------|-----------------------------|
|Size of database cache|`D` -> `I`|**D**isplay tab|
|Enable coin control|`C` -> `a`|**C**ancel option|
|Connect through SOCKS5 proxy|`C` -> `S`|**C**ancel option|
|Minimize to tray instead of taskbar|`M` -> `T`|**M**ain tab|

Also, this PR address [this](https://github.com/bitcoin-core/gui/pull/129#issuecomment-725613606) comment in #129, which was suggested to add with the original PR.

> "Third party transaction URLs" string could be ended with `:`