### PR TITLE
Minor Formatting Fixes

### DIFF
--- a/src/qt/forms/receivecoinsdialog.ui
+++ b/src/qt/forms/receivecoinsdialog.ui
@@ -70,7 +70,7 @@
         <item row="2" column="2">
          <widget class="QLabel" name="label_5">
           <property name="text">
-           <string>Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</string>
+           <string>Use this form to request payments.&#160;All fields are &lt;b&gt;optional&lt;/b&gt;.</string>
           </property>
          </widget>
         </item>

--- a/src/qt/forms/sendcoinsdialog.ui
+++ b/src/qt/forms/sendcoinsdialog.ui
@@ -117,7 +117,7 @@
           <item>
            <widget class="QLabel" name="labelCoinControlAutomaticallySelected">
             <property name="text">
-             <string>automatically selected</string>
+             <string>Automatically selected</string>
             </property>
             <property name="margin">
              <number>5</number>


### PR DESCRIPTION
**Update receivecoinsdialog.ui** - Line 73 - Adding a whitespace character (&#160;) on the QT Receive Coins form instructions in order to show a space after the period in the application.

**Update sendcoinsdialog.ui** - Line 120 - Adding Sentence case to the label to maintain consistency