### PR TITLE
Add Import to Wallet GUI

### DIFF
--- a/build_msvc/libbitcoin_qt/libbitcoin_qt.vcxproj
+++ b/build_msvc/libbitcoin_qt/libbitcoin_qt.vcxproj
@@ -24,6 +24,7 @@
     <ClCompile Include="..\..\src\qt\csvmodelwriter.cpp" />
     <ClCompile Include="..\..\src\qt\editaddressdialog.cpp" />
     <ClCompile Include="..\..\src\qt\importdialog.cpp" />
+    <ClCompile Include="..\..\src\qt\importentry.cpp" />
     <ClCompile Include="..\..\src\qt\guiutil.cpp" />
     <ClCompile Include="..\..\src\qt\initexecutor.cpp" />
     <ClCompile Include="..\..\src\qt\intro.cpp" />
@@ -81,6 +82,7 @@
     <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_csvmodelwriter.cpp" />
     <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_editaddressdialog.cpp" />
     <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_importdialog.cpp" />
+    <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_importentry.cpp" />
     <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_guiutil.cpp" />
     <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_initexecutor.cpp" />
     <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_intro.cpp" />

--- a/build_msvc/libbitcoin_qt/libbitcoin_qt.vcxproj
+++ b/build_msvc/libbitcoin_qt/libbitcoin_qt.vcxproj
@@ -23,6 +23,7 @@
     <ClCompile Include="..\..\src\qt\createwalletdialog.cpp" />
     <ClCompile Include="..\..\src\qt\csvmodelwriter.cpp" />
     <ClCompile Include="..\..\src\qt\editaddressdialog.cpp" />
+    <ClCompile Include="..\..\src\qt\importdialog.cpp" />
     <ClCompile Include="..\..\src\qt\guiutil.cpp" />
     <ClCompile Include="..\..\src\qt\initexecutor.cpp" />
     <ClCompile Include="..\..\src\qt\intro.cpp" />
@@ -79,6 +80,7 @@
     <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_createwalletdialog.cpp" />
     <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_csvmodelwriter.cpp" />
     <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_editaddressdialog.cpp" />
+    <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_importdialog.cpp" />
     <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_guiutil.cpp" />
     <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_initexecutor.cpp" />
     <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_intro.cpp" />

--- a/build_msvc/test_bitcoin-qt/test_bitcoin-qt.vcxproj
+++ b/build_msvc/test_bitcoin-qt/test_bitcoin-qt.vcxproj
@@ -13,6 +13,7 @@
     <ClCompile Include="..\..\src\wallet\test\util.cpp" />
     <ClCompile Include="..\..\src\qt\test\addressbooktests.cpp" />
     <ClCompile Include="..\..\src\qt\test\apptests.cpp" />
+    <ClCompile Include="..\..\src\qt\test\importdescriptorstests.cpp" />
     <ClCompile Include="..\..\src\qt\test\importmultitests.cpp" />
     <ClCompile Include="..\..\src\qt\test\optiontests.cpp" />
     <ClCompile Include="..\..\src\qt\test\rpcnestedtests.cpp" />
@@ -23,6 +24,7 @@
     <ClCompile Include="..\..\src\wallet\test\wallet_test_fixture.cpp" />
     <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_addressbooktests.cpp" />
     <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_apptests.cpp" />
+    <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_importdescriptorstests.cpp" />
     <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_importmultitests.cpp" />
     <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_optiontests.cpp" />
     <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_rpcnestedtests.cpp" />
@@ -96,6 +98,7 @@
   <ItemGroup>
     <MocTestFiles Include="..\..\src\qt\test\addressbooktests.h" />
     <MocTestFiles Include="..\..\src\qt\test\apptests.h" />
+    <MocTestFiles Include="..\..\src\qt\test\importdescriptorstests.h" />
     <MocTestFiles Include="..\..\src\qt\test\importmultitests.h" />
     <MocTestFiles Include="..\..\src\qt\test\optiontests.h" />
     <MocTestFiles Include="..\..\src\qt\test\rpcnestedtests.h" />

--- a/build_msvc/test_bitcoin-qt/test_bitcoin-qt.vcxproj
+++ b/build_msvc/test_bitcoin-qt/test_bitcoin-qt.vcxproj
@@ -13,6 +13,7 @@
     <ClCompile Include="..\..\src\wallet\test\util.cpp" />
     <ClCompile Include="..\..\src\qt\test\addressbooktests.cpp" />
     <ClCompile Include="..\..\src\qt\test\apptests.cpp" />
+    <ClCompile Include="..\..\src\qt\test\importmultitests.cpp" />
     <ClCompile Include="..\..\src\qt\test\optiontests.cpp" />
     <ClCompile Include="..\..\src\qt\test\rpcnestedtests.cpp" />
     <ClCompile Include="..\..\src\qt\test\test_main.cpp" />
@@ -22,6 +23,7 @@
     <ClCompile Include="..\..\src\wallet\test\wallet_test_fixture.cpp" />
     <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_addressbooktests.cpp" />
     <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_apptests.cpp" />
+    <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_importmultitests.cpp" />
     <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_optiontests.cpp" />
     <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_rpcnestedtests.cpp" />
     <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_uritests.cpp" />
@@ -94,6 +96,7 @@
   <ItemGroup>
     <MocTestFiles Include="..\..\src\qt\test\addressbooktests.h" />
     <MocTestFiles Include="..\..\src\qt\test\apptests.h" />
+    <MocTestFiles Include="..\..\src\qt\test\importmultitests.h" />
     <MocTestFiles Include="..\..\src\qt\test\optiontests.h" />
     <MocTestFiles Include="..\..\src\qt\test\rpcnestedtests.h" />
     <MocTestFiles Include="..\..\src\qt\test\uritests.h" />

--- a/build_msvc/test_bitcoin-qt/test_bitcoin-qt.vcxproj
+++ b/build_msvc/test_bitcoin-qt/test_bitcoin-qt.vcxproj
@@ -14,6 +14,7 @@
     <ClCompile Include="..\..\src\qt\test\addressbooktests.cpp" />
     <ClCompile Include="..\..\src\qt\test\apptests.cpp" />
     <ClCompile Include="..\..\src\qt\test\importdescriptorstests.cpp" />
+    <ClCompile Include="..\..\src\qt\test\importlegacytests.cpp" />
     <ClCompile Include="..\..\src\qt\test\importmultitests.cpp" />
     <ClCompile Include="..\..\src\qt\test\optiontests.cpp" />
     <ClCompile Include="..\..\src\qt\test\rpcnestedtests.cpp" />
@@ -25,6 +26,7 @@
     <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_addressbooktests.cpp" />
     <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_apptests.cpp" />
     <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_importdescriptorstests.cpp" />
+    <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_importlegacytests.cpp" />
     <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_importmultitests.cpp" />
     <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_optiontests.cpp" />
     <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_rpcnestedtests.cpp" />
@@ -99,6 +101,7 @@
     <MocTestFiles Include="..\..\src\qt\test\addressbooktests.h" />
     <MocTestFiles Include="..\..\src\qt\test\apptests.h" />
     <MocTestFiles Include="..\..\src\qt\test\importdescriptorstests.h" />
+    <MocTestFiles Include="..\..\src\qt\test\importlegacytests.h" />
     <MocTestFiles Include="..\..\src\qt\test\importmultitests.h" />
     <MocTestFiles Include="..\..\src\qt\test\optiontests.h" />
     <MocTestFiles Include="..\..\src\qt\test\rpcnestedtests.h" />

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -332,6 +332,7 @@ BITCOIN_CORE_H = \
   wallet/external_signer_scriptpubkeyman.h \
   wallet/feebumper.h \
   wallet/fees.h \
+  wallet/imports.h \
   wallet/load.h \
   wallet/receive.h \
   wallet/rpc/util.h \
@@ -484,6 +485,7 @@ libbitcoin_wallet_a_SOURCES = \
   wallet/external_signer_scriptpubkeyman.cpp \
   wallet/feebumper.cpp \
   wallet/fees.cpp \
+  wallet/imports.cpp \
   wallet/interfaces.cpp \
   wallet/load.cpp \
   wallet/receive.cpp \

--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -21,6 +21,7 @@ QT_FORMS_UI = \
   qt/forms/editaddressdialog.ui \
   qt/forms/helpmessagedialog.ui \
   qt/forms/importdialog.ui \
+  qt/forms/importentry.ui \
   qt/forms/intro.ui \
   qt/forms/modaloverlay.ui \
   qt/forms/openuridialog.ui \
@@ -53,6 +54,7 @@ QT_MOC_CPP = \
   qt/moc_editaddressdialog.cpp \
   qt/moc_guiutil.cpp \
   qt/moc_importdialog.cpp \
+  qt/moc_importentry.cpp \
   qt/moc_initexecutor.cpp \
   qt/moc_intro.cpp \
   qt/moc_macdockiconhandler.cpp \
@@ -126,6 +128,7 @@ BITCOIN_QT_H = \
   qt/guiconstants.h \
   qt/guiutil.h \
   qt/importdialog.h \
+  qt/importentry.h \
   qt/initexecutor.h \
   qt/intro.h \
   qt/macdockiconhandler.h \
@@ -260,6 +263,7 @@ BITCOIN_QT_WALLET_CPP = \
   qt/createwalletdialog.cpp \
   qt/editaddressdialog.cpp \
   qt/importdialog.cpp \
+  qt/importentry.cpp \
   qt/openuridialog.cpp \
   qt/overviewpage.cpp \
   qt/paymentserver.cpp \

--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -20,6 +20,7 @@ QT_FORMS_UI = \
   qt/forms/createwalletdialog.ui \
   qt/forms/editaddressdialog.ui \
   qt/forms/helpmessagedialog.ui \
+  qt/forms/importdialog.ui \
   qt/forms/intro.ui \
   qt/forms/modaloverlay.ui \
   qt/forms/openuridialog.ui \
@@ -51,6 +52,7 @@ QT_MOC_CPP = \
   qt/moc_csvmodelwriter.cpp \
   qt/moc_editaddressdialog.cpp \
   qt/moc_guiutil.cpp \
+  qt/moc_importdialog.cpp \
   qt/moc_initexecutor.cpp \
   qt/moc_intro.cpp \
   qt/moc_macdockiconhandler.cpp \
@@ -123,6 +125,7 @@ BITCOIN_QT_H = \
   qt/editaddressdialog.h \
   qt/guiconstants.h \
   qt/guiutil.h \
+  qt/importdialog.h \
   qt/initexecutor.h \
   qt/intro.h \
   qt/macdockiconhandler.h \
@@ -256,6 +259,7 @@ BITCOIN_QT_WALLET_CPP = \
   qt/coincontroltreewidget.cpp \
   qt/createwalletdialog.cpp \
   qt/editaddressdialog.cpp \
+  qt/importdialog.cpp \
   qt/openuridialog.cpp \
   qt/overviewpage.cpp \
   qt/paymentserver.cpp \

--- a/src/Makefile.qttest.include
+++ b/src/Makefile.qttest.include
@@ -14,12 +14,14 @@ TEST_QT_MOC_CPP = \
 if ENABLE_WALLET
 TEST_QT_MOC_CPP += \
   qt/test/moc_addressbooktests.cpp \
+  qt/test/moc_importmultitests.cpp \
   qt/test/moc_wallettests.cpp
 endif # ENABLE_WALLET
 
 TEST_QT_H = \
   qt/test/addressbooktests.h \
   qt/test/apptests.h \
+  qt/test/importmultitests.h \
   qt/test/optiontests.h \
   qt/test/rpcnestedtests.h \
   qt/test/uritests.h \
@@ -36,12 +38,13 @@ qt_test_test_bitcoin_qt_SOURCES = \
   qt/test/rpcnestedtests.cpp \
   qt/test/test_main.cpp \
   qt/test/uritests.cpp \
-  qt/test/util.cpp \
   $(TEST_QT_H)
 if ENABLE_WALLET
 qt_test_test_bitcoin_qt_SOURCES += \
   qt/test/addressbooktests.cpp \
+  qt/test/importmultitests.cpp \
   qt/test/wallettests.cpp \
+  qt/test/util.cpp \
   wallet/test/wallet_test_fixture.cpp
 endif # ENABLE_WALLET
 

--- a/src/Makefile.qttest.include
+++ b/src/Makefile.qttest.include
@@ -14,6 +14,7 @@ TEST_QT_MOC_CPP = \
 if ENABLE_WALLET
 TEST_QT_MOC_CPP += \
   qt/test/moc_addressbooktests.cpp \
+  qt/test/moc_importdescriptorstests.cpp \
   qt/test/moc_importmultitests.cpp \
   qt/test/moc_wallettests.cpp
 endif # ENABLE_WALLET
@@ -21,6 +22,7 @@ endif # ENABLE_WALLET
 TEST_QT_H = \
   qt/test/addressbooktests.h \
   qt/test/apptests.h \
+  qt/test/importdescriptorstests.h \
   qt/test/importmultitests.h \
   qt/test/optiontests.h \
   qt/test/rpcnestedtests.h \
@@ -42,6 +44,7 @@ qt_test_test_bitcoin_qt_SOURCES = \
 if ENABLE_WALLET
 qt_test_test_bitcoin_qt_SOURCES += \
   qt/test/addressbooktests.cpp \
+  qt/test/importdescriptorstests.cpp \
   qt/test/importmultitests.cpp \
   qt/test/wallettests.cpp \
   qt/test/util.cpp \

--- a/src/Makefile.qttest.include
+++ b/src/Makefile.qttest.include
@@ -15,6 +15,7 @@ if ENABLE_WALLET
 TEST_QT_MOC_CPP += \
   qt/test/moc_addressbooktests.cpp \
   qt/test/moc_importdescriptorstests.cpp \
+  qt/test/moc_importlegacytests.cpp \
   qt/test/moc_importmultitests.cpp \
   qt/test/moc_wallettests.cpp
 endif # ENABLE_WALLET
@@ -23,6 +24,7 @@ TEST_QT_H = \
   qt/test/addressbooktests.h \
   qt/test/apptests.h \
   qt/test/importdescriptorstests.h \
+  qt/test/importlegacytests.h \
   qt/test/importmultitests.h \
   qt/test/optiontests.h \
   qt/test/rpcnestedtests.h \
@@ -45,6 +47,7 @@ if ENABLE_WALLET
 qt_test_test_bitcoin_qt_SOURCES += \
   qt/test/addressbooktests.cpp \
   qt/test/importdescriptorstests.cpp \
+  qt/test/importlegacytests.cpp \
   qt/test/importmultitests.cpp \
   qt/test/wallettests.cpp \
   qt/test/util.cpp \

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -395,6 +395,11 @@ void BitcoinGUI::createActions()
                 }
                 action = importWalletMenu->addAction("Import Address");
                 connect(action, &QAction::triggered, walletFrame, &WalletFrame::importAddress);
+                action = importWalletMenu->addAction("Import Multi");
+                connect(action, &QAction::triggered, walletFrame, &WalletFrame::importMulti);
+            } else {
+                QAction* action = importWalletMenu->addAction("Import Descriptors");
+                connect(action, &QAction::triggered, walletFrame, &WalletFrame::importDescriptors);
             }
         });
         connect(changePassphraseAction, &QAction::triggered, walletFrame, &WalletFrame::changePassphrase);

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -312,6 +312,9 @@ void BitcoinGUI::createActions()
     encryptWalletAction->setCheckable(true);
     backupWalletAction = new QAction(tr("&Backup Wallet…"), this);
     backupWalletAction->setStatusTip(tr("Backup wallet to another location"));
+    importWalletAction = new QAction(tr("&Import To Wallet…"), this);
+    importWalletAction->setStatusTip(tr("Import dialog"));
+    importWalletMenu = new QMenu(this);
     changePassphraseAction = new QAction(tr("&Change Passphrase…"), this);
     changePassphraseAction->setStatusTip(tr("Change the passphrase used for wallet encryption"));
     signMessageAction = new QAction(tr("Sign &message…"), this);
@@ -381,6 +384,19 @@ void BitcoinGUI::createActions()
     {
         connect(encryptWalletAction, &QAction::triggered, walletFrame, &WalletFrame::encryptWallet);
         connect(backupWalletAction, &QAction::triggered, walletFrame, &WalletFrame::backupWallet);
+        connect(importWalletMenu, &QMenu::aboutToShow, [this] {
+            importWalletMenu->clear();
+            if (walletFrame->currentWalletModel()->wallet().isLegacy()) {
+                QAction* action = importWalletMenu->addAction("Import Public Key");
+                connect(action, &QAction::triggered, walletFrame, &WalletFrame::importPubkey);
+                if (!walletFrame->currentWalletModel()->wallet().privateKeysDisabled()) {
+                    action = importWalletMenu->addAction("Import Private Key");
+                    connect(action, &QAction::triggered, walletFrame, &WalletFrame::importPrivkey);
+                }
+                action = importWalletMenu->addAction("Import Address");
+                connect(action, &QAction::triggered, walletFrame, &WalletFrame::importAddress);
+            }
+        });
         connect(changePassphraseAction, &QAction::triggered, walletFrame, &WalletFrame::changePassphrase);
         connect(signMessageAction, &QAction::triggered, [this]{ showNormalIfMinimized(); });
         connect(signMessageAction, &QAction::triggered, [this]{ gotoSignMessageTab(); });
@@ -484,6 +500,7 @@ void BitcoinGUI::createMenuBar()
         file->addAction(m_close_all_wallets_action);
         file->addSeparator();
         file->addAction(backupWalletAction);
+        file->addAction(importWalletAction);
         file->addAction(m_restore_wallet_action);
         file->addSeparator();
         file->addAction(openAction);
@@ -791,6 +808,8 @@ void BitcoinGUI::setWalletActionsEnabled(bool enabled)
     historyAction->setEnabled(enabled);
     encryptWalletAction->setEnabled(enabled);
     backupWalletAction->setEnabled(enabled);
+    importWalletAction->setEnabled(enabled);
+    importWalletAction->setMenu(importWalletMenu);
     changePassphraseAction->setEnabled(enabled);
     signMessageAction->setEnabled(enabled);
     verifyMessageAction->setEnabled(enabled);

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -149,6 +149,8 @@ private:
     QAction* optionsAction = nullptr;
     QAction* encryptWalletAction = nullptr;
     QAction* backupWalletAction = nullptr;
+    QAction* importWalletAction = nullptr;
+    QMenu* importWalletMenu{nullptr};
     QAction* changePassphraseAction = nullptr;
     QAction* aboutQtAction = nullptr;
     QAction* openRPCConsoleAction = nullptr;

--- a/src/qt/forms/importdialog.ui
+++ b/src/qt/forms/importdialog.ui
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ImportDialog</class>
+ <widget class="QDialog" name="ImportDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>440</width>
+    <height>80</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>300</width>
+    <height>0</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>Import Dialog</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="sizeConstraint">
+    <enum>QLayout::SetMinimumSize</enum>
+   </property>
+   <item>
+    <widget class="QStackedWidget" name="QStackContainer">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <widget class="QWidget" name="importKeyPage">
+       <layout class="QFormLayout" name="formLayout">
+        <property name="sizeConstraint">
+         <enum>QLayout::SetMinimumSize</enum>
+        </property>
+        <property name="fieldGrowthPolicy">
+         <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+        </property>
+        <item row="0" column="0">
+         <widget class="QLabel" name="keyLabelIKP">
+          <property name="text">
+           <string>Default</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="QLineEdit" name="keyEditIKP">
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="labelLabelIKP">
+          <property name="text">
+           <string>Label</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <widget class="QLineEdit" name="labelEditIKP">
+          <property name="toolTip">
+           <string>Enter a label</string>
+          </property>
+          <property name="placeholderText">
+           <string>Enter a label</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="1">
+         <layout class="QHBoxLayout" name="horizontalLayoutAmount" stretch="0,0,0">
+          <property name="spacing">
+           <number>10</number>
+          </property>
+          <item>
+           <widget class="QCheckBox" name="rescanButtonIKP">
+            <property name="text">
+             <string>Rescan</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="p2shButtonIKP">
+            <property name="text">
+             <string>P2SH</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+       </layout>
+     </widget>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>ImportDialog</receiver>
+   <slot>accept()</slot>
+  </connection>
+ </connections>
+</ui>

--- a/src/qt/forms/importdialog.ui
+++ b/src/qt/forms/importdialog.ui
@@ -96,6 +96,81 @@
         </item>
        </layout>
      </widget>
+     <widget class="QWidget" name="importEntries">
+      <layout class="QVBoxLayout" name="verticalLayout_5">
+       <property name="sizeConstraint">
+        <enum>QLayout::SetMinimumSize</enum>
+       </property>
+       <item>
+        <widget class="QScrollArea" name="scrollArea">
+         <property name="widgetResizable">
+          <bool>true</bool>
+         </property>
+         <widget class="QWidget" name="scrollAreaWidgetContents">
+          <property name="geometry">
+           <rect>
+            <x>0</x>
+            <y>0</y>
+            <width>830</width>
+            <height>104</height>
+           </rect>
+          </property>
+          <layout class="QVBoxLayout" name="verticalLayout_2" stretch="0,1">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
+           <item>
+            <layout class="QVBoxLayout" name="entries">
+             <property name="spacing">
+              <number>6</number>
+             </property>
+            </layout>
+           </item>
+           <item>
+            <spacer name="verticalSpacer">
+             <property name="orientation">
+              <enum>Qt::Vertical</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>20</width>
+               <height>40</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
+         </widget>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="addButton">
+         <property name="toolTip">
+          <string>Send to multiple recipients at once</string>
+         </property>
+         <property name="text">
+          <string>Add &amp;Recipient</string>
+         </property>
+         <property name="icon">
+          <iconset resource="../bitcoin.qrc">
+           <normaloff>:/icons/add</normaloff>:/icons/add</iconset>
+         </property>
+         <property name="autoDefault">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
    <item>

--- a/src/qt/forms/importentry.ui
+++ b/src/qt/forms/importentry.ui
@@ -1,0 +1,538 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ImportEntry</class>
+ <widget class="QStackedWidget" name="ImportEntry">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>729</width>
+    <height>150</height>
+   </rect>
+  </property>
+  <property name="focusPolicy">
+   <enum>Qt::TabFocus</enum>
+  </property>
+  <property name="autoFillBackground">
+   <bool>false</bool>
+  </property>
+  <widget class="QFrame" name="importDescriptorsEntry">
+   <property name="frameShape">
+    <enum>QFrame::NoFrame</enum>
+   </property>
+   <layout class="QGridLayout" name="gridLayoutDescriptor">
+    <property name="sizeConstraint">
+     <enum>QLayout::SetMinimumSize</enum>
+    </property>
+    <property name="topMargin">
+     <number>8</number>
+    </property>
+    <property name="bottomMargin">
+     <number>4</number>
+    </property>
+    <property name="horizontalSpacing">
+     <number>12</number>
+    </property>
+    <property name="verticalSpacing">
+     <number>8</number>
+    </property>
+    <item row="0" column="0">
+     <widget class="QLabel" name="descriptorLabel">
+      <property name="text">
+       <string>Desc:</string>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+      </property>
+     </widget>
+    </item>
+    <item row="0" column="1">
+     <layout class="QHBoxLayout" name="payToLayout">
+      <property name="spacing">
+       <number>10</number>
+      </property>
+      <item>
+       <widget class="QLineEdit" name="descriptor">
+        <property name="toolTip">
+         <string>Enter descriptor</string>
+        </property>
+        <property name="placeholderText">
+         <string>Enter descriptor</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QToolButton" name="deleteDescriptorButton">
+        <property name="toolTip">
+         <string>Remove this entry</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="icon">
+         <iconset resource="../bitcoin.qrc">
+          <normaloff>:/icons/remove</normaloff>:/icons/remove</iconset>
+        </property>
+        <property name="iconSize">
+         <size>
+          <width>22</width>
+          <height>22</height>
+         </size>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </item>
+    <item row="1" column="0">
+     <widget class="QLabel" name="labelLabel">
+      <property name="text">
+       <string>Label:</string>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+      </property>
+     </widget>
+    </item>
+    <item row="1" column="1">
+     <widget class="QLineEdit" name="label">
+      <property name="toolTip">
+       <string>Label to assign to the address, only allowed with internal=false</string>
+      </property>
+      <property name="placeholderText">
+       <string>Enter a label for this address to add it to the list of used addresses</string>
+      </property>
+     </widget>
+    </item>
+    <item row="2" column="0">
+     <widget class="QLabel" name="timestampLabel">
+      <property name="text">
+       <string> Timestamp:</string>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+      </property>
+     </widget>
+    </item>
+    <item row="2" column="1">
+     <layout class="QHBoxLayout" name="horizontalLayoutTimestamp" stretch="0,0,0">
+      <property name="spacing">
+       <number>10</number>
+      </property>
+      <item>
+       <widget class="QLineEdit" name="timestamp">
+        <property name="toolTip">
+         <string>Enter an epoch timestamp or nothing for the current time</string>
+        </property>
+        <property name="placeholderText">
+         <string>Enter an epoch timestamp or nothing for the current time</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="checkboxActive">
+        <property name="text">
+         <string>Active</string>
+        </property>
+        <property name="toolTip">
+         <string>The fee will be deducted from the amount being sent. The recipient will receive less bitcoins than you enter in the amount field. If multiple recipients are selected, the fee is split equally.</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="checkboxInternal">
+        <property name="text">
+         <string>Internal</string>
+        </property>
+        <property name="toolTip">
+         <string>The fee will be deducted from the amount being sent. The recipient will receive less bitcoins than you enter in the amount field. If multiple recipients are selected, the fee is split equally.</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="hiddenButton">
+        <property name="text">
+         <string>▽</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </item>
+    <item row="3" column="0" >
+     <widget class="QLabel" name="nextIndexLabel">
+      <property name="text">
+       <string>Next Index:</string>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+      </property>
+     </widget>
+    </item>
+    <item row="3" column="1">
+     <widget class="QWidget" name="hiddenMenu">
+      <layout class="QHBoxLayout" name="nextIndexLayout">
+       <property name="spacing">
+        <number>10</number>
+       </property>
+       <item>
+        <widget class="QSpinBox" name="nextIndex">
+         <property name="toolTip">
+          <string>If a ranged descriptor is set to active, this specifies the next index to generate addresses from</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="range">
+         <property name="text">
+          <string>Range:</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QSpinBox" name="startRange">
+         <property name="toolTip">
+          <string>If a ranged descriptor is used, this specifies the end or the range (in the form [begin,end]) to import</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QSpinBox" name="endRange">
+         <property name="toolTip">
+          <string>If a ranged descriptor is used, this specifies the end or the range (in the form [begin,end]) to import</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </item>
+    <item row="4" column="0" colspan="2">
+     <widget class="Line" name="line">
+      <property name="orientation">
+       <enum>Qt::Horizontal</enum>
+      </property>
+     </widget>
+    </item>
+   </layout>
+  </widget>
+  <widget class="QFrame" name="importMultiEntry">
+   <property name="frameShape">
+    <enum>QFrame::NoFrame</enum>
+   </property>
+   <layout class="QGridLayout" name="gridLayoutMulti">
+    <property name="topMargin">
+     <number>8</number>
+    </property>
+    <property name="bottomMargin">
+     <number>4</number>
+    </property>
+    <property name="horizontalSpacing">
+     <number>12</number>
+    </property>
+    <property name="verticalSpacing">
+     <number>8</number>
+    </property>
+    <item row="0" column="0" colspan="2">
+     <layout class="QHBoxLayout">
+      <property name="spacing">
+       <number>10</number>
+      </property>
+     <item>
+      <widget class="QRadioButton" name="importScriptPubKeyRadio">
+       <property name="text">
+        <string>Import scriptPubKey</string>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QRadioButton" name="importDescriptorRadio">
+       <property name="text">
+        <string>Import Descriptor</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="deleteMultiButton">
+       <property name="toolTip">
+        <string>Remove this entry</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="icon">
+        <iconset resource="../bitcoin.qrc">
+         <normaloff>:/icons/remove</normaloff>:/icons/remove</iconset>
+       </property>
+       <property name="iconSize">
+        <size>
+         <width>22</width>
+         <height>22</height>
+        </size>
+       </property>
+      </widget>
+     </item>
+     </layout>
+    </item>
+    <item row="1" column="0">
+     <widget class="QLabel" name="scriptPubKeyLabel">
+      <property name="text">
+       <string>scriptPubKey:</string>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+      </property>
+     </widget>
+    </item>
+    <item row="1" column="1">
+     <layout class="QHBoxLayout" name="horizontalLayoutHideScript" stretch="0,0,0">
+      <property name="spacing">
+       <number>10</number>
+      </property>
+      <item>
+       <widget class="QLineEdit" name="scriptPubKey">
+        <property name="toolTip">
+         <string>Enter Address or scriptPubKey</string>
+        </property>
+        <property name="placeholderText">
+         <string>Enter Address or scriptPubKey</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="hideScriptsButton">
+        <property name="text">
+         <string>▽</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </item>
+    <item row="2" column="0">
+     <widget class="QLabel" name="redeemScriptLabel">
+      <property name="text">
+       <string>Redeem Script:</string>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+      </property>
+     </widget>
+    </item>
+    <item row="2" column="1">
+     <widget class="QLineEdit" name="redeemScript">
+      <property name="toolTip">
+       <string>Allowed only if the scriptPubKey is a P2SH or P2SH-P2WSH address/scriptPubKey</string>
+      </property>
+      <property name="placeholderText">
+       <string>Allowed only if the scriptPubKey is a P2SH or P2SH-P2WSH address/scriptPubKey</string>
+      </property>
+     </widget>
+    </item>
+    <item row="3" column="0">
+     <widget class="QLabel" name="witnessScriptLabel">
+      <property name="text">
+       <string>Witness Script:</string>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+      </property>
+     </widget>
+    </item>
+    <item row="3" column="1">
+     <widget class="QLineEdit" name="witnessScript">
+      <property name="toolTip">
+       <string>Allowed only if the scriptPubKey is a P2SH or P2SH-P2WSH address/scriptPubKey</string>
+      </property>
+      <property name="placeholderText">
+       <string>Allowed only if the scriptPubKey is a P2SH or P2SH-P2WSH address/scriptPubKey</string>
+      </property>
+     </widget>
+    </item>
+    <item row="4" column="0">
+     <widget class="QLabel" name="publicKeyLabel">
+      <property name="text">
+       <string>Public Key:</string>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+      </property>
+     </widget>
+    </item>
+    <item row="4" column="1">
+     <widget class="QLineEdit" name="publicKey">
+      <property name="toolTip">
+       <string>Enter Public Keys comma separated (e.g. value1,value2,value3)</string>
+      </property>
+      <property name="placeholderText">
+       <string>Enter Public Keys comma separated (e.g. value1,value2,value3)</string>
+      </property>
+     </widget>
+    </item>
+    <item row="5" column="0" >
+     <widget class="QLabel" name="descLabelMulti">
+      <property name="text">
+       <string>Descriptor:</string>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+      </property>
+     </widget>
+    </item>
+    <item row="5" column="1">
+     <widget class="QWidget" name="descMulti">
+      <layout class="QHBoxLayout" name="descLayoutMulti">
+       <property name="spacing">
+        <number>10</number>
+       </property>
+       <item>
+        <widget class="QLineEdit" name="desccMulti">
+         <property name="toolTip">
+          <string>Enter descriptor</string>
+         </property>
+         <property name="placeholderText">
+          <string>Enter descriptor</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="rangeMulti">
+         <property name="text">
+          <string>Range:</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QSpinBox" name="startRangeMulti">
+         <property name="toolTip">
+          <string>If a ranged descriptor is used, this specifies the end or the range (in the form [begin,end]) to import</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QSpinBox" name="endRangeMulti">
+         <property name="toolTip">
+          <string>If a ranged descriptor is used, this specifies the end or the range (in the form [begin,end]) to import</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </item>
+    <item row="6" column="0">
+     <widget class="QLabel" name="privateKeyLabel">
+      <property name="text">
+       <string>Private Key:</string>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+      </property>
+     </widget>
+    </item>
+    <item row="6" column="1">
+     <widget class="QLineEdit" name="privateKey">
+      <property name="toolTip">
+       <string>Enter Private Keys comma separated (e.g. value1,value2,value3)</string>
+      </property>
+      <property name="placeholderText">
+       <string>Enter Private Keys comma separated (e.g. value1,value2,value3)</string>
+      </property>
+     </widget>
+    </item>
+    <item row="7" column="0">
+     <widget class="QLabel" name="timestampLabelMulti">
+      <property name="text">
+       <string> Timestamp:</string>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+      </property>
+     </widget>
+    </item>
+    <item row="7" column="1">
+     <layout class="QHBoxLayout" name="horizontalLayoutTimestampMulti" stretch="0,0,0">
+      <property name="spacing">
+       <number>10</number>
+      </property>
+      <item>
+       <widget class="QLineEdit" name="timestampMulti">
+        <property name="toolTip">
+         <string>Enter an epoch timestamp or nothing for the current time</string>
+        </property>
+        <property name="placeholderText">
+         <string>Enter an epoch timestamp or nothing for the current time</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="checkboxInternalMulti">
+        <property name="text">
+         <string>Internal</string>
+        </property>
+        <property name="toolTip">
+         <string>Stating whether matching outputs should be treated as not incoming payments (also known as change)</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="checkboxKeyPoolMulti">
+        <property name="text">
+         <string>Key Pool</string>
+        </property>
+        <property name="toolTip">
+         <string>Stating whether imported public keys should be added to the keypool for when users request new addresses. Only allowed when wallet private keys are disabled</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="checkboxWatchOnlyMulti">
+        <property name="text">
+         <string>Watch only</string>
+        </property>
+        <property name="toolTip">
+         <string>Stating whether matching outputs should be considered watchonly.</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </item>
+    <item row="8" column="0">
+     <widget class="QLabel" name="labelLabelMulti">
+      <property name="text">
+       <string>Label:</string>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+      </property>
+     </widget>
+    </item>
+    <item row="8" column="1">
+     <widget class="QLineEdit" name="labelMulti">
+      <property name="toolTip">
+       <string>Label to assign to the address, only allowed with internal=false</string>
+      </property>
+      <property name="placeholderText">
+       <string>Enter a label for this address to add it to the list of used addresses</string>
+      </property>
+     </widget>
+    </item>
+    <item row="9" column="0" colspan="2">
+     <widget class="Line" name="lineMulti">
+      <property name="orientation">
+       <enum>Qt::Horizontal</enum>
+      </property>
+     </widget>
+    </item>
+   </layout>
+  </widget>
+ </widget>
+ <resources>
+  <include location="../bitcoin.qrc"/>
+ </resources>
+ <connections/>
+</ui>

--- a/src/qt/importdialog.cpp
+++ b/src/qt/importdialog.cpp
@@ -1,5 +1,6 @@
 #include <qt/importdialog.h>
 #include <qt/forms/ui_importdialog.h>
+#include <qt/importentry.h>
 
 #include <qt/guiconstants.h>
 #include <qt/guiutil.h>
@@ -15,6 +16,23 @@
 #include <QScrollBar>
 #include <tinyformat.h>
 #include <chain.h>
+
+void RangeDescriptorCheck(int64_t low, int64_t high)
+{
+    if (low > high) {
+        throw wallet::InvalidParameter("Range specified as [begin,end] must not have begin after end");
+    }
+    if (low < 0) {
+        throw wallet::InvalidParameter("Range should be greater or equal than 0");
+    }
+    if ((high >> 31) != 0) {
+        throw wallet::InvalidParameter("End of range is too high");
+    }
+    if (high >= low + 1000000) {
+        throw wallet::InvalidParameter("Range is too large");
+    }
+    return;
+}
 
 ImportDialog::ImportDialog(Page _page, WalletModel *walletModel, QWidget *parent) :
     QDialog(parent, GUIUtil::dialog_flags),
@@ -49,6 +67,23 @@ ImportDialog::ImportDialog(Page _page, WalletModel *walletModel, QWidget *parent
             ui->rescanButtonIKP->setCheckState(Qt::Checked);
             ui->p2shButtonIKP->setCheckState(Qt::Unchecked);
             break;
+        } case importMulti: {
+            ui->QStackContainer->setCurrentWidget(ui->importEntries);
+            this->setWindowTitle("Import Multi");
+            this->resize(240, this->height());
+            this->resize(650, this->width());
+            addEntry();
+            connect(ui->addButton, &QPushButton::clicked, this, &ImportDialog::addEntry);
+            break;
+        }
+        case importDescriptors: {
+            ui->QStackContainer->setCurrentWidget(ui->importEntries);
+            this->setWindowTitle("Import Descriptors");
+            this->resize(240, this->height());
+            this->resize(650, this->width());
+            addEntry();
+            connect(ui->addButton, &QPushButton::clicked, this, &ImportDialog::addEntry);
+            break;
         }
     }
 
@@ -59,6 +94,20 @@ ImportDialog::~ImportDialog()
 {
     delete ui;
 }
+
+int64_t ImportDialog::GetImportTimestamp(const int64_t &entry, int64_t now) {
+    if (entry) {
+        return entry;
+    } else {
+        return now;
+    }
+}
+
+struct resultpdi {
+    bool success;
+    std::vector<std::string> warnings;
+    std::string error;
+};
 
 void ImportDialog::accept() {
     // Whether to perform rescan after import
@@ -121,6 +170,7 @@ void ImportDialog::accept() {
                 }
                 walletModel->wallet().ResubmitWalletTransactions(/*relay=*/false, /*force=*/true);
             }
+            QMessageBox::information(this, tr("Import Succeeded"), tr("Import Succeeded"));
             break;
         }
         case importPrivkey: {
@@ -154,7 +204,7 @@ void ImportDialog::accept() {
                     return;
                 }
             }
-
+            QMessageBox::information(this, tr("Import Succeeded"), tr("Import Succeeded"));
             break;
         }
         case importAddress: {
@@ -183,9 +233,347 @@ void ImportDialog::accept() {
                 }
                 walletModel->wallet().ResubmitWalletTransactions(/*relay=*/false, /*force=*/true);
             }
+            QMessageBox::information(this, tr("Import Succeeded"), tr("Import Succeeded"));
+            break;
+        }
+        case importMulti: {
+            int64_t now = 0;
+            bool fRunScan = false;
+            int64_t nLowestTimestamp = 0;
+            std::vector<resultpdi> response;
+
+            WalletModel::UnlockContext ctx(walletModel->requestUnlock());
+            if (!ctx.isValid()) {
+                return;
+            }
+
+            // Verify all timestamps are present before importing any keys.
+            CHECK_NONFATAL(walletModel->wallet().chain().findBlock(walletModel->wallet().GetLastBlockHash(),
+                                                                   interfaces::FoundBlock().time(nLowestTimestamp).mtpTime(now)));
+            const int64_t minimumTimestamp = 1;
+
+            for (int i = 0; i < ui->entries->count(); ++i) {
+                ImportEntry *entry = qobject_cast<ImportEntry *>(ui->entries->itemAt(i)->widget());
+                wallet::ImportMultiData mData = entry->getMultiData();
+                const int64_t timestamp = std::max(GetImportTimestamp(mData.timestamp, now), minimumTimestamp);
+                resultpdi result;
+
+                try {
+                    // Internal addresses should not have a label
+                    if (mData.internal && !mData.label.empty()) {
+                        throw wallet::InvalidParameter("Internal addresses should not have a label");
+                    }
+
+                    if (!mData.scriptPubKey.empty()) {
+                        // if the input isn't a valid address assume it is a script
+                        CTxDestination dest = DecodeDestination(mData.scriptPubKey);
+                        if (!IsValidDestination(dest)) {
+                            mData.isScript = true;
+                        }
+                    } else {
+                        std::string error;
+                        mData.parsed_desc = Parse(entry->getDesc(), mData.keys, error, /* require_checksum = */ true);
+                        if (!mData.parsed_desc) {
+                            throw wallet::InvalidAddressOrKey(error);
+                        }
+                        if (mData.parsed_desc->GetOutputType() == OutputType::BECH32M) {
+                            throw wallet::InvalidAddressOrKey("Bech32m descriptors cannot be imported into legacy wallets");
+                        }
+                        bool range_exists = mData.range_start > 0 || mData.range_end > 0;
+                        if (!mData.parsed_desc->IsRange() && range_exists) {
+                            throw wallet::InvalidParameter("Range should not be specified for an un-ranged descriptor");
+                        } else if (mData.parsed_desc->IsRange()) {
+                            if (!range_exists) {
+                                throw wallet::InvalidParameter("Descriptor is ranged, please specify the range");
+                            }
+                            RangeDescriptorCheck(mData.range_start, mData.range_end);
+                        }
+                    }
+                    walletModel->wallet().processImport(mData, result.warnings, timestamp);
+                    result.success = true;
+                } catch (const wallet::MiscError& e) {
+                    result.success = false;
+                    result.error = e.error;
+                } catch (const wallet::WalletError& e) {
+                    result.success = false;
+                    result.error = e.error;
+                } catch (const wallet::InvalidAddressOrKey& e) {
+                    result.success = false;
+                    result.error = e.error;
+                } catch (const wallet::InvalidParameter& e) {
+                    result.success = false;
+                    result.error = e.error;
+                } catch (...) {
+                    result.success = false;
+                    result.error = "Missing required fields";
+                }
+
+                response.push_back(result);
+
+                if (!fRescan) {
+                    continue;
+                }
+
+                // If at least one request was successful then allow rescan.
+                if (result.success) {
+                    fRunScan = true;
+                }
+
+                // Get the lowest timestamp.
+                if (timestamp < nLowestTimestamp) {
+                    nLowestTimestamp = timestamp;
+                }
+            }
+
+            if (fRescan && fRunScan && ui->entries->count()) {
+                int64_t scannedTime = walletModel->wallet().RescanFromTime(nLowestTimestamp, reserver, true);
+                walletModel->wallet().ResubmitWalletTransactions(/*relay=*/false, /*force=*/true);
+
+                if (walletModel->wallet().IsAbortingRescan()) {
+                    QMessageBox::critical(this, tr("Misc Error"),
+                                          tr("Rescan aborted by user."));
+
+                    if (scannedTime > nLowestTimestamp) {
+                        std::vector <resultpdi> results = response;
+                        response.clear();
+
+                        for (int i = 0; i < ui->entries->count(); ++i) {
+                            ImportEntry *entry = qobject_cast<ImportEntry *>(ui->entries->itemAt(i)->widget());
+                            // If key creation date is within the successfully scanned
+                            // range, or if the import result already has an error set, let
+                            // the result stand unmodified. Otherwise, replace the result
+                            // with an error message.
+                            if (scannedTime <= GetImportTimestamp(entry->getMultiData().timestamp, now) || !results.at(i).error.empty()) {
+                                response.push_back(results.at(i));
+                            } else {
+                                resultpdi result;
+                                result.success = false;
+                                result.error = strprintf(
+                                                "Rescan failed for key with creation timestamp %d. There was an error reading a "
+                                                "block from time %d, which is after or within %d seconds of key creation, and "
+                                                "could contain transactions pertaining to the key. As a result, transactions "
+                                                "and coins using this key may not appear in the wallet. This error could be "
+                                                "caused by pruning or data corruption (see bitcoind log for details) and could "
+                                                "be dealt with by downloading and rescanning the relevant blocks (see -reindex "
+                                                "option and rescanblockchain RPC).",
+                                                GetImportTimestamp(entry->getMultiData().timestamp, now), scannedTime - TIMESTAMP_WINDOW - 1,
+                                                TIMESTAMP_WINDOW);
+                                response.push_back(std::move(result));
+                            }
+                        }
+                    }
+                }
+            }
+
+            bool success = false;
+            for (size_t i = 0; i < response.size(); i++) {
+                if (response[i].success) {
+                    std::string warning_str;
+                    if (response[i].warnings.size() != 0) {
+                        warning_str = "\nWarnings: ";
+                        for (const auto& w: response[i].warnings) {
+                            warning_str += w + "\n";
+                        }
+                    }
+                    QMessageBox::information(this, QString::fromStdString(strprintf("Import Succeeded: input box # %d", i)),
+                                             QString::fromStdString("Import Succeeded" + warning_str));
+                } else {
+                    success = true;
+                    QMessageBox::critical(this, QString::fromStdString(strprintf("Error: input box # %d", i)),
+                                          QString::fromStdString("Error: " + response[i].error));
+                }
+            }
+            if (success) return;
+            break;
+        }
+        case importDescriptors: {
+            const int64_t minimum_timestamp = 1;
+            int64_t now = 0;
+            int64_t lowest_timestamp = 0;
+            bool rescan = false;
+            std::vector<resultpdi> response;
+
+            WalletModel::UnlockContext ctx(walletModel->requestUnlock());
+            if (!ctx.isValid()) {
+                return;
+            }
+
+            CHECK_NONFATAL(walletModel->wallet().chain().findBlock(walletModel->wallet().GetLastBlockHash(),
+                                                                   interfaces::FoundBlock().time(lowest_timestamp).mtpTime(now)));
+
+            // Get all timestamps and extract the lowest timestamp
+            for (int i = 0; i < ui->entries->count(); ++i) {
+                ImportEntry *entry = qobject_cast<ImportEntry *>(ui->entries->itemAt(i)->widget());
+
+                // This throws an error if "timestamp" doesn't exist
+                wallet::ImportDescriptorData dData = entry->getDescriptorData();
+                const int64_t timestamp = std::max(GetImportTimestamp(dData.timestamp, now), minimum_timestamp);
+                resultpdi result;
+
+                try {
+                    if (entry->getDesc().empty()) {
+                        throw wallet::InvalidParameter("Descriptor not found.");
+                    }
+
+                    // Parse descriptor string
+                    FlatSigningProvider keys;
+                    std::string error;
+                    dData.parsed_desc = Parse(entry->getDesc(), keys, error, /* require_checksum = */ true);
+                    if (!dData.parsed_desc) {
+                        throw wallet::InvalidAddressOrKey(error);
+                    }
+
+                    bool range_exists = dData.range_start > 0 || dData.range_end > 0;
+                    if (!dData.parsed_desc->IsRange() && range_exists) {
+                        throw wallet::InvalidParameter("Range should not be specified for an un-ranged descriptor");
+                    } else if (dData.parsed_desc->IsRange()) {
+                        if (!range_exists) {
+                            result.warnings.push_back("Range not given, using default keypool range");
+                            dData.range_start = 0;
+                            dData.range_end = walletModel->wallet().GetKeypoolSize();
+                        } else {
+                            RangeDescriptorCheck(dData.range_start, dData.range_end);
+                            dData.range_end++;
+                        }
+
+                        if (dData.next_index) {
+                            // bound checks
+                            if (dData.next_index < dData.range_start || dData.next_index >= dData.range_end) {
+                                throw wallet::InvalidParameter("next_index is out of range");
+                            }
+                        } else {
+                            dData.next_index = dData.range_start;
+                        }
+                    } else {
+                        dData.range_start = 0, dData.range_end = 1, dData.next_index = 0;
+                    }
+
+                    walletModel->wallet().processDescriptorImport(dData, result.warnings, keys, range_exists, timestamp);
+                    result.success = true;
+                } catch (const wallet::MiscError& e) {
+                    result.success = false;
+                    result.error = e.error;
+                } catch (const wallet::WalletError& e) {
+                    result.success = false;
+                    result.error = e.error;
+                } catch (const wallet::InvalidAddressOrKey& e) {
+                    result.success = false;
+                    result.error = e.error;
+                } catch (const wallet::InvalidParameter& e) {
+                    result.success = false;
+                    result.error = e.error;
+                }
+
+                response.push_back(result);
+
+                if (lowest_timestamp > timestamp) {
+                    lowest_timestamp = timestamp;
+                }
+
+                // If we know the chain tip, and at least one request was successful then allow rescan
+                if (!rescan && result.success) {
+                    rescan = true;
+                }
+            }
+            walletModel->wallet().ConnectScriptPubKeyManNotifiers();
+
+            // Rescan the blockchain using the lowest timestamp
+            if (rescan) {
+                int64_t scanned_time = walletModel->wallet().RescanFromTime(lowest_timestamp, reserver, true);
+                walletModel->wallet().ResubmitWalletTransactions(/*relay=*/false, /*force=*/true);
+
+                if (walletModel->wallet().IsAbortingRescan()) {
+                    QMessageBox::critical(this, tr("Misc Error"),
+                                          tr("Rescan aborted by user."));
+
+                    if (scanned_time > lowest_timestamp) {
+                        std::vector<resultpdi> results = response;
+                        response.clear();
+
+                        for (int i = 0; i < ui->entries->count(); ++i) {
+                            ImportEntry *entry = qobject_cast<ImportEntry *>(ui->entries->itemAt(i)->widget());
+
+                            // If the descriptor timestamp is within the successfully scanned
+                            // range, or if the import result already has an error set, let
+                            // the result stand unmodified. Otherwise, replace the result
+                            // with an error message.
+                            if (scanned_time <= GetImportTimestamp(entry->getDescriptorData().timestamp, now) || !results.at(i).error.empty()) {
+                                response.push_back(results.at(i));
+                            } else {
+                                resultpdi result;
+                                result.success = false;
+                                result.error = strprintf(
+                                            "Rescan failed for descriptor with timestamp %d. There was an error reading a "
+                                            "block from time %d, which is after or within %d seconds of key creation, and "
+                                            "could contain transactions pertaining to the desc. As a result, transactions "
+                                            "and coins using this desc may not appear in the wallet. This error could be "
+                                            "caused by pruning or data corruption (see bitcoind log for details) and could "
+                                            "be dealt with by downloading and rescanning the relevant blocks (see -reindex "
+                                            "option and rescanblockchain RPC).",
+                                            GetImportTimestamp(entry->getDescriptorData().timestamp, now),
+                                            scanned_time - TIMESTAMP_WINDOW - 1, TIMESTAMP_WINDOW);
+                                response.push_back(std::move(result));
+                            }
+                        }
+                    }
+                }
+            }
+
+            bool success = false;
+            for (size_t i = 0; i < response.size(); i++) {
+                if (response[i].success) {
+                    std::string warning_str;
+                    if (response[i].warnings.size() != 0) {
+                        warning_str = "\nWarnings: ";
+                        for (const auto& w: response[i].warnings) {
+                            warning_str += w + "\n";
+                        }
+                    }
+                    QMessageBox::information(this, QString::fromStdString(strprintf("Import Succeeded: input box # %d", i)),
+                                             QString::fromStdString("Import Succeeded" + warning_str));
+                } else {
+                    success = true;
+                    QMessageBox::critical(this, QString::fromStdString(strprintf("Error: input box # %d", i)),
+                                          QString::fromStdString("Error: " + response[i].error));
+                }
+            }
+            if (success) return;
             break;
         }
     }
-    QMessageBox::information(this, tr("Import Succeeded"), tr("Import Succeeded"));
     QDialog::accept();
+}
+
+ImportEntry *ImportDialog::addEntry()
+{
+    ImportEntry *entry = nullptr;
+    if (page == Page::importMulti) {
+        entry = new ImportEntry(ImportEntry::importMultiEntry, this);
+    } else {
+        entry = new ImportEntry(ImportEntry::importDescriptorsEntry, this);
+    }
+    entry->setModel(walletModel);
+    ui->entries->addWidget(entry);
+    connect(entry, &ImportEntry::removeEntry, this, &ImportDialog::removeEntry);
+
+    // Focus the field, so that entry can start immediately
+    entry->setFocus();
+    ui->scrollAreaWidgetContents->resize(ui->scrollAreaWidgetContents->sizeHint());
+    qApp->processEvents();
+    QScrollBar* bar = ui->scrollArea->verticalScrollBar();
+    if(bar)
+        bar->setSliderPosition(bar->maximum());
+
+    return entry;
+}
+
+void ImportDialog::removeEntry(ImportEntry* entry)
+{
+    entry->hide();
+
+    // If the last entry is about to be removed add an empty one
+    if (ui->entries->count() == 1)
+        addEntry();
+
+    entry->deleteLater();
 }

--- a/src/qt/importdialog.cpp
+++ b/src/qt/importdialog.cpp
@@ -1,0 +1,191 @@
+#include <qt/importdialog.h>
+#include <qt/forms/ui_importdialog.h>
+
+#include <qt/guiconstants.h>
+#include <qt/guiutil.h>
+#include <key_io.h>
+#include <qt/walletmodel.h>
+#include <interfaces/node.h>
+#include <wallet/imports.h>
+#include <wallet/wallet.h>
+#include <QKeyEvent>
+#include <QMessageBox>
+#include <QPushButton>
+#include <iostream>
+#include <QScrollBar>
+#include <tinyformat.h>
+#include <chain.h>
+
+ImportDialog::ImportDialog(Page _page, WalletModel *walletModel, QWidget *parent) :
+    QDialog(parent, GUIUtil::dialog_flags),
+    ui(new Ui::ImportDialog),
+    walletModel(walletModel),
+    page(_page)
+{
+    ui->setupUi(this);
+
+    switch (page) {
+        case importPubkey: {
+            ui->QStackContainer->setCurrentWidget(ui->importKeyPage);
+            this->setWindowTitle("Import Public Key");
+            ui->keyLabelIKP->setText("Public Key");
+            ui->keyEditIKP->setPlaceholderText("Enter a Public Key (e.g. 1NS17iag9jJgTHDlVXjvLCEnZuQ3rJDE9L)");
+            ui->rescanButtonIKP->setCheckState(Qt::Checked);
+            ui->p2shButtonIKP->hide();
+            break;
+        } case importPrivkey: {
+            ui->QStackContainer->setCurrentWidget(ui->importKeyPage);
+            this->setWindowTitle("Import Private Key");
+            ui->keyLabelIKP->setText("Private Key");
+            ui->keyEditIKP->setPlaceholderText("Enter a Private Key (e.g. L4sTHokqoFZpcmJgsAG2yxrf2f71v6PYpK2qEkCvc2Fp8VVdMiU3)");
+            ui->rescanButtonIKP->setCheckState(Qt::Checked);
+            ui->p2shButtonIKP->hide();
+            break;
+        } case importAddress: {
+            ui->QStackContainer->setCurrentWidget(ui->importKeyPage);
+            this->setWindowTitle("Import Address");
+            ui->keyLabelIKP->setText("Address");
+            ui->keyEditIKP->setPlaceholderText("Enter a Bitcoin address (e.g. 1NS17iag9jJgTHDlVXjvLCEnZuQ3rJDE9L)");
+            ui->rescanButtonIKP->setCheckState(Qt::Checked);
+            ui->p2shButtonIKP->setCheckState(Qt::Unchecked);
+            break;
+        }
+    }
+
+    GUIUtil::handleCloseWindowShortcut(this);
+}
+
+ImportDialog::~ImportDialog()
+{
+    delete ui;
+}
+
+void ImportDialog::accept() {
+    // Whether to perform rescan after import
+    bool fRescan = true;
+    std::string strIKP;
+    std::string strLabel;
+    if (page == Page::importPubkey || page == Page::importPrivkey || page == Page::importAddress) {
+        strIKP = ui->keyEditIKP->text().toStdString();
+        if (strIKP.empty()) {
+            QMessageBox::warning(this, tr("Error"), tr("%1 is empty").arg(ui->keyLabelIKP->text()));
+            return;
+        }
+        strLabel = ui->labelEditIKP->text().toStdString();
+
+        if (!ui->rescanButtonIKP->isChecked())
+            fRescan = false;
+
+        if (fRescan && walletModel->wallet().chain().havePruned()) {
+            // Exit early and print an error.
+            // If a block is pruned after this check, we will import the key(s),
+            // but fail the rescan with a generic error.
+            QMessageBox::critical(this, tr("Rescan failed"), tr("Rescan is disabled when blocks are pruned"));
+            return;
+        }
+    }
+
+    wallet::WalletRescanReserver reserver = walletModel->wallet().getReserver();
+    if (fRescan && !reserver.reserve()) {
+        QMessageBox::critical(this, tr("Rescan failed"),
+                              tr("Wallet is currently rescanning. Abort existing rescan or wait."));
+        return;
+    }
+
+    switch (page) {
+        case importPubkey: {
+            if (!IsHex(strIKP)) {
+                QMessageBox::critical(this, tr("Invalid Public Key"), tr("Pubkey must be a hex string"));
+                return;
+            }
+
+            std::vector<unsigned char> data(ParseHex(strIKP));
+            CPubKey pubKey(data);
+            if (!pubKey.IsFullyValid()) {
+                QMessageBox::critical(this, tr("Invalid Public Key"),
+                                      tr("Pubkey is not a valid public key"));
+                return;
+            }
+
+            walletModel->wallet().processPublicKey(strLabel, pubKey);
+
+            if (fRescan) {
+                int64_t scanned_time = walletModel->wallet().RescanFromTime(0, reserver, true);
+                if (walletModel->wallet().IsAbortingRescan()) {
+                    QMessageBox::critical(this, tr("Misc Error"), tr("Rescan aborted by user."));
+                    return;
+                } else if (scanned_time > 0) {
+                    QMessageBox::critical(this, tr("Wallet Error"),
+                                          tr("Rescan was unable to fully rescan the blockchain. Some transactions may be missing."));
+                    return;
+                }
+                walletModel->wallet().ResubmitWalletTransactions(/*relay=*/false, /*force=*/true);
+            }
+            break;
+        }
+        case importPrivkey: {
+            WalletModel::UnlockContext ctx(walletModel->requestUnlock());
+            if (!ctx.isValid()) {
+                return;
+            }
+
+            CKey key = DecodeSecret(strIKP);
+            if (!key.IsValid()) {
+                QMessageBox::critical(this, tr("Invalid Private Key"), tr("Invalid private key encoding."));
+                return;
+            }
+
+            try {
+                walletModel->wallet().processPrivateKey(strLabel, key);
+            } catch (const wallet::WalletError& e) {
+                QMessageBox::critical(this, tr("Wallet Error"), tr(e.error.c_str()));
+                return;
+            }
+
+            if (fRescan) {
+                int64_t scanned_time = walletModel->wallet().RescanFromTime(0, reserver, true);
+                if (walletModel->wallet().IsAbortingRescan()) {
+                    QMessageBox::critical(this, tr("Misc Error"),
+                                          tr("Rescan aborted by user."));
+                    return;
+                } else if (scanned_time > 0) {
+                    QMessageBox::critical(this, tr("Wallet Error"),
+                                          tr("Rescan was unable to fully rescan the blockchain. Some transactions may be missing."));
+                    return;
+                }
+            }
+
+            break;
+        }
+        case importAddress: {
+            // Whether to import a p2sh version, too
+            bool fP2SH = false;
+            if (ui->p2shButtonIKP->isChecked())
+                fP2SH = true;
+
+            try {
+                walletModel->wallet().processAddress(strIKP, strLabel, fP2SH);
+            } catch (const wallet::InvalidAddressOrKey& e) {
+                QMessageBox::critical(this, tr("Invalid Address"), tr(e.error.c_str()));
+                return;
+            }
+
+            if (fRescan) {
+                int64_t scanned_time = walletModel->wallet().RescanFromTime(0, reserver, true);
+                if (walletModel->wallet().IsAbortingRescan()) {
+                    QMessageBox::critical(this, tr("Misc Error"),
+                                          tr("Rescan aborted by user."));
+                    return;
+                } else if (scanned_time > 0) {
+                    QMessageBox::critical(this, tr("Wallet Error"),
+                                          tr("Rescan was unable to fully rescan the blockchain. Some transactions may be missing."));
+                    return;
+                }
+                walletModel->wallet().ResubmitWalletTransactions(/*relay=*/false, /*force=*/true);
+            }
+            break;
+        }
+    }
+    QMessageBox::information(this, tr("Import Succeeded"), tr("Import Succeeded"));
+    QDialog::accept();
+}

--- a/src/qt/importdialog.h
+++ b/src/qt/importdialog.h
@@ -1,0 +1,35 @@
+#ifndef BITCOIN_QT_IMPORTDIALOG_H
+#define BITCOIN_QT_IMPORTDIALOG_H
+
+#include <QDialog>
+
+class WalletModel;
+
+namespace Ui {
+    class ImportDialog;
+}
+
+class ImportDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    enum Page {
+        importPubkey,
+        importPrivkey,
+        importAddress
+    };
+
+    explicit ImportDialog(Page _page, WalletModel *model = nullptr, QWidget *parent = nullptr);
+    ~ImportDialog();
+
+public Q_SLOTS:
+    void accept() override;
+
+private:
+    Ui::ImportDialog *ui;
+    WalletModel *walletModel;
+    Page page;
+};
+
+#endif // BITCOIN_QT_IMPORTDIALOG_H

--- a/src/qt/importdialog.h
+++ b/src/qt/importdialog.h
@@ -2,6 +2,7 @@
 #define BITCOIN_QT_IMPORTDIALOG_H
 
 #include <QDialog>
+#include <qt/importentry.h>
 
 class WalletModel;
 
@@ -17,7 +18,9 @@ public:
     enum Page {
         importPubkey,
         importPrivkey,
-        importAddress
+        importAddress,
+        importMulti,
+        importDescriptors
     };
 
     explicit ImportDialog(Page _page, WalletModel *model = nullptr, QWidget *parent = nullptr);
@@ -25,11 +28,15 @@ public:
 
 public Q_SLOTS:
     void accept() override;
+private Q_SLOTS:
+    ImportEntry *addEntry();
+    void removeEntry(ImportEntry* entry);
 
 private:
     Ui::ImportDialog *ui;
     WalletModel *walletModel;
     Page page;
+    int64_t GetImportTimestamp(const int64_t &entry, int64_t now);
 };
 
 #endif // BITCOIN_QT_IMPORTDIALOG_H

--- a/src/qt/importentry.cpp
+++ b/src/qt/importentry.cpp
@@ -1,0 +1,237 @@
+// Copyright (c) 2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#if defined(HAVE_CONFIG_H)
+#include <config/bitcoin-config.h>
+#endif
+
+#include <qt/importentry.h>
+#include <qt/forms/ui_importentry.h>
+
+#include <qt/addressbookpage.h>
+#include <qt/addresstablemodel.h>
+#include <qt/guiutil.h>
+#include <qt/optionsmodel.h>
+#include <qt/walletmodel.h>
+#include <util/string.h>
+#include <wallet/imports.h>
+
+#include <QGroupBox>
+#include <QApplication>
+#include <QClipboard>
+
+ImportEntry::ImportEntry(EntryPage _entryPage, QWidget *parent) :
+        QStackedWidget(parent),
+        ui(new Ui::ImportEntry),
+        entryPage(_entryPage)
+{
+    ui->setupUi(this);
+
+    switch (entryPage) {
+        case importMultiEntry: {
+            setCurrentWidget(ui->importMultiEntry);
+            connect(ui->importScriptPubKeyRadio, &QRadioButton::clicked, this, &ImportEntry::changeImportDialog);
+            connect(ui->importDescriptorRadio, &QRadioButton::clicked, this, &ImportEntry::changeImportDialog);
+            connect(ui->hideScriptsButton, &QPushButton::clicked, this, &ImportEntry::useHideScriptsButtonClicked);
+            connect(ui->deleteMultiButton, &QPushButton::clicked, this, &ImportEntry::deleteEntryClicked);
+
+            ui->redeemScriptLabel->hide();
+            ui->redeemScript->hide();
+            ui->witnessScriptLabel->hide();
+            ui->witnessScript->hide();
+            ui->descLabelMulti->hide();
+            ui->descMulti->hide();
+
+            ui->timestampMulti->setValidator(new Int64_tValidator(0, 0x7FFFFFFFFFFFFFFF, this));
+            ui->startRangeMulti->setRange(0, 0x7FFFFFFF);
+            ui->endRangeMulti->setRange(0, 0x7FFFFFFF);
+            connect(ui->checkboxInternalMulti, &QCheckBox::clicked, this, &ImportEntry::hideLabel);
+            break;
+        } case importDescriptorsEntry: {
+            setCurrentWidget(ui->importDescriptorsEntry);
+            ui->nextIndexLabel->hide();
+            ui->hiddenMenu->hide();
+            ui->timestamp->setValidator(new Int64_tValidator(0, 0x7FFFFFFFFFFFFFFF, this));
+            ui->nextIndex->setRange(0, 0x7FFFFFFF);
+            ui->startRange->setRange(0, 0x7FFFFFFF);
+            ui->endRange->setRange(0, 0x7FFFFFFF);
+            connect(ui->hiddenButton, &QPushButton::clicked, this, &ImportEntry::usehiddenButtonClicked);
+            connect(ui->deleteDescriptorButton, &QPushButton::clicked, this, &ImportEntry::deleteEntryClicked);
+            connect(ui->checkboxInternal, &QCheckBox::clicked, this, &ImportEntry::hideLabelDesc);
+            break;
+        }
+    }
+}
+
+ImportEntry::~ImportEntry()
+{
+    delete ui;
+}
+
+void ImportEntry::setModel(WalletModel *_model)
+{
+    this->model = _model;
+}
+
+void ImportEntry::usehiddenButtonClicked()
+{
+    if (!hiddenButtonState) {
+        ui->nextIndexLabel->show();
+        ui->hiddenMenu->show();
+        hiddenButtonState = true;
+        ui->hiddenButton->setText("△");
+    } else {
+        ui->nextIndexLabel->hide();
+        ui->hiddenMenu->hide();
+        hiddenButtonState = false;
+        ui->hiddenButton->setText("▽");
+    }
+}
+
+void ImportEntry::useHideScriptsButtonClicked()
+{
+    if (!hideScriptsButtonState) {
+        ui->redeemScriptLabel->show();
+        ui->redeemScript->show();
+
+        ui->witnessScriptLabel->show();
+        ui->witnessScript->show();
+        hideScriptsButtonState = true;
+        ui->hideScriptsButton->setText("△");
+    } else {
+        ui->redeemScriptLabel->hide();
+        ui->redeemScript->hide();
+
+        ui->witnessScriptLabel->hide();
+        ui->witnessScript->hide();
+        hideScriptsButtonState = false;
+        ui->hideScriptsButton->setText("▽");
+    }
+}
+
+void ImportEntry::hideLabel()
+{
+    if (ui->checkboxInternalMulti->isChecked()) {
+        ui->labelLabelMulti->hide();
+        ui->labelMulti->hide();
+    } else {
+        ui->labelLabelMulti->show();
+        ui->labelMulti->show();
+    }
+}
+
+void ImportEntry::hideLabelDesc()
+{
+    if (ui->checkboxInternal->isChecked()) {
+        ui->labelLabel->hide();
+        ui->label->hide();
+    } else {
+        ui->labelLabel->show();
+        ui->label->show();
+    }
+}
+
+void ImportEntry::changeImportDialog()
+{
+    if (ui->importScriptPubKeyRadio->isChecked()) {
+        ui->scriptPubKeyLabel->show();
+        ui->scriptPubKey->show();
+        ui->hideScriptsButton->show();
+
+        ui->redeemScriptLabel->hide();
+        ui->redeemScript->hide();
+
+        ui->witnessScriptLabel->hide();
+        ui->witnessScript->hide();
+
+        ui->publicKeyLabel->show();
+        ui->publicKey->show();
+
+        ui->descLabelMulti->hide();
+        ui->descMulti->hide();
+    } else {
+        ui->scriptPubKeyLabel->hide();
+        ui->scriptPubKey->hide();
+        ui->hideScriptsButton->hide();
+
+        ui->redeemScriptLabel->hide();
+        ui->redeemScript->hide();
+
+        ui->witnessScriptLabel->hide();
+        ui->witnessScript->hide();
+
+        ui->publicKeyLabel->hide();
+        ui->publicKey->hide();
+        ui->descLabelMulti->show();
+        ui->descMulti->show();
+    }
+}
+
+wallet::ImportMultiData ImportEntry::getMultiData()
+{
+    wallet::ImportMultiData multiData;
+
+    if (ui->importScriptPubKeyRadio->isChecked()) {
+        multiData.scriptPubKey = ui->scriptPubKey->text().toStdString();
+        multiData.redeem_script = ui->redeemScript->text().toStdString();
+        multiData.witness_script = ui->witnessScript->text().toStdString();
+        if (!ui->publicKey->text().isEmpty()) {
+            multiData.public_keys = SplitString(ui->publicKey->text().toStdString(), ',');
+        }
+    } else {
+        multiData.range_start = ui->startRangeMulti->text().toInt();
+        multiData.range_end = ui->endRangeMulti->text().toInt();
+    }
+    if (!ui->checkboxInternalMulti->isChecked()) {
+        multiData.label = ui->labelMulti->text().toStdString();
+    }
+    if (!ui->privateKey->text().isEmpty()) {
+        multiData.private_keys = SplitString(ui->privateKey->text().toStdString(), ',');
+    }
+    if (!ui->timestampMulti->text().toStdString().empty()) {
+        multiData.timestamp = ui->timestampMulti->text().toInt();
+    }
+
+    multiData.internal = (ui->checkboxInternalMulti->checkState() == Qt::Checked);
+    multiData.watch_only = (ui->checkboxWatchOnlyMulti->checkState() == Qt::Checked);
+    multiData.keypool = (ui->checkboxKeyPoolMulti->checkState() == Qt::Checked);
+
+    return multiData;
+}
+
+wallet::ImportDescriptorData ImportEntry::getDescriptorData()
+{
+    wallet::ImportDescriptorData descriptorData;
+    descriptorData.label = ui->label->text().toStdString();
+    if (ui->startRange->text().toInt() != 0) {
+        descriptorData.range_start = ui->startRange->text().toInt();
+    }
+    if (ui->endRange->text().toInt() != 0) {
+        descriptorData.range_end = ui->endRange->text().toInt();
+    }
+    if (ui->nextIndex->text().toInt() != 0) {
+        descriptorData.next_index = ui->nextIndex->text().toInt();
+    }
+    if (!ui->timestamp->text().toStdString().empty()) {
+        descriptorData.timestamp = ui->timestamp->text().toInt();
+    }
+    descriptorData.active = (ui->checkboxActive->checkState() == Qt::Checked);
+    descriptorData.internal = (ui->checkboxInternal->checkState() == Qt::Checked);
+
+    return descriptorData;
+}
+
+std::string ImportEntry::getDesc()
+{
+    if (entryPage == EntryPage::importMultiEntry) {
+        return ui->desccMulti->text().toStdString();
+    } else {
+        return ui->descriptor->text().toStdString();
+    }
+}
+
+void ImportEntry::deleteEntryClicked()
+{
+    Q_EMIT removeEntry(this);
+}

--- a/src/qt/importentry.h
+++ b/src/qt/importentry.h
@@ -1,0 +1,118 @@
+// Copyright (c) 2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QT_IMPORTENTRY_H
+#define BITCOIN_QT_IMPORTENTRY_H
+
+#include <QStackedWidget>
+#include <QValidator>
+#include <QRadioButton>
+#include <wallet/imports.h>
+
+class WalletModel;
+
+namespace interfaces {
+class Node;
+} // namespace interfaces
+
+namespace Ui {
+    class ImportEntry;
+}
+
+class ImportEntry : public QStackedWidget
+{
+    Q_OBJECT
+
+public:
+    enum EntryPage {
+        importMultiEntry,
+        importDescriptorsEntry
+    };
+    explicit ImportEntry(EntryPage _entryPage, QWidget *parent = nullptr);
+    ~ImportEntry();
+
+    void setModel(WalletModel *model);
+
+    QSize sizeHint() const override
+    {
+        return currentWidget()->sizeHint();
+    }
+
+    QSize minimumSizeHint() const override
+    {
+        return currentWidget()->minimumSizeHint();
+    }
+
+    wallet::ImportDescriptorData getDescriptorData();
+    wallet::ImportMultiData getMultiData();
+    std::string getDesc();
+
+Q_SIGNALS:
+    void removeEntry(ImportEntry* entry);
+
+private Q_SLOTS:
+    void deleteEntryClicked();
+    void usehiddenButtonClicked();
+    void useHideScriptsButtonClicked();
+    void hideLabel();
+    void hideLabelDesc();
+    void changeImportDialog();
+
+private:
+    Ui::ImportEntry *ui;
+    WalletModel* model{nullptr};
+    bool hiddenButtonState = false;
+    bool hideScriptsButtonState = false;
+    EntryPage entryPage;
+};
+
+class Int64_tValidator : public QValidator
+{
+    Q_OBJECT
+
+public:
+    Int64_tValidator(int64_t bottom, int64_t top, QObject *parent = nullptr) : QValidator(parent), b(bottom), t(top) {};
+
+    // doesn't handle -/+ so can only work with bottom of 0 to top int64_t max
+    QValidator::State validate(QString &input, int &) const override {
+        if (input.isEmpty()) return Intermediate;
+        bool ok;
+        int64_t num = input.toLongLong(&ok, 10);
+        if (!ok) return QValidator::Invalid;
+        if (num < b) return QValidator::Intermediate;
+        if (num > t) return QValidator::Invalid;
+        return QValidator::Acceptable;
+    }
+
+    void setBottom(int64_t bottom) {
+        setRange(bottom, top());
+    }
+
+    void setTop(int64_t top) {
+        setRange(bottom(), top);
+    }
+
+    void setRange(int64_t bottom, int64_t top) {
+        bool rangeChanged = false;
+        if (b != bottom) {
+            b = bottom;
+            rangeChanged = true;
+        }
+        if (t != top) {
+            t = top;
+            rangeChanged = true;
+        }
+        if (rangeChanged)
+            changed();
+    }
+
+    int64_t bottom() const { return b; }
+    int64_t top() const { return t; }
+
+private:
+    int64_t b;
+    int64_t t;
+};
+
+#endif // BITCOIN_QT_IMPORTENTRY_H

--- a/src/qt/test/importdescriptorstests.cpp
+++ b/src/qt/test/importdescriptorstests.cpp
@@ -1,0 +1,360 @@
+// Copyright (c) 2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <qt/test/importdescriptorstests.h>
+#include <qt/test/util.h>
+#include <test/util/setup_common.h>
+
+#include <interfaces/chain.h>
+#include <interfaces/node.h>
+#include <qt/bitcoinamountfield.h>
+#include <qt/importdialog.h>
+#include <qt/clientmodel.h>
+#include <qt/editaddressdialog.h>
+#include <qt/optionsmodel.h>
+#include <qt/platformstyle.h>
+#include <qt/qvalidatedlineedit.h>
+#include <qt/walletmodel.h>
+
+#include <script/standard.h>
+#include <validation.h>
+#include <wallet/coincontrol.h>
+#include <wallet/spend.h>
+#include <wallet/wallet.h>
+#include <wallet/test/util.h>
+#include <walletinitinterface.h>
+
+#include <chrono>
+
+#include <QApplication>
+#include <QCheckBox>
+#include <QLineEdit>
+#include <QString>
+#include <QSpinBox>
+
+using wallet::AddWallet;
+using wallet::CreateMockWalletDatabase;
+using wallet::CWallet;
+using wallet::FEATURE_HD_SPLIT;
+using wallet::FEATURE_LATEST;
+using wallet::RemoveWallet;
+using wallet::WALLET_FLAG_BLANK_WALLET;
+using wallet::WALLET_FLAG_DESCRIPTORS;
+using wallet::WALLET_FLAG_DISABLE_PRIVATE_KEYS;
+using wallet::WalletContext;
+
+struct ImportDescriptorTestData
+{
+    QString desc;
+    QString label;
+    int64_t index = 0;
+    int64_t range_start = 0;
+    int64_t range_end = 0;
+    int64_t timestamp = 0;
+    bool active = false;
+    bool internal = false;
+};
+
+struct KeypoolInfo
+{
+    int64_t keypoolsize = 0;
+    int64_t keypoolsize_hd_internal = 0;
+};
+
+void EditDescriptorAndSubmit(WalletModel &walletModel, const ImportDescriptorTestData& data, QString expected_msg)
+{
+    QString warning_text;
+
+    ImportDialog dialog(ImportDialog::importDescriptors, &walletModel);
+
+    dialog.findChild<QLineEdit*>("descriptor")->setText(data.desc);
+    dialog.findChild<QLineEdit*>("label")->setText(data.label);
+    dialog.findChild<QLineEdit*>("timestamp")->setText(QString::number(data.timestamp));
+    dialog.findChild<QCheckBox*>("checkboxActive")->setChecked(data.active);
+    dialog.findChild<QCheckBox*>("checkboxInternal")->setChecked(data.internal);
+    dialog.findChild<QSpinBox*>("nextIndex")->setValue(data.index);
+    dialog.findChild<QSpinBox*>("startRange")->setValue(data.range_start);
+    dialog.findChild<QSpinBox*>("endRange")->setValue(data.range_end);
+
+    ConfirmMessage(&warning_text, 5ms);
+    dialog.accept();
+    QCOMPARE(warning_text, expected_msg);
+}
+
+void TestImportDescriptors(interfaces::Node& node)
+{
+    auto get_keypool_info = [](CWallet* wallet) {
+        KeypoolInfo keypoolInfo;
+
+        LOCK(wallet->cs_wallet);
+        size_t kpExternalSize = wallet->KeypoolCountExternalKeys();
+        keypoolInfo.keypoolsize = kpExternalSize;
+
+        if (wallet->CanSupportFeature(FEATURE_HD_SPLIT)) {
+            keypoolInfo.keypoolsize_hd_internal = (int64_t)(wallet->GetKeyPoolSize() - kpExternalSize);
+        }
+
+        return keypoolInfo;
+    };
+
+    // Set up wallet and chain with 105 blocks.
+    TestChain100Setup test;
+    auto wallet_loader = interfaces::MakeWalletLoader(*test.m_node.chain, *Assert(test.m_node.args));
+    test.m_node.wallet_loader = wallet_loader.get();
+    node.setContext(&test.m_node);
+
+    const std::shared_ptr<CWallet> w1 = std::make_shared<CWallet>(node.context()->chain.get(), "", CreateMockWalletDatabase());
+    w1->LoadWallet();
+    w1->SetWalletFlag(WALLET_FLAG_DESCRIPTORS);
+    w1->SetWalletFlag(WALLET_FLAG_DISABLE_PRIVATE_KEYS);
+    w1->SetWalletFlag(WALLET_FLAG_BLANK_WALLET);
+    QCOMPARE(get_keypool_info(w1.get()).keypoolsize, 0);
+
+    const std::shared_ptr<CWallet> wpriv = std::make_shared<CWallet>(node.context()->chain.get(), "", CreateMockWalletDatabase());
+    wpriv->LoadWallet();
+    wpriv->SetMinVersion(FEATURE_LATEST);
+    wpriv->SetWalletFlag(WALLET_FLAG_DESCRIPTORS);
+    wpriv->SetWalletFlag(WALLET_FLAG_BLANK_WALLET);
+    QCOMPARE(get_keypool_info(wpriv.get()).keypoolsize, 0);
+
+    {
+        LOCK2(w1->cs_wallet, ::cs_main);
+        w1->SetLastBlockProcessed(105, node.context()->chainman->ActiveChain().Tip()->GetBlockHash());
+    }
+
+    {
+        LOCK2(wpriv->cs_wallet, ::cs_main);
+        wpriv->SetLastBlockProcessed(105, node.context()->chainman->ActiveChain().Tip()->GetBlockHash());
+    }
+
+    // Initialize relevant QT models.
+    std::unique_ptr<const PlatformStyle> platformStyle(PlatformStyle::instantiate("other"));
+    OptionsModel optionsModel(node);
+    bilingual_str error;
+    QVERIFY(optionsModel.Init(error));
+    ClientModel clientModel(node, &optionsModel);
+    WalletContext& context = *node.walletLoader().context();
+
+    // w1 wallet
+    AddWallet(context, w1);
+    WalletModel walletModelW1(interfaces::MakeWallet(context, w1), clientModel, platformStyle.get());
+    RemoveWallet(context, w1,  std::nullopt);
+
+    // wpriv wallet
+    AddWallet(context, wpriv);
+    WalletModel walletModelWpriv(interfaces::MakeWallet(context, wpriv), clientModel, platformStyle.get());
+    RemoveWallet(context, wpriv, std::nullopt);
+
+    // Test import fails if no descriptor present
+    // Import should fail if a descriptor is not provided
+    ImportDescriptorTestData data;
+    EditDescriptorAndSubmit(walletModelW1, data, QString("Error: Descriptor not found."));
+
+    // Test importing of a P2PKH descriptor
+    Key key;
+    key = BuildAddress(w1.get());
+    // Should import a p2pkh descriptor
+    data = ImportDescriptorTestData();
+    std::string desc_str = "pkh(" + key.pubkey.toStdString() + ")";
+    data.desc = DescsumCreate(desc_str);
+    data.label = "Descriptor import test";
+    EditDescriptorAndSubmit(walletModelW1, data, QString("Import Succeeded"));
+
+    AddressInfo addressInfo;
+    GetAddressInfo(w1.get(), addressInfo, key.p2pkh_addr);
+    QCOMPARE(addressInfo.ismine, true);
+    QCOMPARE(addressInfo.solvable, true);
+    QCOMPARE(addressInfo.label, "Descriptor import test");
+    QCOMPARE(get_keypool_info(w1.get()).keypoolsize, 0);
+
+    // Test can import same descriptor with public key twice
+    EditDescriptorAndSubmit(walletModelW1, data, QString("Import Succeeded"));
+
+    // Test can update descriptor label
+    data.label = "Updated label";
+    EditDescriptorAndSubmit(walletModelW1, data, QString("Import Succeeded"));
+    GetAddressInfo(w1.get(), addressInfo, key.p2pkh_addr);
+    QCOMPARE(addressInfo.ismine, true);
+    QCOMPARE(addressInfo.solvable, true);
+    QCOMPARE(addressInfo.label, "Updated label");
+
+    // Internal addresses cannot have labels
+    data.internal = true;
+    EditDescriptorAndSubmit(walletModelW1, data, QString("Error: Internal addresses should not have a label"));
+
+    // Internal addresses should be detected as such
+    key = BuildAddress(w1.get());
+    data = ImportDescriptorTestData();
+    desc_str = "pkh(" + key.pubkey.toStdString() + ")";
+    data.desc = DescsumCreate(desc_str);
+    data.internal = true;
+    EditDescriptorAndSubmit(walletModelW1, data, QString("Import Succeeded"));
+    GetAddressInfo(w1.get(), addressInfo, key.p2pkh_addr);
+    QCOMPARE(addressInfo.ismine, true);
+    QCOMPARE(addressInfo.ischange, true);
+
+    // Test importing of a P2SH-P2WPKH descriptor
+    // Should not import a p2sh-p2wpkh descriptor without checksum
+    key = BuildAddress(w1.get());
+    data = ImportDescriptorTestData();
+    desc_str = "sh(wpkh(" + key.pubkey.toStdString() + "))";
+    data.desc = QString::fromStdString(desc_str);
+    EditDescriptorAndSubmit(walletModelW1, data, QString("Error: Missing checksum"));
+
+    // Should not import a p2sh-p2wpkh descriptor that has range specified
+    data = ImportDescriptorTestData();
+    desc_str = "sh(wpkh(" + key.pubkey.toStdString() + "))";
+    data.desc = DescsumCreate(desc_str);
+    data.range_end = 1;
+    EditDescriptorAndSubmit(walletModelW1, data, QString("Error: Range should not be specified for an un-ranged descriptor"));
+
+    // Should not import a p2sh-p2wpkh descriptor and have it set to active
+    data = ImportDescriptorTestData();
+    desc_str = "sh(wpkh(" + key.pubkey.toStdString() + "))";
+    data.desc = DescsumCreate(desc_str);
+    data.active = true;
+    EditDescriptorAndSubmit(walletModelW1, data, QString("Error: Active descriptors must be ranged"));
+
+    // Should import a (non-active) p2sh-p2wpkh descriptor
+    data = ImportDescriptorTestData();
+    desc_str = "sh(wpkh(" + key.pubkey.toStdString() + "))";
+    data.desc = DescsumCreate(desc_str);
+    data.active = false;
+    EditDescriptorAndSubmit(walletModelW1, data, QString("Import Succeeded"));
+    QCOMPARE(get_keypool_info(w1.get()).keypoolsize, 0);
+    GetAddressInfo(w1.get(), addressInfo, key.p2sh_p2wpkh_addr);
+    QCOMPARE(addressInfo.ismine, true);
+    QCOMPARE(addressInfo.solvable, true);
+
+    // Test importing of a multisig descriptor
+    Key key1 = BuildAddress(w1.get());
+    Key key2 = BuildAddress(w1.get());
+    // Should import a 1-of-2 bare multisig from descriptor
+    data = ImportDescriptorTestData();
+    desc_str = "multi(1," + key1.pubkey.toStdString() + "," + key2.pubkey.toStdString() + ")";
+    data.desc = DescsumCreate(desc_str);
+    EditDescriptorAndSubmit(walletModelW1, data, QString("Import Succeeded"));
+    // Should not treat individual keys from the imported bare multisig as watchonly
+    GetAddressInfo(w1.get(), addressInfo, key.p2pkh_addr);
+    QCOMPARE(addressInfo.ismine, false);
+
+    // Test ranged descriptors
+    std::string xpriv = "tprv8ZgxMBicQKsPeuVhWwi6wuMQGfPKi9Li5GtX35jVNknACgqe3CY4g5xgkfDDJcmtF7o1QnxWDRYw4H5P26PXq7sbcUkEqeR4fg3Kxp2tigg";
+    std::string xpub = "tpubD6NzVbkrYhZ4YNXVQbNhMK1WqguFsUXceaVJKbmno2aZ3B6QfbMeraaYvnBSGpV3vxLyTTK9DYT1yoEck4XUScMzXoQ2U2oSmE2JyMedq3H";
+    std::vector<QString> addresses = {"2N7yv4p8G8yEaPddJxY41kPihnWvs39qCMf", "2MsHxyb2JS3pAySeNUsJ7mNnurtpeenDzLA", // hdkeypath=m/0'/0'/0' and 1'
+                                      "bcrt1qrd3n235cj2czsfmsuvqqpr3lu6lg0ju7scl8gn", "bcrt1qfqeppuvj0ww98r6qghmdkj70tv8qpchehegrg8"}; // wpkh subscripts corresponding to the above addresses
+    std::string desc = "sh(wpkh(" + xpub + "/0/0/*" + "))";
+
+    // Ranged descriptors cannot have labels
+    data = ImportDescriptorTestData();
+    data.desc = DescsumCreate(desc);
+    data.range_start = 0;
+    data.range_end = 100;
+    data.label = "test";
+    EditDescriptorAndSubmit(walletModelW1, data, QString("Error: Ranged descriptors should not have a label"));
+
+    // Private keys required for private keys enabled wallet
+    data = ImportDescriptorTestData();
+    data.desc = DescsumCreate(desc);
+    data.range_start = 0;
+    data.range_end = 100;
+    EditDescriptorAndSubmit(walletModelWpriv, data, QString("Error: Cannot import descriptor without private keys to a wallet with private keys enabled"));
+
+    // Ranged descriptor import should warn without a specified range
+    data = ImportDescriptorTestData();
+    data.desc = DescsumCreate(desc);
+    EditDescriptorAndSubmit(walletModelW1, data, QString("Import Succeeded\nWarnings: Range not given, using default keypool range\n"));
+    QCOMPARE(get_keypool_info(w1.get()).keypoolsize, 0);
+
+    // Test importing of a ranged descriptor with xpriv
+    // Should not import a ranged descriptor that includes xpriv into a watch-only wallet
+    data = ImportDescriptorTestData();
+    desc = "sh(wpkh(" + xpriv + "/0'/0'/*'" + "))";
+    data.desc = DescsumCreate(desc);
+    data.range_end = 1;
+    EditDescriptorAndSubmit(walletModelW1, data, QString("Error: Cannot import private keys to a wallet with private keys disabled"));
+
+    // Should not import a descriptor with hardened derivations when private keys are disabled
+    data = ImportDescriptorTestData();
+    desc = "wpkh(" + xpub + "/1h/*)";
+    data.desc = DescsumCreate(desc);
+    data.range_end = 1;
+    EditDescriptorAndSubmit(walletModelW1, data, QString("Error: Cannot expand descriptor. Probably because of hardened derivations without private keys provided"));
+
+    for (const auto& address: addresses) {
+        GetAddressInfo(w1.get(), addressInfo, address);
+        QCOMPARE(addressInfo.ismine, false);
+        QCOMPARE(addressInfo.solvable, false);
+    }
+
+    // GUI only accepts range 0 to 0x7FFFFFFF
+    data = ImportDescriptorTestData();
+    desc = "sh(wpkh(" + xpriv + "/0'/0'/*'" + "))";
+    data.desc = DescsumCreate(desc);
+
+    data.range_start = 2;
+    data.range_end = 1;
+    EditDescriptorAndSubmit(walletModelW1, data, QString("Error: Range specified as [begin,end] must not have begin after end"));
+
+    data.range_start = 0;
+    data.range_end = 1000001;
+    EditDescriptorAndSubmit(walletModelW1, data, QString("Error: Range is too large"));
+
+    // Verify we can only extend descriptor's range
+    data.range_start = 5;
+    data.range_end = 1010;
+    data.active = true;
+    EditDescriptorAndSubmit(walletModelWpriv, data, QString("Import Succeeded"));
+    QCOMPARE(get_keypool_info(wpriv.get()).keypoolsize, 1006);
+    data.range_start = 0;
+    EditDescriptorAndSubmit(walletModelWpriv, data, QString("Import Succeeded"));
+    QCOMPARE(get_keypool_info(wpriv.get()).keypoolsize, 1011);
+    data.range_end = 1020;
+    EditDescriptorAndSubmit(walletModelWpriv, data, QString("Import Succeeded"));
+    QCOMPARE(get_keypool_info(wpriv.get()).keypoolsize, 1021);
+
+    // Can keep range the same
+    EditDescriptorAndSubmit(walletModelWpriv, data, QString("Import Succeeded"));
+    QCOMPARE(get_keypool_info(wpriv.get()).keypoolsize, 1021);
+
+    data.range_start = 5;
+    data.range_end = 1010;
+    EditDescriptorAndSubmit(walletModelWpriv, data, QString("Error: new range must include current range = [0,1020]"));
+    data.range_start = 0;
+    data.range_end = 1010;
+    EditDescriptorAndSubmit(walletModelWpriv, data, QString("Error: new range must include current range = [0,1020]"));
+    data.range_start = 5;
+    data.range_end = 1020;
+    EditDescriptorAndSubmit(walletModelWpriv, data, QString("Error: new range must include current range = [0,1020]"));
+    QCOMPARE(get_keypool_info(wpriv.get()).keypoolsize, 1021);
+
+    // Check we can change descriptor internal flag
+    data.range_start = 0;
+    data.range_end = 1020;
+    data.internal = true;
+    EditDescriptorAndSubmit(walletModelWpriv, data, QString("Import Succeeded"));
+    QCOMPARE(get_keypool_info(wpriv.get()).keypoolsize, 0);
+    QCOMPARE(get_keypool_info(wpriv.get()).keypoolsize_hd_internal, 1021);
+
+    data.internal = false;
+    EditDescriptorAndSubmit(walletModelWpriv, data, QString("Import Succeeded"));
+    QCOMPARE(get_keypool_info(wpriv.get()).keypoolsize, 1021);
+    QCOMPARE(get_keypool_info(wpriv.get()).keypoolsize_hd_internal, 0);
+}
+
+void ImportDescriptorsTests::importDescriptorsTests()
+{
+#ifdef Q_OS_MACOS
+    if (QApplication::platformName() == "minimal") {
+        // Disable for mac on "minimal" platform to avoid crashes inside the Qt
+        // framework when it tries to look up unimplemented cocoa functions,
+        // and fails to handle returned nulls
+        // (https://bugreports.qt.io/browse/QTBUG-49686).
+        QWARN("Skipping ImportDescriptorsTests on mac build with 'minimal' platform set due to Qt bugs. To run AppTests, invoke "
+              "with 'QT_QPA_PLATFORM=cocoa test_bitcoin-qt' on mac, or else use a linux or windows build.");
+        return;
+    }
+#endif
+    TestImportDescriptors(m_node);
+}

--- a/src/qt/test/importdescriptorstests.h
+++ b/src/qt/test/importdescriptorstests.h
@@ -1,0 +1,27 @@
+// Copyright (c) 2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QT_TEST_IMPORTDESCRIPTORSTESTS_H
+#define BITCOIN_QT_TEST_IMPORTDESCRIPTORSTESTS_H
+
+#include <QObject>
+#include <QTest>
+
+namespace interfaces {
+class Node;
+} // namespace interfaces
+
+class ImportDescriptorsTests : public QObject
+{
+public:
+    explicit ImportDescriptorsTests(interfaces::Node& node) : m_node(node) {}
+    interfaces::Node& m_node;
+
+    Q_OBJECT
+
+private Q_SLOTS:
+    void importDescriptorsTests();
+};
+
+#endif // BITCOIN_QT_TEST_IMPORTDESCRIPTORSTESTS_H

--- a/src/qt/test/importlegacytests.cpp
+++ b/src/qt/test/importlegacytests.cpp
@@ -1,0 +1,223 @@
+// Copyright (c) 2023 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <qt/test/importlegacytests.h>
+#include <qt/test/util.h>
+#include <test/util/setup_common.h>
+
+#include <interfaces/chain.h>
+#include <interfaces/node.h>
+#include <qt/bitcoinamountfield.h>
+#include <qt/importdialog.h>
+#include <qt/clientmodel.h>
+#include <qt/editaddressdialog.h>
+#include <qt/optionsmodel.h>
+#include <qt/platformstyle.h>
+#include <qt/qvalidatedlineedit.h>
+#include <qt/walletmodel.h>
+
+#include <key_io.h>
+#include <script/standard.h>
+#include <validation.h>
+#include <wallet/coincontrol.h>
+#include <wallet/spend.h>
+#include <wallet/wallet.h>
+#include <wallet/test/util.h>
+#include <walletinitinterface.h>
+
+#include <chrono>
+
+#include <QApplication>
+#include <QCheckBox>
+#include <QLineEdit>
+#include <QString>
+
+using wallet::AddWallet;
+using wallet::CreateMockWalletDatabase;
+using wallet::CWallet;
+using wallet::RemoveWallet;
+using wallet::WalletContext;
+
+struct ImportKeyData
+{
+    QString key;
+    QString label;
+    bool rescan = true;
+    bool p2sh = false;
+};
+
+void EditKeyAndSubmit(ImportDialog* dialog, ImportDialog::Page _page, const ImportKeyData& data, QString expected_msg) {
+    QString warning_text;
+
+    dialog->findChild<QLineEdit*>("keyEditIKP")->setText(data.key);
+    dialog->findChild<QLineEdit*>("labelEditIKP")->setText(data.label);
+    dialog->findChild<QCheckBox*>("rescanButtonIKP")->setChecked(data.rescan);
+    if (_page == ImportDialog::importAddress) {
+        dialog->findChild<QCheckBox*>("p2shButtonIKP")->setChecked(data.p2sh);
+    }
+
+    ConfirmMessage(&warning_text, 5ms);
+    dialog->accept();
+    QCOMPARE(warning_text, expected_msg);
+}
+
+void TestImportLegacy(interfaces::Node& node)
+{
+    // Set up wallet and chain with 105 blocks.
+    TestChain100Setup test;
+    auto wallet_loader = interfaces::MakeWalletLoader(*test.m_node.chain, *Assert(test.m_node.args));
+    test.m_node.wallet_loader = wallet_loader.get();
+    node.setContext(&test.m_node);
+    const std::shared_ptr<CWallet> wallet = std::make_shared<CWallet>(node.context()->chain.get(), "", CreateMockWalletDatabase());
+    {
+        LOCK2(wallet->cs_wallet, ::cs_main);
+        wallet->SetLastBlockProcessed(105, node.context()->chainman->ActiveChain().Tip()->GetBlockHash());
+    }
+
+    wallet->LoadWallet();
+    wallet->SetupLegacyScriptPubKeyMan();
+
+    // Initialize relevant QT models.
+    std::unique_ptr<const PlatformStyle> platformStyle(PlatformStyle::instantiate("other"));
+    OptionsModel optionsModel(node);
+    bilingual_str error;
+    QVERIFY(optionsModel.Init(error));
+    ClientModel clientModel(node, &optionsModel);
+    WalletContext& context = *node.walletLoader().context();
+    AddWallet(context, wallet);
+    WalletModel walletModel(interfaces::MakeWallet(context, wallet), clientModel, platformStyle.get());
+    RemoveWallet(context, wallet, /* load_on_start= */ std::nullopt);
+
+    ImportDialog importDialogPubkey(ImportDialog::importPubkey, &walletModel);
+    ImportDialog importDialogPrivkey(ImportDialog::importPrivkey, &walletModel);
+    ImportDialog importDialogAddress(ImportDialog::importAddress, &walletModel);
+
+    // Public key
+    Key key = BuildAddress(wallet.get());
+    ImportKeyData data;
+    data.key = key.pubkey;
+    EditKeyAndSubmit(&importDialogPubkey, ImportDialog::importPubkey, data, QString("Import Succeeded"));
+
+    AddressInfo addressInfo;
+    GetAddressInfo(wallet.get(), addressInfo, key.p2pkh_addr);
+    QCOMPARE(addressInfo.iswatchonly, true);
+    QCOMPARE(addressInfo.ismine, false);
+
+    // Public key + Label
+    key = BuildAddress(wallet.get());
+    data = ImportKeyData();
+    data.key = key.pubkey;
+    data.rescan = false;
+    data.label = "Successful public key import";
+    EditKeyAndSubmit(&importDialogPubkey, ImportDialog::importPubkey, data, QString("Import Succeeded"));
+
+    GetAddressInfo(wallet.get(), addressInfo, key.p2pkh_addr);
+    QCOMPARE(addressInfo.iswatchonly, true);
+    QCOMPARE(addressInfo.ismine, false);
+    QCOMPARE(addressInfo.label, "Successful public key import");
+
+    // Public key + Rescan
+    key = BuildAddress(wallet.get());
+    data = ImportKeyData();
+    data.key = key.pubkey;
+    EditKeyAndSubmit(&importDialogPubkey, ImportDialog::importPubkey, data, QString("Import Succeeded"));
+
+    GetAddressInfo(wallet.get(), addressInfo, key.p2pkh_addr);
+    QCOMPARE(addressInfo.iswatchonly, true);
+    QCOMPARE(addressInfo.ismine, false);
+
+    // Public key must be hex string
+    key = BuildAddress(wallet.get());
+    data = ImportKeyData();
+    data.key = key.p2pkh_addr;
+    EditKeyAndSubmit(&importDialogPubkey, ImportDialog::importPubkey, data, QString("Pubkey must be a hex string"));
+
+    // Public key not a valid public key
+    data = ImportKeyData();
+    data.key = "02e053f77836d086a6082f441fc0db6a71de0620f3e1c9797d80ade82979c73c";
+    EditKeyAndSubmit(&importDialogPubkey, ImportDialog::importPubkey, data, QString("Pubkey is not a valid public key"));
+
+    // Private key
+    key = BuildAddress(wallet.get());
+    data = ImportKeyData();
+    data.key = key.privkey;
+    EditKeyAndSubmit(&importDialogPrivkey, ImportDialog::importPrivkey, data, QString("Import Succeeded"));
+
+    GetAddressInfo(wallet.get(), addressInfo, key.p2pkh_addr);
+    QCOMPARE(addressInfo.iswatchonly, false);
+    QCOMPARE(addressInfo.ismine, true);
+
+    // Private key + Label
+    key = BuildAddress(wallet.get());
+    data = ImportKeyData();
+    data.key = key.privkey;
+    data.label = "Successful private key import";
+    EditKeyAndSubmit(&importDialogPrivkey, ImportDialog::importPrivkey, data, QString("Import Succeeded"));
+
+    GetAddressInfo(wallet.get(), addressInfo, key.p2pkh_addr);
+    QCOMPARE(addressInfo.iswatchonly, false);
+    QCOMPARE(addressInfo.ismine, true);
+    QCOMPARE(addressInfo.label, "Successful private key import");
+
+    // Private key not a valid public key
+    data = ImportKeyData();
+    data.key = "cSFUNyEbpxP6Jur5kJftYEugGzkd1QUjHwSwkjH5yco6z1oERCq";
+    EditKeyAndSubmit(&importDialogPrivkey, ImportDialog::importPrivkey, data, QString("Invalid private key encoding."));
+
+    // Address
+    key = BuildAddress(wallet.get());
+    data = ImportKeyData();
+    data.key = key.p2pkh_addr;
+    EditKeyAndSubmit(&importDialogAddress, ImportDialog::importAddress, data, QString("Import Succeeded"));
+
+    GetAddressInfo(wallet.get(), addressInfo, key.p2pkh_addr);
+    QCOMPARE(addressInfo.iswatchonly, true);
+    QCOMPARE(addressInfo.ismine, false);
+
+    // Address + Label
+    key = BuildAddress(wallet.get());
+    data = ImportKeyData();
+    data.key = key.p2pkh_addr;
+    data.label = "Successful address import";
+    EditKeyAndSubmit(&importDialogAddress, ImportDialog::importAddress, data, QString("Import Succeeded"));
+
+    GetAddressInfo(wallet.get(), addressInfo, key.p2pkh_addr);
+    QCOMPARE(addressInfo.iswatchonly, true);
+    QCOMPARE(addressInfo.ismine, false);
+    QCOMPARE(addressInfo.label, "Successful address import");
+
+    // Invalid Address or script
+    key = BuildAddress(wallet.get());
+    data = ImportKeyData();
+    data.key = key.privkey;
+    EditKeyAndSubmit(&importDialogAddress, ImportDialog::importAddress, data, QString("Invalid Bitcoin address or script"));
+
+    // Invalid Address can't import Bech32m into a legacy wallet
+    data = ImportKeyData();
+    data.key = "bcrt1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqc8gma6";
+    EditKeyAndSubmit(&importDialogAddress, ImportDialog::importAddress, data, QString("Bech32m addresses cannot be imported into legacy wallets"));
+
+    // Invalid Address use the p2sh flag with an address
+    key = BuildAddress(wallet.get());
+    data = ImportKeyData();
+    data.key = key.p2pkh_addr;
+    data.p2sh = true;
+    EditKeyAndSubmit(&importDialogAddress, ImportDialog::importAddress, data, QString("Cannot use the p2sh flag with an address - use a script instead"));
+}
+
+void ImportLegacyTests::importLegacyTests()
+{
+#ifdef Q_OS_MACOS
+    if (QApplication::platformName() == "minimal") {
+        // Disable for mac on "minimal" platform to avoid crashes inside the Qt
+        // framework when it tries to look up unimplemented cocoa functions,
+        // and fails to handle returned nulls
+        // (https://bugreports.qt.io/browse/QTBUG-49686).
+        QWARN("Skipping ImportLegacyTests on mac build with 'minimal' platform set due to Qt bugs. To run AppTests, invoke "
+              "with 'QT_QPA_PLATFORM=cocoa test_bitcoin-qt' on mac, or else use a linux or windows build.");
+        return;
+    }
+#endif
+    TestImportLegacy(m_node);
+}

--- a/src/qt/test/importlegacytests.h
+++ b/src/qt/test/importlegacytests.h
@@ -1,0 +1,27 @@
+// Copyright (c) 2023 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QT_TEST_IMPORTLEGACYTESTS_H
+#define BITCOIN_QT_TEST_IMPORTLEGACYTESTS_H
+
+#include <QObject>
+#include <QTest>
+
+namespace interfaces {
+class Node;
+} // namespace interfaces
+
+class ImportLegacyTests : public QObject
+{
+public:
+    explicit ImportLegacyTests(interfaces::Node& node) : m_node(node) {}
+    interfaces::Node& m_node;
+
+    Q_OBJECT
+
+private Q_SLOTS:
+    void importLegacyTests();
+};
+
+#endif // BITCOIN_QT_TEST_IMPORTLEGACYTESTS_H

--- a/src/qt/test/importmultitests.cpp
+++ b/src/qt/test/importmultitests.cpp
@@ -1,0 +1,781 @@
+// Copyright (c) 2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <qt/test/importmultitests.h>
+#include <qt/test/util.h>
+#include <test/util/setup_common.h>
+
+#include <interfaces/chain.h>
+#include <interfaces/node.h>
+#include <qt/bitcoinamountfield.h>
+#include <qt/importdialog.h>
+#include <qt/clientmodel.h>
+#include <qt/editaddressdialog.h>
+#include <qt/optionsmodel.h>
+#include <qt/platformstyle.h>
+#include <qt/qvalidatedlineedit.h>
+#include <qt/walletmodel.h>
+
+#include <key_io.h>
+#include <script/standard.h>
+#include <validation.h>
+#include <wallet/coincontrol.h>
+#include <wallet/spend.h>
+#include <wallet/wallet.h>
+#include <wallet/test/util.h>
+#include <walletinitinterface.h>
+
+#include <chrono>
+
+#include <QApplication>
+#include <QCheckBox>
+#include <QLineEdit>
+#include <QString>
+#include <QSpinBox>
+
+using wallet::AddWallet;
+using wallet::AvailableCoinsListUnspent;
+using wallet::CCoinControl;
+using wallet::CRecipient;
+using wallet::CoinFilterParams;
+using wallet::COutput;
+using wallet::CreateMockWalletDatabase;
+using wallet::CWallet;
+using wallet::CWalletTx;
+using wallet::RemoveWallet;
+using wallet::TxStateConfirmed;
+using wallet::WalletContext;
+using wallet::WalletRescanReserver;
+
+struct ImportMultiTestData
+{
+    QString desc;
+    QString scriptPubKey;
+    QString redeem_script;
+    QString witness_script;
+    QString label;
+    QString public_keys;
+    QString private_keys;
+    int64_t range_start = 0;
+    int64_t range_end = 0;
+    int64_t timestamp = 0;
+    bool internal = false;
+    bool watch_only = false;
+    bool keypool = false;
+};
+
+struct UnspentInfo
+{
+    bool spendable = false;
+    bool solvable = false;
+};
+
+void EditMultiAndSubmit(ImportDialog* dialog, const ImportMultiTestData& data, QString expected_msg)
+{
+    QString warning_text;
+
+    if (!data.scriptPubKey.isEmpty()) {
+        dialog->findChild<QRadioButton*>("importScriptPubKeyRadio")->setChecked(true);
+        dialog->findChild<QLineEdit*>("scriptPubKey")->setText(data.scriptPubKey);
+        dialog->findChild<QLineEdit*>("redeemScript")->setText(data.redeem_script);
+        dialog->findChild<QLineEdit*>("witnessScript")->setText(data.witness_script);
+        dialog->findChild<QLineEdit*>("publicKey")->setText(data.public_keys);
+        dialog->findChild<QLineEdit*>("privateKey")->setText(data.private_keys);
+        dialog->findChild<QLineEdit*>("timestampMulti")->setText(QString::number(data.timestamp));
+        dialog->findChild<QCheckBox*>("checkboxInternalMulti")->setChecked(data.internal);
+        dialog->findChild<QCheckBox*>("checkboxKeyPoolMulti")->setChecked(data.keypool);
+        dialog->findChild<QCheckBox*>("checkboxWatchOnlyMulti")->setChecked(data.watch_only);
+        dialog->findChild<QLineEdit*>("labelMulti")->setText(data.label);
+    } else {
+        dialog->findChild<QRadioButton*>("importDescriptorRadio")->setChecked(true);
+        dialog->findChild<QLineEdit*>("desccMulti")->setText(data.desc);
+        dialog->findChild<QSpinBox*>("startRangeMulti")->setValue(data.range_start);
+        dialog->findChild<QSpinBox*>("endRangeMulti")->setValue(data.range_end);
+        dialog->findChild<QLineEdit*>("privateKey")->setText(data.private_keys);
+        dialog->findChild<QLineEdit*>("timestampMulti")->setText(QString::number(data.timestamp));
+        dialog->findChild<QCheckBox*>("checkboxInternalMulti")->setChecked(data.internal);
+        dialog->findChild<QCheckBox*>("checkboxKeyPoolMulti")->setChecked(data.keypool);
+        dialog->findChild<QCheckBox*>("checkboxWatchOnlyMulti")->setChecked(data.watch_only);
+        dialog->findChild<QLineEdit*>("labelMulti")->setText(data.label);
+    }
+
+    ConfirmMessage(&warning_text, 5ms);
+    dialog->accept();
+    QCOMPARE(warning_text, expected_msg);
+}
+
+class TestImportMultiSetup : public TestChain100Setup
+{
+public:
+    CWalletTx& AddTx(CWallet& wallet, CRecipient recipient, bool& error)
+    {
+        CTransactionRef tx;
+        CCoinControl dummy;
+        {
+            constexpr int RANDOM_CHANGE_POSITION = -1;
+            auto res = CreateTransaction(wallet, {recipient}, RANDOM_CHANGE_POSITION, dummy);
+            if (!res) {
+                error = true;
+            }
+            tx = res->tx;
+        }
+        wallet.CommitTransaction(tx, {}, {});
+        CMutableTransaction blocktx;
+        {
+            LOCK(wallet.cs_wallet);
+            blocktx = CMutableTransaction(*wallet.mapWallet.at(tx->GetHash()).tx);
+        }
+        CreateAndProcessBlock({CMutableTransaction(blocktx)}, GetScriptForRawPubKey(coinbaseKey.GetPubKey()));
+
+        LOCK(wallet.cs_wallet);
+        LOCK(Assert(m_node.chainman)->GetMutex());
+        wallet.SetLastBlockProcessed(wallet.GetLastBlockHeight() + 1, m_node.chainman->ActiveChain().Tip()->GetBlockHash());
+        auto it = wallet.mapWallet.find(tx->GetHash());
+        if (it == wallet.mapWallet.end()) {
+            error = true;
+        }
+        it->second.m_state = TxStateConfirmed{m_node.chainman->ActiveChain().Tip()->GetBlockHash(), m_node.chainman->ActiveChain().Height(), /*index=*/1};
+        return it->second;
+    }
+};
+
+void TestImportMulti(interfaces::Node& node)
+{
+    // Set up wallet and chain with 105 blocks.
+    TestImportMultiSetup test;
+    auto wallet_loader = interfaces::MakeWalletLoader(*test.m_node.chain, *Assert(test.m_node.args));
+    test.m_node.wallet_loader = wallet_loader.get();
+    node.setContext(&test.m_node);
+    const std::shared_ptr<CWallet> wallet = std::make_shared<CWallet>(node.context()->chain.get(), "", CreateMockWalletDatabase());
+    {
+        LOCK2(wallet->cs_wallet, ::cs_main);
+        wallet->SetLastBlockProcessed(105, node.context()->chainman->ActiveChain().Tip()->GetBlockHash());
+    }
+    wallet->LoadWallet();
+    {
+        auto spk_man = wallet->GetOrCreateLegacyScriptPubKeyMan();
+        LOCK2(wallet->cs_wallet, spk_man->cs_KeyStore);
+        spk_man->AddKeyPubKey(test.coinbaseKey, test.coinbaseKey.GetPubKey());
+    }
+
+    {
+        WalletRescanReserver reserver(*wallet);
+        reserver.reserve();
+        CWallet::ScanResult result = wallet->ScanForWalletTransactions(Params().GetConsensus().hashGenesisBlock, /*start_height=*/0, /*max_height=*/{}, reserver, /*fUpdate=*/true, /*save_progress=*/false);
+        QCOMPARE(result.status, CWallet::ScanResult::SUCCESS);
+        {
+            LOCK(::cs_main);
+            QCOMPARE(result.last_scanned_block, node.context()->chainman->ActiveChain().Tip()->GetBlockHash());
+        }
+        QVERIFY(result.last_failed_block.IsNull());
+    }
+
+    // Initialize relevant QT models.
+    std::unique_ptr<const PlatformStyle> platformStyle(PlatformStyle::instantiate("other"));
+    OptionsModel optionsModel(node);
+    bilingual_str error;
+    QVERIFY(optionsModel.Init(error));
+    ClientModel clientModel(node, &optionsModel);
+    WalletContext& context = *node.walletLoader().context();
+    AddWallet(context, wallet);
+    WalletModel walletModel(interfaces::MakeWallet(context, wallet), clientModel, platformStyle.get());
+    RemoveWallet(context, wallet, /* load_on_start= */ std::nullopt);
+    ImportDialog importDialog(ImportDialog::importMulti, &walletModel);
+
+    auto get_multisig = [](int key_length = 3) {
+        Key key;
+        CKey k[3];
+        for (int i = 0; i < 3; i++)
+            k[i].MakeNewKey(true);
+
+        CScript script_code;
+        script_code << OP_2 << ToByteVector(k[0].GetPubKey()) << ToByteVector(k[1].GetPubKey()) << ToByteVector(k[2].GetPubKey()) << OP_3 << OP_CHECKMULTISIG;
+
+        // privkey and pubkey here are a list of keys separated by commas
+        std::string privkeys = EncodeSecret(k[0]);
+        for (int i = 0; i < key_length - 1; i++) {
+            privkeys += ",";
+            privkeys += EncodeSecret(k[i + 1]);
+        }
+        key.privkey = QString::fromStdString(privkeys);
+        std::string pubkeys = HexStr(k[0].GetPubKey());
+        for (int i = 0; i < key_length - 1; i++) {
+            pubkeys += ",";
+            pubkeys += HexStr(k[i + 1].GetPubKey());
+        }
+        key.pubkey = QString::fromStdString(pubkeys);
+        key.p2pkh_addr = QString::fromStdString(EncodeDestination(ScriptHash(script_code)));
+        key.p2pkh_script = QString::fromStdString(HexStr(GetScriptForDestination(ScriptHash(script_code))));
+        key.p2wpkh_addr = QString::fromStdString(EncodeDestination(WitnessV0ScriptHash(script_code)));
+        key.p2wpkh_script = QString::fromStdString(HexStr(GetScriptForDestination(WitnessV0ScriptHash(script_code))));
+        key.p2sh_p2wpkh_addr = QString::fromStdString(EncodeDestination(ScriptHash(GetScriptForDestination(WitnessV0ScriptHash(script_code)))));
+        key.p2sh_p2wpkh_script = QString::fromStdString(HexStr(GetScriptForDestination(ScriptHash(GetScriptForDestination(WitnessV0ScriptHash(script_code))))));
+        key.p2sh_p2wpkh_redeem_script = QString::fromStdString(HexStr(script_code));
+        return key;
+    };
+
+    auto get_unspent_info = [&wallet](QString& input) {
+        UnspentInfo unspentInfo;
+
+        CoinFilterParams filter_coins;
+        filter_coins.min_amount = 0;
+        filter_coins.max_amount = MAX_MONEY;
+        filter_coins.min_sum_amount = MAX_MONEY;
+        filter_coins.max_count = 0;
+        std::vector<COutput> vecOutputs;
+        {
+            CCoinControl cctl;
+            cctl.m_avoid_address_reuse = false;
+            cctl.m_min_depth = 0;
+            cctl.m_max_depth = 999999;
+            cctl.m_include_unsafe_inputs = true;
+            LOCK(wallet->cs_wallet);
+            vecOutputs = AvailableCoinsListUnspent(*wallet, &cctl, filter_coins).All();
+        }
+
+        LOCK(wallet->cs_wallet);
+        CTxDestination dest = DecodeDestination(input.toStdString());
+        std::set<CTxDestination> destinations;
+        destinations.insert(dest);
+        for (const COutput& out : vecOutputs) {
+            CTxDestination address;
+            const CScript &scriptPubKey = out.txout.scriptPubKey;
+            bool fValidAddress = ExtractDestination(scriptPubKey, address);
+
+            if (!fValidAddress || !destinations.count(address))
+                continue;
+
+            unspentInfo.spendable = out.spendable;
+            unspentInfo.solvable = out.solvable;
+            break;
+        }
+        return unspentInfo;
+    };
+
+    auto send_coins = [&wallet, &test](QString& address, CAmount amount) {
+        LOCK(wallet->cs_wallet);
+        CTxDestination dest = DecodeDestination(address.toStdString());
+
+        // Make sure the destination is valid
+        QVERIFY2(IsValidDestination(dest), "Invalid address");
+        CScript script_pub_key = GetScriptForDestination(dest);
+        bool error = false;
+        test.AddTx(*wallet, CRecipient{script_pub_key, amount, false}, error);
+        QVERIFY(!error);
+    };
+
+    // Bitcoin Address (implicit non-internal)
+    Key key;
+    key = BuildAddress(wallet.get());
+    ImportMultiTestData data;
+    data.scriptPubKey = key.p2pkh_addr;
+    EditMultiAndSubmit(&importDialog, data, QString("Import Succeeded"));
+
+    QString watchonly_address = key.p2pkh_addr;
+    int64_t timestamp = 0;
+    {
+        LOCK(::cs_main);
+        timestamp = node.context()->chainman->ActiveChain().Tip()->GetMedianTimePast();
+    }
+
+    AddressInfo addressInfo;
+    GetAddressInfo(wallet.get(), addressInfo, key.p2pkh_addr);
+    QCOMPARE(addressInfo.iswatchonly, true);
+    QCOMPARE(addressInfo.ismine, false);
+    QCOMPARE(addressInfo.timestamp, timestamp);
+    QCOMPARE(addressInfo.ischange, false);
+
+    data = ImportMultiTestData();
+    data.scriptPubKey = "not valid scriptPubKey";
+    EditMultiAndSubmit(&importDialog, data,
+                       QString("Error: Invalid scriptPubKey \"not valid scriptPubKey\""));
+
+    // ScriptPubKey + internal
+    key = BuildAddress(wallet.get());
+    data = ImportMultiTestData();
+    data.scriptPubKey = key.p2pkh_script;
+    data.internal = true;
+    EditMultiAndSubmit(&importDialog, data, QString("Import Succeeded"));
+
+    GetAddressInfo(wallet.get(), addressInfo, key.p2pkh_addr);
+    QCOMPARE(addressInfo.iswatchonly, true);
+    QCOMPARE(addressInfo.ismine, false);
+    QCOMPARE(addressInfo.timestamp, timestamp);
+    QCOMPARE(addressInfo.ischange, true);
+
+    // should pass since GUI can't accept a label if internal is set to true
+    // ScriptPubKey + internal + label
+    key = BuildAddress(wallet.get());
+    data = ImportMultiTestData();
+    data.scriptPubKey = key.p2pkh_script;
+    data.internal = true;
+    data.label = "Unsuccessful labelling for internal addresses";
+    EditMultiAndSubmit(&importDialog, data, QString("Import Succeeded"));
+
+    // Nonstandard scriptPubKey + !internal
+    key = BuildAddress(wallet.get());
+    data = ImportMultiTestData();
+    data.scriptPubKey = QString::fromStdString(HexStr(GetScriptForDestination(key.dest) << OP_NOP));
+    EditMultiAndSubmit(&importDialog, data,
+                       QString("Error: Internal must be set to true for nonstandard scriptPubKey imports."));
+
+    GetAddressInfo(wallet.get(), addressInfo, key.p2pkh_addr);
+    QCOMPARE(addressInfo.iswatchonly, false);
+    QCOMPARE(addressInfo.ismine, false);
+    QCOMPARE(addressInfo.timestamp, 0);
+
+    // Address + Public key + !Internal(explicit)
+    key = BuildAddress(wallet.get());
+    data = ImportMultiTestData();
+    data.scriptPubKey = key.p2pkh_addr;
+    data.public_keys = key.pubkey;
+    EditMultiAndSubmit(&importDialog, data,
+                       QString("Import Succeeded\n") +
+                       QString("Warnings: Some private keys are missing, outputs will be considered watchonly. If this is intentional, specify the watchonly flag.\n"));
+
+    GetAddressInfo(wallet.get(), addressInfo, key.p2pkh_addr);
+    QCOMPARE(addressInfo.iswatchonly, true);
+    QCOMPARE(addressInfo.ismine, false);
+    QCOMPARE(addressInfo.timestamp, timestamp);
+
+    // ScriptPubKey + Public key + internal
+    key = BuildAddress(wallet.get());
+    data = ImportMultiTestData();
+    data.scriptPubKey = key.p2pkh_script;
+    data.public_keys = key.pubkey;
+    data.internal = true;
+    EditMultiAndSubmit(&importDialog, data,
+                       QString("Import Succeeded\n") +
+                       QString("Warnings: Some private keys are missing, outputs will be considered watchonly. If this is intentional, specify the watchonly flag.\n"));
+
+    GetAddressInfo(wallet.get(), addressInfo, key.p2pkh_addr);
+    QCOMPARE(addressInfo.iswatchonly, true);
+    QCOMPARE(addressInfo.ismine, false);
+    QCOMPARE(addressInfo.timestamp, timestamp);
+
+    // Nonstandard scriptPubKey + Public key + !internal
+    key = BuildAddress(wallet.get());
+    data = ImportMultiTestData();
+    data.scriptPubKey = QString::fromStdString(HexStr(GetScriptForDestination(key.dest) << OP_NOP));
+    data.public_keys = key.pubkey;
+    EditMultiAndSubmit(&importDialog, data,
+                       QString("Error: Internal must be set to true for nonstandard scriptPubKey imports."));
+
+    GetAddressInfo(wallet.get(), addressInfo, key.p2pkh_addr);
+    QCOMPARE(addressInfo.iswatchonly, false);
+    QCOMPARE(addressInfo.ismine, false);
+    QCOMPARE(addressInfo.timestamp, 0);
+
+    // Address + Private key + !watchonly
+    key = BuildAddress(wallet.get());
+    data = ImportMultiTestData();
+    data.scriptPubKey = key.p2pkh_addr;
+    data.private_keys = key.privkey;
+    EditMultiAndSubmit(&importDialog, data, QString("Import Succeeded"));
+
+    GetAddressInfo(wallet.get(), addressInfo, key.p2pkh_addr);
+    QCOMPARE(addressInfo.iswatchonly, false);
+    QCOMPARE(addressInfo.ismine, true);
+    QCOMPARE(addressInfo.timestamp, timestamp);
+
+    EditMultiAndSubmit(&importDialog, data,
+                       QString("Error: The wallet already contains the private key for this address or script (\"" + key.p2pkh_script + "\")"));
+
+    // Address + Private key + watchonly
+    key = BuildAddress(wallet.get());
+    data = ImportMultiTestData();
+    data.scriptPubKey = key.p2pkh_addr;
+    data.private_keys = key.privkey;
+    data.watch_only = true;
+    EditMultiAndSubmit(&importDialog, data, QString("Import Succeeded\n") +
+            QString("Warnings: All private keys are provided, outputs will be considered spendable. If this is intentional, do not specify the watchonly flag.\n"));
+
+    GetAddressInfo(wallet.get(), addressInfo, key.p2pkh_addr);
+    QCOMPARE(addressInfo.iswatchonly, false);
+    QCOMPARE(addressInfo.ismine, true);
+    QCOMPARE(addressInfo.timestamp, timestamp);
+
+    // ScriptPubKey + Private key + internal
+    key = BuildAddress(wallet.get());
+    data = ImportMultiTestData();
+    data.scriptPubKey = key.p2pkh_script;
+    data.private_keys = key.privkey;
+    data.internal = true;
+    EditMultiAndSubmit(&importDialog, data, QString("Import Succeeded"));
+
+    GetAddressInfo(wallet.get(), addressInfo, key.p2pkh_addr);
+    QCOMPARE(addressInfo.iswatchonly, false);
+    QCOMPARE(addressInfo.ismine, true);
+    QCOMPARE(addressInfo.timestamp, timestamp);
+
+    // Nonstandard scriptPubKey + Private key + !internal
+    key = BuildAddress(wallet.get());
+    data = ImportMultiTestData();
+    data.scriptPubKey = QString::fromStdString(HexStr(GetScriptForDestination(key.dest) << OP_NOP));
+    data.private_keys = key.privkey;
+    EditMultiAndSubmit(&importDialog, data,
+                       QString("Error: Internal must be set to true for nonstandard scriptPubKey imports."));
+
+    GetAddressInfo(wallet.get(), addressInfo, key.p2pkh_addr);
+    QCOMPARE(addressInfo.iswatchonly, false);
+    QCOMPARE(addressInfo.ismine, false);
+    QCOMPARE(addressInfo.timestamp, 0);
+
+    // P2SH address
+    key = get_multisig();
+    send_coins(key.p2pkh_addr, 5 * COIN);
+    {
+        LOCK(::cs_main);
+        timestamp = node.context()->chainman->ActiveChain().Tip()->GetMedianTimePast();
+    }
+    data = ImportMultiTestData();
+    data.scriptPubKey = key.p2pkh_addr;
+    EditMultiAndSubmit(&importDialog, data, QString("Import Succeeded"));
+
+    GetAddressInfo(wallet.get(), addressInfo, key.p2pkh_addr);
+    QCOMPARE(addressInfo.isscript, true);
+    QCOMPARE(addressInfo.iswatchonly, true);
+    QCOMPARE(addressInfo.timestamp, timestamp);
+
+    UnspentInfo unspentInfo = get_unspent_info(key.p2pkh_addr);
+    QCOMPARE(unspentInfo.spendable, false);
+    QCOMPARE(unspentInfo.solvable, false);
+
+    // P2SH + Redeem script
+    key = get_multisig();
+    send_coins(key.p2pkh_addr, 5 * COIN);
+    data = ImportMultiTestData();
+    data.scriptPubKey = key.p2pkh_addr;
+    data.redeem_script = key.p2sh_p2wpkh_redeem_script;
+    EditMultiAndSubmit(&importDialog, data, QString("Import Succeeded\n") +
+                                            QString("Warnings: Some private keys are missing, outputs will be considered watchonly. If this is intentional, specify the watchonly flag.\n"));
+
+    GetAddressInfo(wallet.get(), addressInfo, key.p2pkh_addr);
+    QCOMPARE(addressInfo.iswatchonly, true);
+    QCOMPARE(addressInfo.ismine, false);
+    QCOMPARE(addressInfo.solvable, true);
+    QCOMPARE(addressInfo.timestamp, timestamp);
+
+
+    unspentInfo = get_unspent_info(key.p2pkh_addr);
+    QCOMPARE(unspentInfo.spendable, false);
+    QCOMPARE(unspentInfo.solvable, true);
+
+    // P2SH + Redeem script + Private Keys + !Watchonly
+    key = get_multisig(2);
+    send_coins(key.p2pkh_addr, 5 * COIN);
+    data = ImportMultiTestData();
+    data.scriptPubKey = key.p2pkh_addr;
+    data.redeem_script = key.p2sh_p2wpkh_redeem_script;
+    data.private_keys = key.privkey;
+    EditMultiAndSubmit(&importDialog, data, QString("Import Succeeded\n") +
+                                            QString("Warnings: Some private keys are missing, outputs will be considered watchonly. If this is intentional, specify the watchonly flag.\n"));
+
+    GetAddressInfo(wallet.get(), addressInfo, key.p2pkh_addr);
+    QCOMPARE(addressInfo.iswatchonly, true);
+    QCOMPARE(addressInfo.ismine, false);
+    QCOMPARE(addressInfo.solvable, true);
+    QCOMPARE(addressInfo.timestamp, timestamp);
+
+    unspentInfo = get_unspent_info(key.p2pkh_addr);
+    QCOMPARE(unspentInfo.spendable, false);
+    QCOMPARE(unspentInfo.solvable, true);
+
+    // P2SH + Redeem script + Private Keys + Watchonly
+    key = get_multisig(2);
+    send_coins(key.p2pkh_addr, 5 * COIN);
+    data = ImportMultiTestData();
+    data.scriptPubKey = key.p2pkh_addr;
+    data.redeem_script = key.p2sh_p2wpkh_redeem_script;
+    data.private_keys = key.privkey;
+    data.watch_only = true;
+    EditMultiAndSubmit(&importDialog, data, QString("Import Succeeded"));
+
+    GetAddressInfo(wallet.get(), addressInfo, key.p2pkh_addr);
+    QCOMPARE(addressInfo.iswatchonly, true);
+    QCOMPARE(addressInfo.ismine, false);
+    QCOMPARE(addressInfo.solvable, true);
+    QCOMPARE(addressInfo.timestamp, timestamp);
+
+    // Address + Public key + !Internal + Wrong pubkey
+    key = BuildAddress(wallet.get());
+    data = ImportMultiTestData();
+    data.scriptPubKey = key.p2pkh_addr;
+    Key wrong_key = BuildAddress(wallet.get());
+    data.public_keys = wrong_key.pubkey;
+    EditMultiAndSubmit(&importDialog, data,
+                       QString("Import Succeeded\n") +
+                       QString("Warnings: Some private keys are missing, outputs will be considered watchonly. If this is intentional, specify the watchonly flag.\nImporting as non-solvable: some required keys are missing. If this is intentional, don't provide any keys, pubkeys, witnessscript, or redeemscript.\n"));
+
+    GetAddressInfo(wallet.get(), addressInfo, key.p2pkh_addr);
+    QCOMPARE(addressInfo.iswatchonly, true);
+    QCOMPARE(addressInfo.ismine, false);
+    QCOMPARE(addressInfo.solvable, false);
+    QCOMPARE(addressInfo.timestamp, timestamp);
+
+    // ScriptPubKey + Public key + internal + Wrong pubkey
+    key = BuildAddress(wallet.get());
+    data = ImportMultiTestData();
+    data.scriptPubKey = key.p2pkh_script;
+    wrong_key = BuildAddress(wallet.get());
+    data.public_keys = wrong_key.pubkey;
+    data.internal = true;
+    EditMultiAndSubmit(&importDialog, data,
+                       QString("Import Succeeded\n") +
+                       QString("Warnings: Some private keys are missing, outputs will be considered watchonly. If this is intentional, specify the watchonly flag.\nImporting as non-solvable: some required keys are missing. If this is intentional, don't provide any keys, pubkeys, witnessscript, or redeemscript.\n"));
+
+    GetAddressInfo(wallet.get(), addressInfo, key.p2pkh_addr);
+    QCOMPARE(addressInfo.iswatchonly, true);
+    QCOMPARE(addressInfo.ismine, false);
+    QCOMPARE(addressInfo.solvable, false);
+    QCOMPARE(addressInfo.timestamp, timestamp);
+
+    // Address + Private key + !watchonly + Wrong private key
+    key = BuildAddress(wallet.get());
+    data = ImportMultiTestData();
+    data.scriptPubKey = key.p2pkh_addr;
+    wrong_key = BuildAddress(wallet.get());
+    data.private_keys = wrong_key.privkey;
+    EditMultiAndSubmit(&importDialog, data,
+                       QString("Import Succeeded\n") +
+                       QString("Warnings: Some private keys are missing, outputs will be considered watchonly. If this is intentional, specify the watchonly flag.\nImporting as non-solvable: some required keys are missing. If this is intentional, don't provide any keys, pubkeys, witnessscript, or redeemscript.\n"));
+
+    GetAddressInfo(wallet.get(), addressInfo, key.p2pkh_addr);
+    QCOMPARE(addressInfo.iswatchonly, true);
+    QCOMPARE(addressInfo.ismine, false);
+    QCOMPARE(addressInfo.solvable, false);
+    QCOMPARE(addressInfo.timestamp, timestamp);
+
+    // ScriptPubKey + Private key + internal + Wrong private key
+    key = BuildAddress(wallet.get());
+    data = ImportMultiTestData();
+    data.scriptPubKey = key.p2pkh_script;
+    wrong_key = BuildAddress(wallet.get());
+    data.private_keys = wrong_key.privkey;
+    data.internal = true;
+    EditMultiAndSubmit(&importDialog, data,
+                       QString("Import Succeeded\n") +
+                       QString("Warnings: Some private keys are missing, outputs will be considered watchonly. If this is intentional, specify the watchonly flag.\nImporting as non-solvable: some required keys are missing. If this is intentional, don't provide any keys, pubkeys, witnessscript, or redeemscript.\n"));
+
+    GetAddressInfo(wallet.get(), addressInfo, key.p2pkh_addr);
+    QCOMPARE(addressInfo.iswatchonly, true);
+    QCOMPARE(addressInfo.ismine, false);
+    QCOMPARE(addressInfo.solvable, false);
+    QCOMPARE(addressInfo.timestamp, timestamp);
+
+    // Import P2WPKH address as watch only
+    key = BuildAddress(wallet.get());
+    data = ImportMultiTestData();
+    data.scriptPubKey = key.p2wpkh_addr;
+    EditMultiAndSubmit(&importDialog, data, QString("Import Succeeded"));
+
+    GetAddressInfo(wallet.get(), addressInfo, key.p2wpkh_addr);
+    QCOMPARE(addressInfo.iswatchonly, true);
+    QCOMPARE(addressInfo.solvable, false);
+
+    // Import P2WPKH address with public key but no private key
+    key = BuildAddress(wallet.get());
+    data = ImportMultiTestData();
+    data.scriptPubKey = key.p2wpkh_addr;
+    data.public_keys = key.pubkey;
+    EditMultiAndSubmit(&importDialog, data,
+                       QString("Import Succeeded\n") +
+                       QString("Warnings: Some private keys are missing, outputs will be considered watchonly. If this is intentional, specify the watchonly flag.\n"));
+
+    GetAddressInfo(wallet.get(), addressInfo, key.p2wpkh_addr);
+    QCOMPARE(addressInfo.ismine, false);
+    QCOMPARE(addressInfo.solvable, true);
+
+    // Import P2WPKH address with key and check it is spendable
+    key = BuildAddress(wallet.get());
+    data = ImportMultiTestData();
+    data.scriptPubKey = key.p2wpkh_addr;
+    data.private_keys = key.privkey;
+    EditMultiAndSubmit(&importDialog, data, QString("Import Succeeded"));
+
+    GetAddressInfo(wallet.get(), addressInfo, key.p2wpkh_addr);
+    QCOMPARE(addressInfo.iswatchonly, false);
+    QCOMPARE(addressInfo.ismine, true);
+
+    // P2WSH multisig address without scripts or keys
+    key = get_multisig();
+    data = ImportMultiTestData();
+    data.scriptPubKey = key.p2wpkh_addr;
+    EditMultiAndSubmit(&importDialog, data, QString("Import Succeeded"));
+
+    GetAddressInfo(wallet.get(), addressInfo, key.p2pkh_addr);
+    QCOMPARE(addressInfo.solvable, false);
+
+    // Same P2WSH multisig address as above, but now with witnessscript + private keys
+    key = get_multisig();
+    data = ImportMultiTestData();
+    data.scriptPubKey = key.p2pkh_addr;
+    data.redeem_script = key.p2sh_p2wpkh_redeem_script;
+    data.private_keys = key.privkey;
+    EditMultiAndSubmit(&importDialog, data, QString("Import Succeeded"));
+
+    GetAddressInfo(wallet.get(), addressInfo, key.p2pkh_addr);
+    QCOMPARE(addressInfo.ismine, true);
+    QCOMPARE(addressInfo.solvable, true);
+    QCOMPARE(addressInfo.sigsrequired, 2);
+
+    // P2SH-P2WPKH address with no redeemscript or public or private key
+    key = BuildAddress(wallet.get());
+    data = ImportMultiTestData();
+    data.scriptPubKey = key.p2sh_p2wpkh_addr;
+    EditMultiAndSubmit(&importDialog, data, QString("Import Succeeded"));
+
+    GetAddressInfo(wallet.get(), addressInfo, key.p2sh_p2wpkh_addr);
+    QCOMPARE(addressInfo.ismine, false);
+    QCOMPARE(addressInfo.solvable, false);
+
+    // P2SH-P2WPKH address + redeemscript + public key with no private key
+    key = BuildAddress(wallet.get());
+    data = ImportMultiTestData();
+    data.scriptPubKey = key.p2sh_p2wpkh_addr;
+    data.redeem_script = key.p2sh_p2wpkh_redeem_script;
+    data.public_keys = key.pubkey;
+    EditMultiAndSubmit(&importDialog, data,
+                       QString("Import Succeeded\n") +
+                       QString("Warnings: Some private keys are missing, outputs will be considered watchonly. If this is intentional, specify the watchonly flag.\n"));
+
+    GetAddressInfo(wallet.get(), addressInfo, key.p2sh_p2wpkh_addr);
+    QCOMPARE(addressInfo.ismine, false);
+    QCOMPARE(addressInfo.solvable, true);
+
+    // P2SH-P2WPKH address + redeemscript + private key
+    key = BuildAddress(wallet.get());
+    data = ImportMultiTestData();
+    data.scriptPubKey = key.p2sh_p2wpkh_addr;
+    data.redeem_script = key.p2sh_p2wpkh_redeem_script;
+    data.private_keys = key.privkey;
+    EditMultiAndSubmit(&importDialog, data, QString("Import Succeeded"));
+
+    GetAddressInfo(wallet.get(), addressInfo, key.p2wpkh_addr);
+    QCOMPARE(addressInfo.ismine, true);
+    QCOMPARE(addressInfo.solvable, true);
+
+    // P2SH-P2WSH multisig + redeemscript with no private key
+    key = get_multisig();
+    data = ImportMultiTestData();
+    data.scriptPubKey = key.p2sh_p2wpkh_addr;
+    data.redeem_script = key.p2wpkh_script;
+    data.witness_script = key.p2sh_p2wpkh_redeem_script;
+    EditMultiAndSubmit(&importDialog, data,
+                       QString("Import Succeeded\n") +
+                       QString("Warnings: Some private keys are missing, outputs will be considered watchonly. If this is intentional, specify the watchonly flag.\n"));
+
+    GetAddressInfo(wallet.get(), addressInfo, key.p2pkh_addr);
+    QCOMPARE(addressInfo.ismine, false);
+    QCOMPARE(addressInfo.solvable, true);
+
+    // Test importing of a P2SH-P2WPKH address via descriptor + private key
+    key = BuildAddress(wallet.get());
+    data = ImportMultiTestData();
+    data.desc = "sh(wpkh(" + key.pubkey + "))";
+    data.label = "Unsuccessful P2SH-P2WPKH descriptor import";
+    data.private_keys = key.privkey;
+    EditMultiAndSubmit(&importDialog, data, QString("Error: Missing checksum"));
+
+    // Test importing of a P2SH-P2WPKH address via descriptor + private key
+    key = BuildAddress(wallet.get());
+    data = ImportMultiTestData();
+    std::string desc_str = "sh(wpkh(" + key.pubkey.toStdString() + "))";
+    data.desc = DescsumCreate(desc_str);
+    data.label = "Successful P2SH-P2WPKH descriptor import";
+    data.private_keys = key.privkey;
+    EditMultiAndSubmit(&importDialog, data, QString("Import Succeeded"));
+
+    GetAddressInfo(wallet.get(), addressInfo, key.p2sh_p2wpkh_addr);
+    QCOMPARE(addressInfo.ismine, true);
+    QCOMPARE(addressInfo.solvable, true);
+    QCOMPARE(addressInfo.label, "Successful P2SH-P2WPKH descriptor import");
+
+    // Test ranged descriptor fails if range is not specified
+    std::string xpriv = "tprv8ZgxMBicQKsPeuVhWwi6wuMQGfPKi9Li5GtX35jVNknACgqe3CY4g5xgkfDDJcmtF7o1QnxWDRYw4H5P26PXq7sbcUkEqeR4fg3Kxp2tigg";
+    std::vector<QString> addresses = {"2N7yv4p8G8yEaPddJxY41kPihnWvs39qCMf", "2MsHxyb2JS3pAySeNUsJ7mNnurtpeenDzLA", // hdkeypath=m/0'/0'/0' and 1'
+                        "bcrt1qrd3n235cj2czsfmsuvqqpr3lu6lg0ju7scl8gn", "bcrt1qfqeppuvj0ww98r6qghmdkj70tv8qpchehegrg8"}; // wpkh subscripts corresponding to the above addresses
+    std::string desc = "sh(wpkh(" + xpriv + "/0'/0'/*'" + "))";
+    key = BuildAddress(wallet.get());
+    data = ImportMultiTestData();
+    data.desc = DescsumCreate(desc);
+    EditMultiAndSubmit(&importDialog, data, QString("Error: Descriptor is ranged, please specify the range"));
+
+    // Test importing of a ranged descriptor with xpriv
+    data.range_end = 1;
+    EditMultiAndSubmit(&importDialog, data, QString("Import Succeeded"));
+
+    for (const auto& address: addresses) {
+        GetAddressInfo(wallet.get(), addressInfo, address);
+        QCOMPARE(addressInfo.ismine, true);
+        QCOMPARE(addressInfo.solvable, true);
+    }
+
+    // GUI only accepts range 0 to 0x7FFFFFFF
+    data.range_start = 2;
+    data.range_end = 1;
+    EditMultiAndSubmit(&importDialog, data, QString("Error: Range specified as [begin,end] must not have begin after end"));
+
+    data.range_start = 0;
+    data.range_end = 1000001;
+    EditMultiAndSubmit(&importDialog, data, QString("Error: Range is too large"));
+
+    // Test importing a descriptor containing a WIF private key
+    std::string wif_priv = "cTe1f5rdT8A8DFgVWTjyPwACsDPJM9ff4QngFxUixCSvvbg1x6sh";
+    QString address = "2MuhcG52uHPknxDgmGPsV18jSHFBnnRgjPg";
+    desc = "sh(wpkh(" + wif_priv + "))";
+    key = BuildAddress(wallet.get());
+    data = ImportMultiTestData();
+    data.desc = DescsumCreate(desc);
+    EditMultiAndSubmit(&importDialog, data, QString("Import Succeeded"));
+
+    GetAddressInfo(wallet.get(), addressInfo, address);
+    QCOMPARE(addressInfo.ismine, true);
+    QCOMPARE(addressInfo.solvable, true);
+
+    // Test importing of a P2PKH address via descriptor
+    key = BuildAddress(wallet.get());
+    data = ImportMultiTestData();
+    desc_str = "pkh(" + key.pubkey.toStdString() + ")";
+    data.desc = DescsumCreate(desc_str);
+    data.label = "P2PKH descriptor import";
+    EditMultiAndSubmit(&importDialog, data,
+                       QString("Import Succeeded\n") +
+                       QString("Warnings: Some private keys are missing, outputs will be considered watchonly. If this is intentional, specify the watchonly flag.\n"));
+
+    GetAddressInfo(wallet.get(), addressInfo, key.p2pkh_addr);
+    QCOMPARE(addressInfo.ismine, false);
+    QCOMPARE(addressInfo.solvable, true);
+    QCOMPARE(addressInfo.label, "P2PKH descriptor import");
+
+    // Test importing of a multisig via descriptor
+    key = BuildAddress(wallet.get());
+    Key key2 = BuildAddress(wallet.get());
+    data = ImportMultiTestData();
+    desc_str = "multi(1," + key.pubkey.toStdString() + "," + key2.pubkey.toStdString() + ")";
+    data.desc = DescsumCreate(desc_str);
+    EditMultiAndSubmit(&importDialog, data,
+                       QString("Import Succeeded\n") +
+                       QString("Warnings: Some private keys are missing, outputs will be considered watchonly. If this is intentional, specify the watchonly flag.\n"));
+
+    GetAddressInfo(wallet.get(), addressInfo, key.p2pkh_addr);
+    QCOMPARE(addressInfo.ismine, false);
+    QCOMPARE(addressInfo.iswatchonly, false);
+}
+
+void ImportMultiTests::importMultiTests()
+{
+#ifdef Q_OS_MACOS
+    if (QApplication::platformName() == "minimal") {
+        // Disable for mac on "minimal" platform to avoid crashes inside the Qt
+        // framework when it tries to look up unimplemented cocoa functions,
+        // and fails to handle returned nulls
+        // (https://bugreports.qt.io/browse/QTBUG-49686).
+        QWARN("Skipping ImportMultiTests on mac build with 'minimal' platform set due to Qt bugs. To run AppTests, invoke "
+              "with 'QT_QPA_PLATFORM=cocoa test_bitcoin-qt' on mac, or else use a linux or windows build.");
+        return;
+    }
+#endif
+    TestImportMulti(m_node);
+}

--- a/src/qt/test/importmultitests.h
+++ b/src/qt/test/importmultitests.h
@@ -1,0 +1,27 @@
+// Copyright (c) 2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QT_TEST_IMPORTMULTITESTS_H
+#define BITCOIN_QT_TEST_IMPORTMULTITESTS_H
+
+#include <QObject>
+#include <QTest>
+
+namespace interfaces {
+class Node;
+} // namespace interfaces
+
+class ImportMultiTests : public QObject
+{
+public:
+    explicit ImportMultiTests(interfaces::Node& node) : m_node(node) {}
+    interfaces::Node& m_node;
+
+    Q_OBJECT
+
+private Q_SLOTS:
+    void importMultiTests();
+};
+
+#endif // BITCOIN_QT_TEST_IMPORTMULTITESTS_H

--- a/src/qt/test/test_main.cpp
+++ b/src/qt/test/test_main.cpp
@@ -18,6 +18,7 @@
 
 #ifdef ENABLE_WALLET
 #include <qt/test/addressbooktests.h>
+#include <qt/test/importdescriptorstests.h>
 #include <qt/test/importmultitests.h>
 #include <qt/test/wallettests.h>
 #endif // ENABLE_WALLET
@@ -108,6 +109,9 @@ int main(int argc, char* argv[])
 
     ImportMultiTests test7(app.node());
     num_test_failures += QTest::qExec(&test7);
+
+    ImportDescriptorsTests test8(app.node());
+    num_test_failures += QTest::qExec(&test8);
 #endif
 
     if (num_test_failures) {

--- a/src/qt/test/test_main.cpp
+++ b/src/qt/test/test_main.cpp
@@ -19,6 +19,7 @@
 #ifdef ENABLE_WALLET
 #include <qt/test/addressbooktests.h>
 #include <qt/test/importdescriptorstests.h>
+#include <qt/test/importlegacytests.h>
 #include <qt/test/importmultitests.h>
 #include <qt/test/wallettests.h>
 #endif // ENABLE_WALLET
@@ -112,6 +113,9 @@ int main(int argc, char* argv[])
 
     ImportDescriptorsTests test8(app.node());
     num_test_failures += QTest::qExec(&test8);
+
+    ImportLegacyTests test9(app.node());
+    num_test_failures += QTest::qExec(&test9);
 #endif
 
     if (num_test_failures) {

--- a/src/qt/test/test_main.cpp
+++ b/src/qt/test/test_main.cpp
@@ -18,6 +18,7 @@
 
 #ifdef ENABLE_WALLET
 #include <qt/test/addressbooktests.h>
+#include <qt/test/importmultitests.h>
 #include <qt/test/wallettests.h>
 #endif // ENABLE_WALLET
 
@@ -104,6 +105,9 @@ int main(int argc, char* argv[])
 
     AddressBookTests test6(app.node());
     num_test_failures += QTest::qExec(&test6);
+
+    ImportMultiTests test7(app.node());
+    num_test_failures += QTest::qExec(&test7);
 #endif
 
     if (num_test_failures) {

--- a/src/qt/test/util.cpp
+++ b/src/qt/test/util.cpp
@@ -5,11 +5,15 @@
 #include <qt/test/util.h>
 
 #include <chrono>
+#include <key_io.h>
+#include <wallet/receive.h>
+#include <wallet/wallet.h>
 
 #include <QApplication>
 #include <QMessageBox>
 #include <QPushButton>
 #include <QString>
+#include <QTest>
 #include <QTimer>
 #include <QWidget>
 
@@ -25,3 +29,74 @@ void ConfirmMessage(QString* text, std::chrono::milliseconds msec)
         }
     });
 }
+
+std::pair<bool, int> DescribeAddressTest(const CTxDestination& dest, const SigningProvider* provider)
+{
+    return std::visit(DescribeAddressVisitorTest(provider), dest);
+}
+
+QString DescsumCreate(std::string& descriptor) {
+    return QString::fromStdString(descriptor + "#" + GetDescriptorChecksum(descriptor));
+}
+
+Key BuildAddress(wallet::CWallet* wallet) {
+    Key key;
+    key.key.MakeNewKey(true);
+    key.dest = GetDestinationForKey(key.key.GetPubKey(), wallet->m_default_address_type);
+    key.privkey = QString::fromStdString(EncodeSecret(key.key));
+    key.pubkey = QString::fromStdString(HexStr(key.key.GetPubKey()));
+    key.p2pkh_addr = QString::fromStdString(EncodeDestination(PKHash(key.key.GetPubKey())));
+    key.p2pkh_script = QString::fromStdString(HexStr(GetScriptForDestination(PKHash(key.key.GetPubKey()))));
+    key.p2wpkh_addr = QString::fromStdString(EncodeDestination(WitnessV0KeyHash(key.key.GetPubKey())));
+    key.p2wpkh_script = QString::fromStdString(HexStr(GetScriptForDestination(WitnessV0KeyHash(key.key.GetPubKey()))));
+    key.p2sh_p2wpkh_addr = QString::fromStdString(EncodeDestination(ScriptHash(GetScriptForDestination(WitnessV0KeyHash(key.key.GetPubKey())))));
+    key.p2sh_p2wpkh_script = QString::fromStdString(HexStr(GetScriptForDestination(ScriptHash(GetScriptForDestination(WitnessV0KeyHash(key.key.GetPubKey()))))));
+    key.p2sh_p2wpkh_redeem_script = QString::fromStdString(HexStr(GetScriptForDestination(WitnessV0KeyHash(key.key.GetPubKey()))));
+    return key;
+}
+
+void GetAddressInfo(wallet::CWallet* wallet, AddressInfo& addressInfo, QString input) {
+    addressInfo = AddressInfo();
+
+    LOCK(wallet->cs_wallet);
+
+    CTxDestination dest = DecodeDestination(input.toStdString());
+
+    // Make sure the destination is valid
+    QVERIFY2(IsValidDestination(dest), "Invalid address");
+
+    wallet::isminetype mine = wallet->IsMine(dest);
+    addressInfo.ismine = bool(mine & wallet::ISMINE_SPENDABLE);
+    addressInfo.iswatchonly = bool(mine & wallet::ISMINE_WATCH_ONLY);
+    CScript scriptPubKey = GetScriptForDestination(dest);
+    addressInfo.ischange = ScriptIsChange(*wallet, scriptPubKey);
+    std::unique_ptr<SigningProvider> provider = wallet->GetSolvingProvider(scriptPubKey);
+    std::pair<bool, int> addressDescription = DescribeAddressTest(dest, provider.get());
+    addressInfo.isscript = addressDescription.first;
+    addressInfo.sigsrequired = addressDescription.second;
+
+    if (provider) {
+        auto inferred = InferDescriptor(scriptPubKey, *provider);
+        bool solvable = inferred->IsSolvable();
+        addressInfo.solvable = solvable;
+    } else {
+        addressInfo.solvable = false;
+    }
+
+    const auto& spk_mans = wallet->GetScriptPubKeyMans(scriptPubKey);
+    // In most cases there is only one matching ScriptPubKey manager and we can't resolve ambiguity in a better way
+    wallet::ScriptPubKeyMan* spk_man{nullptr};
+    if (spk_mans.size()) spk_man = *spk_mans.begin();
+
+    if (spk_man) {
+        if (const std::unique_ptr<wallet::CKeyMetadata> meta = spk_man->GetMetadata(dest)) {
+            addressInfo.timestamp = meta->nCreateTime;
+        }
+    }
+
+    const auto* address_book_entry = wallet->FindAddressBookEntry(dest);
+    if (address_book_entry) {
+        addressInfo.label = address_book_entry->GetLabel();
+    }
+}
+

--- a/src/qt/test/util.h
+++ b/src/qt/test/util.h
@@ -9,9 +9,10 @@
 
 #include <qglobal.h>
 
-QT_BEGIN_NAMESPACE
-class QString;
-QT_END_NAMESPACE
+#include <script/standard.h>
+#include <script/signingprovider.h>
+#include <QString>
+#include <qt/walletmodel.h>
 
 /**
  * Press "Ok" button in message box dialog.
@@ -20,5 +21,106 @@ QT_END_NAMESPACE
  * @param msec - Number of milliseconds to pause before triggering the callback.
  */
 void ConfirmMessage(QString* text, std::chrono::milliseconds msec);
+
+class DescribeAddressVisitorTest
+{
+public:
+    const SigningProvider * const provider;
+
+    int ProcessSubScript(const CScript& subscript) const
+    {
+        // Always present: script type and redeemscript
+        std::vector<std::vector<unsigned char>> solutions_data;
+        TxoutType which_type = Solver(subscript, solutions_data);
+
+        if (which_type == TxoutType::MULTISIG) {
+            return solutions_data[0][0];
+        }
+        return -1;
+    }
+
+    explicit DescribeAddressVisitorTest(const SigningProvider* _provider) : provider(_provider) {};
+
+    std::pair<bool, int> operator()(const CNoDestination& dest) const
+    {
+        return std::make_pair(false, -1);
+    }
+
+    std::pair<bool, int> operator()(const PKHash& keyID) const
+    {
+        return std::make_pair(false, -1);
+    }
+
+    std::pair<bool, int> operator()(const ScriptHash& scripthash) const
+    {
+        CScriptID scriptID(scripthash);
+        CScript subscript;
+        int sigsrequired = -1;
+        if (provider && provider->GetCScript(scriptID, subscript)) {
+            sigsrequired = ProcessSubScript(subscript);
+        }
+        return std::make_pair(true, sigsrequired);
+    }
+
+    std::pair<bool, int> operator()(const WitnessV0KeyHash& id) const
+    {
+        return std::make_pair(false, -1);
+    }
+
+    std::pair<bool, int> operator()(const WitnessV0ScriptHash& id) const
+    {
+        CScript subscript;
+        CRIPEMD160 hasher;
+        uint160 hash;
+        hasher.Write(id.begin(), 32).Finalize(hash.begin());
+        int sigsrequired = -1;
+        if (provider && provider->GetCScript(CScriptID(hash), subscript)) {
+            sigsrequired = ProcessSubScript(subscript);
+        }
+        return std::make_pair(true, sigsrequired);
+    }
+
+    std::pair<bool, int> operator()(const WitnessV1Taproot& tap) const
+    {
+        return std::make_pair(true, -1);
+    }
+
+    std::pair<bool, int> operator()(const WitnessUnknown& id) const
+    {
+        return std::make_pair(false, -1);
+    }
+};
+
+struct Key
+{
+    CKey key;
+    CTxDestination dest;
+    QString privkey;
+    QString pubkey;
+    QString p2pkh_addr;
+    QString p2pkh_script;
+    QString p2wpkh_addr;
+    QString p2wpkh_script;
+    QString p2sh_p2wpkh_addr;
+    QString p2sh_p2wpkh_script;
+    QString p2sh_p2wpkh_redeem_script;
+};
+
+struct AddressInfo
+{
+    bool ischange = false;
+    bool ismine = false;
+    bool isscript = false;
+    bool iswatchonly = false;
+    std::string label;
+    int sigsrequired = -1;
+    bool solvable = false;
+    int64_t timestamp = 0;
+};
+
+std::pair<bool, int> DescribeAddressTest(const CTxDestination& dest, const SigningProvider* provider);
+QString DescsumCreate(std::string& descriptor);
+Key BuildAddress(wallet::CWallet* wallet);
+void GetAddressInfo(wallet::CWallet* wallet, AddressInfo& addressInfo, QString input);
 
 #endif // BITCOIN_QT_TEST_UTIL_H

--- a/src/qt/walletframe.cpp
+++ b/src/qt/walletframe.cpp
@@ -249,6 +249,27 @@ void WalletFrame::backupWallet()
         walletView->backupWallet();
 }
 
+void WalletFrame::importPubkey()
+{
+    WalletView *walletView = currentWalletView();
+    if (walletView)
+        walletView->importPubkey();
+}
+
+void WalletFrame::importPrivkey()
+{
+    WalletView *walletView = currentWalletView();
+    if (walletView)
+        walletView->importPrivkey();
+}
+
+void WalletFrame::importAddress()
+{
+    WalletView *walletView = currentWalletView();
+    if (walletView)
+        walletView->importAddress();
+}
+
 void WalletFrame::changePassphrase()
 {
     WalletView *walletView = currentWalletView();

--- a/src/qt/walletframe.cpp
+++ b/src/qt/walletframe.cpp
@@ -270,6 +270,19 @@ void WalletFrame::importAddress()
         walletView->importAddress();
 }
 
+void WalletFrame::importMulti() {
+    WalletView *walletView = currentWalletView();
+    if (walletView)
+        walletView->importMulti();
+}
+
+void WalletFrame::importDescriptors()
+{
+    WalletView *walletView = currentWalletView();
+    if (walletView)
+        walletView->importDescriptors();
+}
+
 void WalletFrame::changePassphrase()
 {
     WalletView *walletView = currentWalletView();

--- a/src/qt/walletframe.h
+++ b/src/qt/walletframe.h
@@ -94,6 +94,10 @@ public Q_SLOTS:
     void importPrivkey();
     /** Import address */
     void importAddress();
+    /** Import multi */
+    void importMulti();
+    /** Import descriptors */
+    void importDescriptors();
     /** Change encrypted wallet passphrase */
     void changePassphrase();
     /** Ask for passphrase to unlock wallet temporarily */

--- a/src/qt/walletframe.h
+++ b/src/qt/walletframe.h
@@ -88,6 +88,12 @@ public Q_SLOTS:
     void encryptWallet();
     /** Backup the wallet */
     void backupWallet();
+    /** Import public key */
+    void importPubkey();
+    /** Import private key */
+    void importPrivkey();
+    /** Import address */
+    void importAddress();
     /** Change encrypted wallet passphrase */
     void changePassphrase();
     /** Ask for passphrase to unlock wallet temporarily */

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -8,6 +8,7 @@
 #include <qt/askpassphrasedialog.h>
 #include <qt/clientmodel.h>
 #include <qt/guiutil.h>
+#include <qt/importdialog.h>
 #include <qt/optionsmodel.h>
 #include <qt/overviewpage.h>
 #include <qt/platformstyle.h>
@@ -226,6 +227,24 @@ void WalletView::backupWallet()
         Q_EMIT message(tr("Backup Successful"), tr("The wallet data was successfully saved to %1.").arg(filename),
             CClientUIInterface::MSG_INFORMATION);
     }
+}
+
+void WalletView::importPubkey()
+{
+    auto dlg = new ImportDialog(ImportDialog::importPubkey, walletModel, this);
+    GUIUtil::ShowModalDialogAsynchronously(dlg);
+}
+
+void WalletView::importPrivkey()
+{
+    auto dlg = new ImportDialog(ImportDialog::importPrivkey, walletModel, this);
+    GUIUtil::ShowModalDialogAsynchronously(dlg);
+}
+
+void WalletView::importAddress()
+{
+    auto dlg = new ImportDialog(ImportDialog::importAddress, walletModel, this);
+    GUIUtil::ShowModalDialogAsynchronously(dlg);
 }
 
 void WalletView::changePassphrase()

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -247,6 +247,18 @@ void WalletView::importAddress()
     GUIUtil::ShowModalDialogAsynchronously(dlg);
 }
 
+void WalletView::importMulti()
+{
+    auto dlg = new ImportDialog(ImportDialog::importMulti, walletModel, this);
+    GUIUtil::ShowModalDialogAsynchronously(dlg);
+}
+
+void WalletView::importDescriptors()
+{
+    auto dlg = new ImportDialog(ImportDialog::importDescriptors, walletModel, this);
+    GUIUtil::ShowModalDialogAsynchronously(dlg);
+}
+
 void WalletView::changePassphrase()
 {
     auto dlg = new AskPassphraseDialog(AskPassphraseDialog::ChangePass, this);

--- a/src/qt/walletview.h
+++ b/src/qt/walletview.h
@@ -100,6 +100,10 @@ public Q_SLOTS:
     void importPrivkey();
     /** Import address */
     void importAddress();
+    /** Import multi */
+    void importMulti();
+    /** Import descriptors */
+    void importDescriptors();
     /** Change encrypted wallet passphrase */
     void changePassphrase();
     /** Ask for passphrase to unlock wallet temporarily */

--- a/src/qt/walletview.h
+++ b/src/qt/walletview.h
@@ -94,6 +94,12 @@ public Q_SLOTS:
     void encryptWallet();
     /** Backup the wallet */
     void backupWallet();
+    /** Import public key */
+    void importPubkey();
+    /** Import private key */
+    void importPrivkey();
+    /** Import address */
+    void importAddress();
     /** Change encrypted wallet passphrase */
     void changePassphrase();
     /** Ask for passphrase to unlock wallet temporarily */

--- a/src/wallet/imports.cpp
+++ b/src/wallet/imports.cpp
@@ -1,0 +1,535 @@
+// Copyright (c) 2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <wallet/imports.h>
+
+#include <key_io.h>
+#include <set>
+#include <string>
+#include <util/check.h>
+#include <vector>
+#include <wallet/wallet.h>
+
+namespace wallet {
+struct ImportData {
+    // Input data
+    std::unique_ptr<CScript> redeemscript; //!< Provided redeemScript; will be moved to `import_scripts` if relevant.
+    std::unique_ptr<CScript> witnessscript; //!< Provided witnessScript; will be moved to `import_scripts` if relevant.
+
+    // Output data
+    std::set<CScript> import_scripts;
+    std::map<CKeyID, bool> used_keys; //!< Import these private keys if available (the value indicates whether if the key is required for solvability)
+    std::map<CKeyID, std::pair<CPubKey, KeyOriginInfo>> key_origins;
+};
+
+enum class ScriptContext {
+    TOP, //!< Top-level scriptPubKey
+    P2SH, //!< P2SH redeemScript
+    WITNESS_V0, //!< P2WSH witnessScript
+};
+
+// Analyse the provided scriptPubKey, determining which keys and which redeem scripts from the ImportData struct are needed to spend it, and mark them as used.
+// Returns an error string, or the empty string for success.
+static std::string RecurseImportData(const CScript &script, ImportData &import_data, const ScriptContext script_ctx) {
+    // Use Solver to obtain script type and parsed pubkeys or hashes:
+    std::vector<std::vector<unsigned char>> solverdata;
+    TxoutType script_type = Solver(script, solverdata);
+
+    switch (script_type) {
+        case TxoutType::PUBKEY: {
+            CPubKey pubkey(solverdata[0]);
+            import_data.used_keys.emplace(pubkey.GetID(), false);
+            return "";
+        }
+        case TxoutType::PUBKEYHASH: {
+            CKeyID id = CKeyID(uint160(solverdata[0]));
+            import_data.used_keys[id] = true;
+            return "";
+        }
+        case TxoutType::SCRIPTHASH: {
+            if (script_ctx == ScriptContext::P2SH)
+                throw InvalidAddressOrKey("Trying to nest P2SH inside another P2SH");
+            if (script_ctx == ScriptContext::WITNESS_V0)
+                throw InvalidAddressOrKey("Trying to nest P2SH inside a P2WSH");
+            CHECK_NONFATAL(script_ctx == ScriptContext::TOP);
+            CScriptID id = CScriptID(uint160(solverdata[0]));
+            auto subscript = std::move(
+                    import_data.redeemscript); // Remove redeemscript from import_data to check for superfluous script later.
+            if (!subscript) return "missing redeemscript";
+            if (CScriptID(*subscript) != id) return "redeemScript does not match the scriptPubKey";
+            import_data.import_scripts.emplace(*subscript);
+            return RecurseImportData(*subscript, import_data, ScriptContext::P2SH);
+        }
+        case TxoutType::MULTISIG: {
+            for (size_t i = 1; i + 1 < solverdata.size(); ++i) {
+                CPubKey pubkey(solverdata[i]);
+                import_data.used_keys.emplace(pubkey.GetID(), false);
+            }
+            return "";
+        }
+        case TxoutType::WITNESS_V0_SCRIPTHASH: {
+            if (script_ctx == ScriptContext::WITNESS_V0)
+                throw InvalidAddressOrKey("Trying to nest P2WSH inside another P2WSH");
+            uint256 fullid(solverdata[0]);
+            CScriptID id;
+            CRIPEMD160().Write(fullid.begin(), fullid.size()).Finalize(id.begin());
+            auto subscript = std::move(
+                    import_data.witnessscript); // Remove redeemscript from import_data to check for superfluous script later.
+            if (!subscript) return "missing witnessscript";
+            if (CScriptID(*subscript) != id) return "witnessScript does not match the scriptPubKey or redeemScript";
+            if (script_ctx == ScriptContext::TOP) {
+                import_data.import_scripts.emplace(
+                        script); // Special rule for IsMine: native P2WSH requires the TOP script imported (see script/ismine.cpp)
+            }
+            import_data.import_scripts.emplace(*subscript);
+            return RecurseImportData(*subscript, import_data, ScriptContext::WITNESS_V0);
+        }
+        case TxoutType::WITNESS_V0_KEYHASH: {
+            if (script_ctx == ScriptContext::WITNESS_V0)
+                throw InvalidAddressOrKey("Trying to nest P2WPKH inside P2WSH");
+            CKeyID id = CKeyID(uint160(solverdata[0]));
+            import_data.used_keys[id] = true;
+            if (script_ctx == ScriptContext::TOP) {
+                import_data.import_scripts.emplace(
+                        script); // Special rule for IsMine: native P2WPKH requires the TOP script imported (see script/ismine.cpp)
+            }
+            return "";
+        }
+        case TxoutType::NULL_DATA:
+            return "unspendable script";
+        case TxoutType::NONSTANDARD:
+        case TxoutType::WITNESS_UNKNOWN:
+        case TxoutType::WITNESS_V1_TAPROOT:
+            return "unrecognized script";
+    } // no default case, so the compiler can warn about missing cases
+    NONFATAL_UNREACHABLE();
+}
+
+std::vector<std::string> ProcessImportLegacy(ImportData &import_data, std::map<CKeyID, CPubKey> &pubkey_map,
+                                             std::map<CKeyID, CKey> &privkey_map,
+                                             std::set<CScript> &script_pub_keys, bool &have_solving_data,
+                                             const ImportMultiData &data, std::vector<CKeyID> &ordered_pubkeys) {
+    std::vector<std::string> warnings;
+
+    // Generate the script and destination for the scriptPubKey provided
+    CScript script;
+    if (!data.isScript) {
+        CTxDestination dest = DecodeDestination(data.scriptPubKey);
+        if (!IsValidDestination(dest)) {
+            throw InvalidAddressOrKey("Invalid address \"" + data.scriptPubKey + "\"");
+        }
+        if (OutputTypeFromDestination(dest) == OutputType::BECH32M) {
+            throw InvalidAddressOrKey("Bech32m addresses cannot be imported into legacy wallets");
+        }
+        script = GetScriptForDestination(dest);
+    } else {
+        if (!IsHex(data.scriptPubKey)) {
+            throw InvalidAddressOrKey("Invalid scriptPubKey \"" + data.scriptPubKey + "\"");
+        }
+        std::vector<unsigned char> vData(ParseHex(data.scriptPubKey));
+        script = CScript(vData.begin(), vData.end());
+        CTxDestination dest;
+        if (!ExtractDestination(script, dest) && !data.internal) {
+            throw InvalidParameter("Internal must be set to true for nonstandard scriptPubKey imports.");
+        }
+    }
+    script_pub_keys.emplace(script);
+
+    // Parse all arguments
+    if (data.redeem_script.size()) {
+        if (!IsHex(data.redeem_script)) {
+            throw InvalidAddressOrKey("Invalid redeem script \"" + data.redeem_script + "\": must be hex string");
+        }
+        auto parsed_redeemscript = ParseHex(data.redeem_script);
+        import_data.redeemscript = std::make_unique<CScript>(parsed_redeemscript.begin(),
+                                                             parsed_redeemscript.end());
+    }
+    if (data.witness_script.size()) {
+        if (!IsHex(data.witness_script)) {
+            throw InvalidAddressOrKey("Invalid witness script \"" + data.witness_script + "\": must be hex string");
+        }
+        auto parsed_witnessscript = ParseHex(data.witness_script);
+        import_data.witnessscript = std::make_unique<CScript>(parsed_witnessscript.begin(),
+                                                              parsed_witnessscript.end());
+    }
+    for (size_t i = 0; i < data.public_keys.size(); ++i) {
+        const auto &str = data.public_keys[i];
+        if (!IsHex(str)) {
+            throw InvalidAddressOrKey("Pubkey \"" + str + "\" must be a hex string");
+        }
+        auto parsed_pubkey = ParseHex(str);
+        CPubKey pubkey(parsed_pubkey);
+        if (!pubkey.IsFullyValid()) {
+            throw InvalidAddressOrKey("Pubkey \"" + str + "\" is not a valid public key");
+        }
+        pubkey_map.emplace(pubkey.GetID(), pubkey);
+        ordered_pubkeys.push_back(pubkey.GetID());
+    }
+    for (size_t i = 0; i < data.private_keys.size(); ++i) {
+        const auto &str = data.private_keys[i];
+        CKey key = DecodeSecret(str);
+        if (!key.IsValid()) {
+            throw InvalidAddressOrKey("Invalid private key encoding " + str);
+        }
+        CPubKey pubkey = key.GetPubKey();
+        CKeyID id = pubkey.GetID();
+        if (pubkey_map.count(id)) {
+            pubkey_map.erase(id);
+        }
+        privkey_map.emplace(id, key);
+    }
+
+
+    // Verify and process input data
+    have_solving_data =
+            import_data.redeemscript || import_data.witnessscript || pubkey_map.size() || privkey_map.size();
+    if (have_solving_data) {
+        // Match up data in import_data with the scriptPubKey in script.
+        auto error = RecurseImportData(script, import_data, ScriptContext::TOP);
+
+        // Verify whether the watchonly option corresponds to the availability of private keys.
+        bool spendable = std::all_of(import_data.used_keys.begin(), import_data.used_keys.end(),
+                                     [&](const std::pair<CKeyID, bool> &used_key) {
+                                         return privkey_map.count(used_key.first) > 0;
+                                     });
+        if (!data.watch_only && !spendable) {
+            warnings.push_back(
+                    "Some private keys are missing, outputs will be considered watchonly. If this is intentional, specify the watchonly flag.");
+        }
+        if (data.watch_only && spendable) {
+            warnings.push_back(
+                    "All private keys are provided, outputs will be considered spendable. If this is intentional, do not specify the watchonly flag.");
+        }
+
+        // Check that all required keys for solvability are provided.
+        if (error.empty()) {
+            for (const auto &require_key: import_data.used_keys) {
+                if (!require_key.second) continue; // Not a required key
+                if (pubkey_map.count(require_key.first) == 0 && privkey_map.count(require_key.first) == 0) {
+                    error = "some required keys are missing";
+                }
+            }
+        }
+
+        if (!error.empty()) {
+            warnings.push_back("Importing as non-solvable: " + error +
+                               ". If this is intentional, don't provide any keys, pubkeys, witnessscript, or redeemscript.");
+            import_data = ImportData();
+            pubkey_map.clear();
+            privkey_map.clear();
+            have_solving_data = false;
+        } else {
+            // RecurseImportData() removes any relevant redeemscript/witnessscript from import_data, so we can use that to discover if a superfluous one was provided.
+            if (import_data.redeemscript) warnings.push_back("Ignoring redeemscript as this is not a P2SH script.");
+            if (import_data.witnessscript)
+                warnings.push_back("Ignoring witnessscript as this is not a (P2SH-)P2WSH script.");
+            for (auto it = privkey_map.begin(); it != privkey_map.end();) {
+                auto oldit = it++;
+                if (import_data.used_keys.count(oldit->first) == 0) {
+                    warnings.push_back("Ignoring irrelevant private key.");
+                    privkey_map.erase(oldit);
+                }
+            }
+            for (auto it = pubkey_map.begin(); it != pubkey_map.end();) {
+                auto oldit = it++;
+                auto key_data_it = import_data.used_keys.find(oldit->first);
+                if (key_data_it == import_data.used_keys.end() || !key_data_it->second) {
+                    warnings.push_back("Ignoring public key \"" + HexStr(oldit->first) +
+                                       "\" as it doesn't appear inside P2PKH or P2WPKH.");
+                    pubkey_map.erase(oldit);
+                }
+            }
+        }
+    }
+
+    return warnings;
+}
+
+std::vector<std::string> ProcessImportDescriptor(ImportData &import_data, std::map<CKeyID, CPubKey> &pubkey_map,
+                                                 std::map<CKeyID, CKey> &privkey_map,
+                                                 std::set<CScript> &script_pub_keys, bool &have_solving_data,
+                                                 const ImportMultiData &data,
+                                                 std::vector<CKeyID> &ordered_pubkeys) {
+    std::vector<std::string> warnings;
+
+    have_solving_data = data.parsed_desc->IsSolvable();
+
+    // Expand all descriptors to get public keys and scripts, and private keys if available.
+    for (int i = data.range_start; i <= data.range_end; ++i) {
+        FlatSigningProvider out_keys;
+        std::vector<CScript> scripts_temp;
+        data.parsed_desc->Expand(i, data.keys, scripts_temp, out_keys);
+        std::copy(scripts_temp.begin(), scripts_temp.end(), std::inserter(script_pub_keys, script_pub_keys.end()));
+        for (const auto &key_pair: out_keys.pubkeys) {
+            ordered_pubkeys.push_back(key_pair.first);
+        }
+
+        for (const auto &x: out_keys.scripts) {
+            import_data.import_scripts.emplace(x.second);
+        }
+
+        data.parsed_desc->ExpandPrivate(i, data.keys, out_keys);
+
+        std::copy(out_keys.pubkeys.begin(), out_keys.pubkeys.end(), std::inserter(pubkey_map, pubkey_map.end()));
+        std::copy(out_keys.keys.begin(), out_keys.keys.end(), std::inserter(privkey_map, privkey_map.end()));
+        import_data.key_origins.insert(out_keys.origins.begin(), out_keys.origins.end());
+    }
+
+    for (size_t i = 0; i < data.private_keys.size(); ++i) {
+        const auto &str = data.private_keys[i];
+        CKey key = DecodeSecret(str);
+        if (!key.IsValid()) {
+            throw InvalidAddressOrKey("Invalid private key encoding");
+        }
+        CPubKey pubkey = key.GetPubKey();
+        CKeyID id = pubkey.GetID();
+
+        // Check if this private key corresponds to a public key from the descriptor
+        if (!pubkey_map.count(id)) {
+            warnings.push_back("Ignoring irrelevant private key.");
+        } else {
+            privkey_map.emplace(id, key);
+        }
+    }
+
+    // Check if all the public keys have corresponding private keys in the import for spendability.
+    // This does not take into account threshold multisigs which could be spendable without all keys.
+    // Thus, threshold multisigs without all keys will be considered not spendable here, even if they are,
+    // perhaps triggering a false warning message. This is consistent with the current wallet IsMine check.
+    bool spendable = std::all_of(pubkey_map.begin(), pubkey_map.end(),
+                                 [&](const std::pair<CKeyID, CPubKey> &used_key) {
+                                     return privkey_map.count(used_key.first) > 0;
+                                 }) && std::all_of(import_data.key_origins.begin(), import_data.key_origins.end(),
+                                                   [&](const std::pair<CKeyID, std::pair<CPubKey, KeyOriginInfo>> &entry) {
+                                                       return privkey_map.count(entry.first) > 0;
+                                                   });
+    if (!data.watch_only && !spendable) {
+        warnings.push_back(
+                "Some private keys are missing, outputs will be considered watchonly. If this is intentional, specify the watchonly flag.");
+    }
+    if (data.watch_only && spendable) {
+        warnings.push_back(
+                "All private keys are provided, outputs will be considered spendable. If this is intentional, do not specify the watchonly flag.");
+    }
+
+    return warnings;
+}
+
+bool ProcessImport(CWallet &wallet, const ImportMultiData &data, std::vector<std::string> &warnings,
+                   const int64_t timestamp) {
+    // Add to keypool only works with privkeys disabled
+    if (data.keypool && !wallet.IsWalletFlagSet(WALLET_FLAG_DISABLE_PRIVATE_KEYS)) {
+        throw InvalidParameter("Keys can only be imported to the keypool when private keys are disabled");
+    }
+
+    ImportData import_data;
+    std::map<CKeyID, CPubKey> pubkey_map;
+    std::map<CKeyID, CKey> privkey_map;
+    std::set<CScript> script_pub_keys;
+    std::vector<CKeyID> ordered_pubkeys;
+    bool have_solving_data;
+
+    if (!data.scriptPubKey.empty()) {
+        warnings = ProcessImportLegacy(import_data, pubkey_map, privkey_map, script_pub_keys, have_solving_data,
+                                       data, ordered_pubkeys);
+    } else {
+        warnings = ProcessImportDescriptor(import_data, pubkey_map, privkey_map, script_pub_keys, have_solving_data,
+                                           data, ordered_pubkeys);
+    }
+
+    // If private keys are disabled, abort if private keys are being imported
+    if (wallet.IsWalletFlagSet(WALLET_FLAG_DISABLE_PRIVATE_KEYS) && !privkey_map.empty()) {
+        throw WalletError("Cannot import private keys to a wallet with private keys disabled");
+    }
+
+    // Check whether we have any work to do
+    for (const CScript &script: script_pub_keys) {
+        if (wallet.IsMine(script) & ISMINE_SPENDABLE) {
+            throw WalletError(
+                    "The wallet already contains the private key for this address or script (\"" + HexStr(script) +
+                    "\")");
+        }
+    }
+
+    // All good, time to import
+    wallet.MarkDirty();
+    if (!wallet.ImportScripts(import_data.import_scripts, timestamp)) {
+        throw WalletError("Error adding script to wallet");
+    }
+    if (!wallet.ImportPrivKeys(privkey_map, timestamp)) {
+        throw WalletError("Error adding key to wallet");
+    }
+    if (!wallet.ImportPubKeys(ordered_pubkeys, pubkey_map, import_data.key_origins, data.keypool, data.internal,
+                              timestamp)) {
+        throw WalletError("Error adding address to wallet");
+    }
+    if (!wallet.ImportScriptPubKeys(data.label, script_pub_keys, have_solving_data, !data.internal, timestamp)) {
+        throw WalletError("Error adding address to wallet");
+    }
+
+    return true;
+}
+
+bool ProcessDescriptorImport(CWallet &wallet, const ImportDescriptorData &data, std::vector<std::string> &warnings,
+                             FlatSigningProvider &keys, bool range_exists, const int64_t timestamp) {
+    // Active descriptors must be ranged
+    if (data.active && !data.parsed_desc->IsRange()) {
+        throw InvalidParameter("Active descriptors must be ranged");
+    }
+
+    // Ranged descriptors should not have a label
+    if (range_exists && !data.label.empty()) {
+        throw InvalidParameter("Ranged descriptors should not have a label");
+    }
+
+    // Internal addresses should not have a label either
+    if (data.internal && !data.label.empty()) {
+        throw InvalidParameter("Internal addresses should not have a label");
+    }
+
+    // Combo descriptor check
+    if (data.active && !data.parsed_desc->IsSingleType()) {
+        throw WalletError("Combo descriptors cannot be set to active");
+    }
+
+    // If the wallet disabled private keys, abort if private keys exist
+    if (wallet.IsWalletFlagSet(WALLET_FLAG_DISABLE_PRIVATE_KEYS) && !keys.keys.empty()) {
+        throw WalletError("Cannot import private keys to a wallet with private keys disabled");
+    }
+
+    // Need to ExpandPrivate to check if private keys are available for all pubkeys
+    FlatSigningProvider expand_keys;
+    std::vector<CScript> scripts;
+    if (!data.parsed_desc->Expand(0, keys, scripts, expand_keys)) {
+        throw WalletError(
+                "Cannot expand descriptor. Probably because of hardened derivations without private keys provided");
+    }
+    data.parsed_desc->ExpandPrivate(0, keys, expand_keys);
+
+    // Check if all private keys are provided
+    bool have_all_privkeys = !expand_keys.keys.empty();
+    for (const auto &entry: expand_keys.origins) {
+        const CKeyID &key_id = entry.first;
+        CKey key;
+        if (!expand_keys.GetKey(key_id, key)) {
+            have_all_privkeys = false;
+            break;
+        }
+    }
+
+    // If private keys are enabled, check some things.
+    if (!wallet.IsWalletFlagSet(WALLET_FLAG_DISABLE_PRIVATE_KEYS)) {
+        if (keys.keys.empty()) {
+            throw WalletError(
+                    "Cannot import descriptor without private keys to a wallet with private keys enabled");
+        }
+        if (!have_all_privkeys) {
+            warnings.push_back(
+                    "Not all private keys provided. Some wallet functionality may return unexpected errors");
+        }
+    }
+
+    WalletDescriptor w_desc(data.parsed_desc, timestamp, data.range_start, data.range_end, data.next_index);
+
+    // Check if the wallet already contains the descriptor
+    std::string error;
+    auto existing_spk_manager = wallet.GetDescriptorScriptPubKeyMan(w_desc);
+    if (existing_spk_manager) {
+        if (!existing_spk_manager->CanUpdateToWalletDescriptor(w_desc, error)) {
+            throw InvalidParameter(error);
+        }
+    }
+
+    // Add descriptor to the wallet
+    auto spk_manager = wallet.AddWalletDescriptor(w_desc, keys, data.label, data.internal);
+    if (spk_manager == nullptr) {
+        throw WalletError(strprintf("Could not add descriptor '%s'", data.parsed_desc->ToString()));
+    }
+
+    // Set descriptor as active if necessary
+    if (data.active) {
+        if (!w_desc.descriptor->GetOutputType()) {
+            warnings.push_back("Unknown output type, cannot set descriptor to active.");
+        } else {
+            wallet.AddActiveScriptPubKeyMan(spk_manager->GetID(), *w_desc.descriptor->GetOutputType(),
+                                            data.internal);
+        }
+    } else {
+        if (w_desc.descriptor->GetOutputType()) {
+            wallet.DeactivateScriptPubKeyMan(spk_manager->GetID(), *w_desc.descriptor->GetOutputType(),
+                                             data.internal);
+        }
+    }
+    return true;
+}
+
+bool ProcessPublicKey(CWallet &wallet, std::string strLabel, CPubKey pubKey) {
+    std::set<CScript> script_pub_keys;
+    for (const auto& dest : GetAllDestinationsForKey(pubKey)) {
+        script_pub_keys.insert(GetScriptForDestination(dest));
+    }
+
+    wallet.MarkDirty();
+    wallet.ImportScriptPubKeys(strLabel, script_pub_keys, /*have_solving_data=*/true, /*apply_label=*/true, /*timestamp=*/1);
+    wallet.ImportPubKeys({pubKey.GetID()}, {{pubKey.GetID(), pubKey}} , /*key_origins=*/{}, /*add_keypool=*/false, /*internal=*/false, /*timestamp=*/1);
+    return true;
+}
+
+bool ProcessPrivateKey(CWallet &wallet, std::string strLabel, CKey key) {
+    CPubKey pubkey = key.GetPubKey();
+    CHECK_NONFATAL(key.VerifyPubKey(pubkey));
+    CKeyID vchAddress = pubkey.GetID();
+    wallet.MarkDirty();
+
+    // We don't know which corresponding address will be used;
+    // label all new addresses, and label existing addresses if a
+    // label was passed.
+    for (const auto &dest: GetAllDestinationsForKey(pubkey)) {
+        if (!strLabel.empty() || !wallet.FindAddressBookEntry(dest)) {
+            wallet.SetAddressBook(dest, strLabel, AddressPurpose::RECEIVE);
+        }
+    }
+
+    // Use timestamp of 1 to scan the whole chain
+    if (!wallet.ImportPrivKeys({{vchAddress, key}}, 1)) {
+        throw WalletError("Error adding key to wallet");
+    }
+
+    // Add the wpkh script for this key if possible
+    if (pubkey.IsCompressed()) {
+        wallet.ImportScripts({GetScriptForDestination(WitnessV0KeyHash(vchAddress))}, /*timestamp=*/0);
+    }
+    return true;
+}
+
+bool ProcessAddress(CWallet &wallet, std::string strAddress, std::string strLabel, bool fP2SH) {
+    CTxDestination dest = DecodeDestination(strAddress);
+    if (IsValidDestination(dest)) {
+        if (fP2SH) {
+            throw InvalidAddressOrKey("Cannot use the p2sh flag with an address - use a script instead");
+        }
+        if (OutputTypeFromDestination(dest) == OutputType::BECH32M) {
+            throw InvalidAddressOrKey("Bech32m addresses cannot be imported into legacy wallets");
+        }
+
+        wallet.MarkDirty();
+        wallet.ImportScriptPubKeys(strLabel, {GetScriptForDestination(dest)}, /*have_solving_data=*/false, /*apply_label=*/true, /*timestamp=*/1);
+    } else if (IsHex(strAddress)) {
+        std::vector<unsigned char> data(ParseHex(strAddress));
+        CScript redeem_script(data.begin(), data.end());
+
+        std::set<CScript> scripts = {redeem_script};
+        wallet.ImportScripts(scripts, /*timestamp=*/0);
+
+        if (fP2SH) {
+            scripts.insert(GetScriptForDestination(ScriptHash(redeem_script)));
+        }
+
+        wallet.ImportScriptPubKeys(strLabel, scripts, /*have_solving_data=*/false, /*apply_label=*/true, /*timestamp=*/1);
+    } else {
+        throw InvalidAddressOrKey("Invalid Bitcoin address or script");
+    }
+    return true;
+}
+}

--- a/src/wallet/imports.h
+++ b/src/wallet/imports.h
@@ -1,0 +1,74 @@
+// Copyright (c) 2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_WALLET_IMPORTS_H
+#define BITCOIN_WALLET_IMPORTS_H
+
+#include <string>
+#include <vector>
+#include <threadsafety.h>
+#include <script/descriptor.h>
+#include <script/signingprovider.h>
+#include <wallet/wallet.h>
+
+namespace wallet {
+struct MiscError {
+    std::string error;
+    MiscError(std::string error) : error(error) {}
+};
+
+struct WalletError {
+    std::string error;
+    WalletError(std::string error) : error(error) {}
+};
+
+struct InvalidAddressOrKey {
+    std::string error;
+    InvalidAddressOrKey(std::string error) : error(error) {}
+};
+
+struct InvalidParameter {
+    std::string error;
+    InvalidParameter(std::string error) : error(error) {}
+};
+
+struct ImportMultiData
+{
+    std::unique_ptr<Descriptor> parsed_desc;
+    std::string scriptPubKey;
+    std::string redeem_script;
+    std::string witness_script;
+    std::string label;
+    std::vector<std::string> public_keys;
+    std::vector<std::string> private_keys;
+    int64_t range_start = 0;
+    int64_t range_end = 0;
+    int64_t timestamp = 0;
+    bool internal = false;
+    bool isScript = false;
+    bool watch_only = false;
+    bool keypool = false;
+    FlatSigningProvider keys;
+};
+
+struct ImportDescriptorData
+{
+    std::shared_ptr<Descriptor> parsed_desc;
+    std::string label;
+    int64_t range_start = 0;
+    int64_t range_end = 0;
+    int64_t next_index = 0;
+    int64_t timestamp = 0;
+    bool active = false;
+    bool internal = false;
+};
+
+bool ProcessDescriptorImport(CWallet& wallet, const ImportDescriptorData& data, std::vector<std::string>& warnings, FlatSigningProvider& keys, bool range_exists, const int64_t timestamp) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet);
+bool ProcessImport(CWallet& wallet, const ImportMultiData& data, std::vector<std::string>& warnings, const int64_t timestamp) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet);
+bool ProcessPublicKey(CWallet& wallet, std::string strLabel, CPubKey pubKey) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet);
+bool ProcessPrivateKey(CWallet& wallet, std::string strLabel, CKey key) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet);
+bool ProcessAddress(CWallet &wallet, std::string strAddress, std::string strLabel, bool fP2SH) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet);
+}
+
+#endif // BITCOIN_WALLET_IMPORTS_H

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -20,6 +20,7 @@
 #include <util/ui_change_type.h>
 #include <wallet/coincontrol.h>
 #include <wallet/context.h>
+#include <wallet/imports.h>
 #include <wallet/feebumper.h>
 #include <wallet/fees.h>
 #include <wallet/types.h>
@@ -558,6 +559,62 @@ public:
 
     WalletContext& m_context;
     std::shared_ptr<CWallet> m_wallet;
+    interfaces::Chain& chain() override { return m_wallet->chain(); }
+    int64_t RescanFromTime(int64_t startTime, const WalletRescanReserver& reserver, bool update) override
+    {
+        return m_wallet->RescanFromTime(startTime, reserver, update);
+    }
+    void ResubmitWalletTransactions(bool relay, bool force) override {
+        return m_wallet->ResubmitWalletTransactions(relay, force);
+    }
+    bool IsAbortingRescan() override
+    {
+        return m_wallet->IsAbortingRescan();
+    }
+    WalletRescanReserver getReserver() override
+    {
+        WalletRescanReserver reserver(*m_wallet);
+        return reserver;
+    }
+    void ConnectScriptPubKeyManNotifiers() override
+    {
+        return m_wallet->ConnectScriptPubKeyManNotifiers();
+    }
+    uint256 GetLastBlockHash() override
+    {
+        LOCK(m_wallet->cs_wallet);
+        return m_wallet->GetLastBlockHash();
+    }
+    bool processDescriptorImport(const ImportDescriptorData& data, std::vector<std::string>& warnings, FlatSigningProvider& keys, bool range_exists, const int64_t timestamp) override
+    {
+        LOCK(m_wallet->cs_wallet);
+        return ProcessDescriptorImport(*m_wallet, data, warnings, keys, range_exists, timestamp);
+    }
+    bool processImport(const ImportMultiData& data, std::vector<std::string>& warnings, const int64_t timestamp) override
+    {
+        LOCK(m_wallet->cs_wallet);
+        return ProcessImport(*m_wallet, data, warnings, timestamp);
+    }
+    bool processPublicKey(std::string strLabel, CPubKey pubKey) override
+    {
+        LOCK(m_wallet->cs_wallet);
+        return ProcessPublicKey(*m_wallet, strLabel, pubKey);
+    }
+    bool processPrivateKey(std::string strLabel, CKey key) override
+    {
+        LOCK(m_wallet->cs_wallet);
+        return ProcessPrivateKey(*m_wallet, strLabel, key);
+    }
+    bool processAddress(std::string strAddress, std::string strLabel, bool fP2SH) override
+    {
+        LOCK(m_wallet->cs_wallet);
+        return ProcessAddress(*m_wallet, strAddress, strLabel, fP2SH);
+    }
+
+    int64_t GetKeypoolSize() override
+    {
+        return m_wallet->m_keypool_size;
+    }
 };
 
 class WalletLoaderImpl : public WalletLoader

--- a/src/wallet/rpc/backup.cpp
+++ b/src/wallet/rpc/backup.cpp
@@ -21,6 +21,8 @@
 #include <util/translation.h>
 #include <wallet/rpc/util.h>
 #include <wallet/wallet.h>
+#include <wallet/imports.h>
+
 
 #include <cstdint>
 #include <fstream>
@@ -152,56 +154,36 @@ RPCHelpMan importprivkey()
 
     WalletRescanReserver reserver(*pwallet);
     bool fRescan = true;
+
+    std::string strSecret = request.params[0].get_str();
+    const std::string strLabel{LabelFromValue(request.params[1])};
+
+    // Whether to perform rescan after import
+    if (!request.params[2].isNull())
+        fRescan = request.params[2].get_bool();
+
+    if (fRescan && pwallet->chain().havePruned()) {
+        // Exit early and print an error.
+        // If a block is pruned after this check, we will import the key(s),
+        // but fail the rescan with a generic error.
+        throw JSONRPCError(RPC_WALLET_ERROR, "Rescan is disabled when blocks are pruned");
+    }
+
+    if (fRescan && !reserver.reserve()) {
+        throw JSONRPCError(RPC_WALLET_ERROR, "Wallet is currently rescanning. Abort existing rescan or wait.");
+    }
+
+    CKey key = DecodeSecret(strSecret);
+    if (!key.IsValid()) throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid private key encoding");
+
     {
         LOCK(pwallet->cs_wallet);
-
         EnsureWalletIsUnlocked(*pwallet);
 
-        std::string strSecret = request.params[0].get_str();
-        const std::string strLabel{LabelFromValue(request.params[1])};
-
-        // Whether to perform rescan after import
-        if (!request.params[2].isNull())
-            fRescan = request.params[2].get_bool();
-
-        if (fRescan && pwallet->chain().havePruned()) {
-            // Exit early and print an error.
-            // If a block is pruned after this check, we will import the key(s),
-            // but fail the rescan with a generic error.
-            throw JSONRPCError(RPC_WALLET_ERROR, "Rescan is disabled when blocks are pruned");
-        }
-
-        if (fRescan && !reserver.reserve()) {
-            throw JSONRPCError(RPC_WALLET_ERROR, "Wallet is currently rescanning. Abort existing rescan or wait.");
-        }
-
-        CKey key = DecodeSecret(strSecret);
-        if (!key.IsValid()) throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid private key encoding");
-
-        CPubKey pubkey = key.GetPubKey();
-        CHECK_NONFATAL(key.VerifyPubKey(pubkey));
-        CKeyID vchAddress = pubkey.GetID();
-        {
-            pwallet->MarkDirty();
-
-            // We don't know which corresponding address will be used;
-            // label all new addresses, and label existing addresses if a
-            // label was passed.
-            for (const auto& dest : GetAllDestinationsForKey(pubkey)) {
-                if (!request.params[1].isNull() || !pwallet->FindAddressBookEntry(dest)) {
-                    pwallet->SetAddressBook(dest, strLabel, AddressPurpose::RECEIVE);
-                }
-            }
-
-            // Use timestamp of 1 to scan the whole chain
-            if (!pwallet->ImportPrivKeys({{vchAddress, key}}, 1)) {
-                throw JSONRPCError(RPC_WALLET_ERROR, "Error adding key to wallet");
-            }
-
-            // Add the wpkh script for this key if possible
-            if (pubkey.IsCompressed()) {
-                pwallet->ImportScripts({GetScriptForDestination(WitnessV0KeyHash(vchAddress))}, /*timestamp=*/0);
-            }
+        try {
+            ProcessPrivateKey(*pwallet, strLabel, key);
+        } catch (const WalletError& e) {
+            throw JSONRPCError(RPC_WALLET_ERROR, e.error);
         }
     }
     if (fRescan) {
@@ -273,35 +255,14 @@ RPCHelpMan importaddress()
     if (!request.params[3].isNull())
         fP2SH = request.params[3].get_bool();
 
+    std::string strAddress = request.params[0].get_str();
+
     {
         LOCK(pwallet->cs_wallet);
-
-        CTxDestination dest = DecodeDestination(request.params[0].get_str());
-        if (IsValidDestination(dest)) {
-            if (fP2SH) {
-                throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Cannot use the p2sh flag with an address - use a script instead");
-            }
-            if (OutputTypeFromDestination(dest) == OutputType::BECH32M) {
-                throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Bech32m addresses cannot be imported into legacy wallets");
-            }
-
-            pwallet->MarkDirty();
-
-            pwallet->ImportScriptPubKeys(strLabel, {GetScriptForDestination(dest)}, /*have_solving_data=*/false, /*apply_label=*/true, /*timestamp=*/1);
-        } else if (IsHex(request.params[0].get_str())) {
-            std::vector<unsigned char> data(ParseHex(request.params[0].get_str()));
-            CScript redeem_script(data.begin(), data.end());
-
-            std::set<CScript> scripts = {redeem_script};
-            pwallet->ImportScripts(scripts, /*timestamp=*/0);
-
-            if (fP2SH) {
-                scripts.insert(GetScriptForDestination(ScriptHash(redeem_script)));
-            }
-
-            pwallet->ImportScriptPubKeys(strLabel, scripts, /*have_solving_data=*/false, /*apply_label=*/true, /*timestamp=*/1);
-        } else {
-            throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid Bitcoin address or script");
+        try {
+            ProcessAddress(*pwallet, strAddress, strLabel, fP2SH);
+        } catch (const InvalidAddressOrKey& e) {
+            throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, e.error);
         }
     }
     if (fRescan)
@@ -469,17 +430,7 @@ RPCHelpMan importpubkey()
 
     {
         LOCK(pwallet->cs_wallet);
-
-        std::set<CScript> script_pub_keys;
-        for (const auto& dest : GetAllDestinationsForKey(pubKey)) {
-            script_pub_keys.insert(GetScriptForDestination(dest));
-        }
-
-        pwallet->MarkDirty();
-
-        pwallet->ImportScriptPubKeys(strLabel, script_pub_keys, /*have_solving_data=*/true, /*apply_label=*/true, /*timestamp=*/1);
-
-        pwallet->ImportPubKeys({pubKey.GetID()}, {{pubKey.GetID(), pubKey}} , /*key_origins=*/{}, /*add_keypool=*/false, /*internal=*/false, /*timestamp=*/1);
+        ProcessPublicKey(*pwallet, strLabel, pubKey);
     }
     if (fRescan)
     {
@@ -835,405 +786,6 @@ RPCHelpMan dumpwallet()
     };
 }
 
-struct ImportData
-{
-    // Input data
-    std::unique_ptr<CScript> redeemscript; //!< Provided redeemScript; will be moved to `import_scripts` if relevant.
-    std::unique_ptr<CScript> witnessscript; //!< Provided witnessScript; will be moved to `import_scripts` if relevant.
-
-    // Output data
-    std::set<CScript> import_scripts;
-    std::map<CKeyID, bool> used_keys; //!< Import these private keys if available (the value indicates whether if the key is required for solvability)
-    std::map<CKeyID, std::pair<CPubKey, KeyOriginInfo>> key_origins;
-};
-
-enum class ScriptContext
-{
-    TOP, //!< Top-level scriptPubKey
-    P2SH, //!< P2SH redeemScript
-    WITNESS_V0, //!< P2WSH witnessScript
-};
-
-// Analyse the provided scriptPubKey, determining which keys and which redeem scripts from the ImportData struct are needed to spend it, and mark them as used.
-// Returns an error string, or the empty string for success.
-static std::string RecurseImportData(const CScript& script, ImportData& import_data, const ScriptContext script_ctx)
-{
-    // Use Solver to obtain script type and parsed pubkeys or hashes:
-    std::vector<std::vector<unsigned char>> solverdata;
-    TxoutType script_type = Solver(script, solverdata);
-
-    switch (script_type) {
-    case TxoutType::PUBKEY: {
-        CPubKey pubkey(solverdata[0]);
-        import_data.used_keys.emplace(pubkey.GetID(), false);
-        return "";
-    }
-    case TxoutType::PUBKEYHASH: {
-        CKeyID id = CKeyID(uint160(solverdata[0]));
-        import_data.used_keys[id] = true;
-        return "";
-    }
-    case TxoutType::SCRIPTHASH: {
-        if (script_ctx == ScriptContext::P2SH) throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Trying to nest P2SH inside another P2SH");
-        if (script_ctx == ScriptContext::WITNESS_V0) throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Trying to nest P2SH inside a P2WSH");
-        CHECK_NONFATAL(script_ctx == ScriptContext::TOP);
-        CScriptID id = CScriptID(uint160(solverdata[0]));
-        auto subscript = std::move(import_data.redeemscript); // Remove redeemscript from import_data to check for superfluous script later.
-        if (!subscript) return "missing redeemscript";
-        if (CScriptID(*subscript) != id) return "redeemScript does not match the scriptPubKey";
-        import_data.import_scripts.emplace(*subscript);
-        return RecurseImportData(*subscript, import_data, ScriptContext::P2SH);
-    }
-    case TxoutType::MULTISIG: {
-        for (size_t i = 1; i + 1< solverdata.size(); ++i) {
-            CPubKey pubkey(solverdata[i]);
-            import_data.used_keys.emplace(pubkey.GetID(), false);
-        }
-        return "";
-    }
-    case TxoutType::WITNESS_V0_SCRIPTHASH: {
-        if (script_ctx == ScriptContext::WITNESS_V0) throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Trying to nest P2WSH inside another P2WSH");
-        CScriptID id{RIPEMD160(solverdata[0])};
-        auto subscript = std::move(import_data.witnessscript); // Remove redeemscript from import_data to check for superfluous script later.
-        if (!subscript) return "missing witnessscript";
-        if (CScriptID(*subscript) != id) return "witnessScript does not match the scriptPubKey or redeemScript";
-        if (script_ctx == ScriptContext::TOP) {
-            import_data.import_scripts.emplace(script); // Special rule for IsMine: native P2WSH requires the TOP script imported (see script/ismine.cpp)
-        }
-        import_data.import_scripts.emplace(*subscript);
-        return RecurseImportData(*subscript, import_data, ScriptContext::WITNESS_V0);
-    }
-    case TxoutType::WITNESS_V0_KEYHASH: {
-        if (script_ctx == ScriptContext::WITNESS_V0) throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Trying to nest P2WPKH inside P2WSH");
-        CKeyID id = CKeyID(uint160(solverdata[0]));
-        import_data.used_keys[id] = true;
-        if (script_ctx == ScriptContext::TOP) {
-            import_data.import_scripts.emplace(script); // Special rule for IsMine: native P2WPKH requires the TOP script imported (see script/ismine.cpp)
-        }
-        return "";
-    }
-    case TxoutType::NULL_DATA:
-        return "unspendable script";
-    case TxoutType::NONSTANDARD:
-    case TxoutType::WITNESS_UNKNOWN:
-    case TxoutType::WITNESS_V1_TAPROOT:
-        return "unrecognized script";
-    } // no default case, so the compiler can warn about missing cases
-    NONFATAL_UNREACHABLE();
-}
-
-static UniValue ProcessImportLegacy(ImportData& import_data, std::map<CKeyID, CPubKey>& pubkey_map, std::map<CKeyID, CKey>& privkey_map, std::set<CScript>& script_pub_keys, bool& have_solving_data, const UniValue& data, std::vector<CKeyID>& ordered_pubkeys)
-{
-    UniValue warnings(UniValue::VARR);
-
-    // First ensure scriptPubKey has either a script or JSON with "address" string
-    const UniValue& scriptPubKey = data["scriptPubKey"];
-    bool isScript = scriptPubKey.getType() == UniValue::VSTR;
-    if (!isScript && !(scriptPubKey.getType() == UniValue::VOBJ && scriptPubKey.exists("address"))) {
-        throw JSONRPCError(RPC_INVALID_PARAMETER, "scriptPubKey must be string with script or JSON with address string");
-    }
-    const std::string& output = isScript ? scriptPubKey.get_str() : scriptPubKey["address"].get_str();
-
-    // Optional fields.
-    const std::string& strRedeemScript = data.exists("redeemscript") ? data["redeemscript"].get_str() : "";
-    const std::string& witness_script_hex = data.exists("witnessscript") ? data["witnessscript"].get_str() : "";
-    const UniValue& pubKeys = data.exists("pubkeys") ? data["pubkeys"].get_array() : UniValue();
-    const UniValue& keys = data.exists("keys") ? data["keys"].get_array() : UniValue();
-    const bool internal = data.exists("internal") ? data["internal"].get_bool() : false;
-    const bool watchOnly = data.exists("watchonly") ? data["watchonly"].get_bool() : false;
-
-    if (data.exists("range")) {
-        throw JSONRPCError(RPC_INVALID_PARAMETER, "Range should not be specified for a non-descriptor import");
-    }
-
-    // Generate the script and destination for the scriptPubKey provided
-    CScript script;
-    if (!isScript) {
-        CTxDestination dest = DecodeDestination(output);
-        if (!IsValidDestination(dest)) {
-            throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid address \"" + output + "\"");
-        }
-        if (OutputTypeFromDestination(dest) == OutputType::BECH32M) {
-            throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Bech32m addresses cannot be imported into legacy wallets");
-        }
-        script = GetScriptForDestination(dest);
-    } else {
-        if (!IsHex(output)) {
-            throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid scriptPubKey \"" + output + "\"");
-        }
-        std::vector<unsigned char> vData(ParseHex(output));
-        script = CScript(vData.begin(), vData.end());
-        CTxDestination dest;
-        if (!ExtractDestination(script, dest) && !internal) {
-            throw JSONRPCError(RPC_INVALID_PARAMETER, "Internal must be set to true for nonstandard scriptPubKey imports.");
-        }
-    }
-    script_pub_keys.emplace(script);
-
-    // Parse all arguments
-    if (strRedeemScript.size()) {
-        if (!IsHex(strRedeemScript)) {
-            throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid redeem script \"" + strRedeemScript + "\": must be hex string");
-        }
-        auto parsed_redeemscript = ParseHex(strRedeemScript);
-        import_data.redeemscript = std::make_unique<CScript>(parsed_redeemscript.begin(), parsed_redeemscript.end());
-    }
-    if (witness_script_hex.size()) {
-        if (!IsHex(witness_script_hex)) {
-            throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid witness script \"" + witness_script_hex + "\": must be hex string");
-        }
-        auto parsed_witnessscript = ParseHex(witness_script_hex);
-        import_data.witnessscript = std::make_unique<CScript>(parsed_witnessscript.begin(), parsed_witnessscript.end());
-    }
-    for (size_t i = 0; i < pubKeys.size(); ++i) {
-        const auto& str = pubKeys[i].get_str();
-        if (!IsHex(str)) {
-            throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Pubkey \"" + str + "\" must be a hex string");
-        }
-        auto parsed_pubkey = ParseHex(str);
-        CPubKey pubkey(parsed_pubkey);
-        if (!pubkey.IsFullyValid()) {
-            throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Pubkey \"" + str + "\" is not a valid public key");
-        }
-        pubkey_map.emplace(pubkey.GetID(), pubkey);
-        ordered_pubkeys.push_back(pubkey.GetID());
-    }
-    for (size_t i = 0; i < keys.size(); ++i) {
-        const auto& str = keys[i].get_str();
-        CKey key = DecodeSecret(str);
-        if (!key.IsValid()) {
-            throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid private key encoding");
-        }
-        CPubKey pubkey = key.GetPubKey();
-        CKeyID id = pubkey.GetID();
-        if (pubkey_map.count(id)) {
-            pubkey_map.erase(id);
-        }
-        privkey_map.emplace(id, key);
-    }
-
-
-    // Verify and process input data
-    have_solving_data = import_data.redeemscript || import_data.witnessscript || pubkey_map.size() || privkey_map.size();
-    if (have_solving_data) {
-        // Match up data in import_data with the scriptPubKey in script.
-        auto error = RecurseImportData(script, import_data, ScriptContext::TOP);
-
-        // Verify whether the watchonly option corresponds to the availability of private keys.
-        bool spendable = std::all_of(import_data.used_keys.begin(), import_data.used_keys.end(), [&](const std::pair<CKeyID, bool>& used_key){ return privkey_map.count(used_key.first) > 0; });
-        if (!watchOnly && !spendable) {
-            warnings.push_back("Some private keys are missing, outputs will be considered watchonly. If this is intentional, specify the watchonly flag.");
-        }
-        if (watchOnly && spendable) {
-            warnings.push_back("All private keys are provided, outputs will be considered spendable. If this is intentional, do not specify the watchonly flag.");
-        }
-
-        // Check that all required keys for solvability are provided.
-        if (error.empty()) {
-            for (const auto& require_key : import_data.used_keys) {
-                if (!require_key.second) continue; // Not a required key
-                if (pubkey_map.count(require_key.first) == 0 && privkey_map.count(require_key.first) == 0) {
-                    error = "some required keys are missing";
-                }
-            }
-        }
-
-        if (!error.empty()) {
-            warnings.push_back("Importing as non-solvable: " + error + ". If this is intentional, don't provide any keys, pubkeys, witnessscript, or redeemscript.");
-            import_data = ImportData();
-            pubkey_map.clear();
-            privkey_map.clear();
-            have_solving_data = false;
-        } else {
-            // RecurseImportData() removes any relevant redeemscript/witnessscript from import_data, so we can use that to discover if a superfluous one was provided.
-            if (import_data.redeemscript) warnings.push_back("Ignoring redeemscript as this is not a P2SH script.");
-            if (import_data.witnessscript) warnings.push_back("Ignoring witnessscript as this is not a (P2SH-)P2WSH script.");
-            for (auto it = privkey_map.begin(); it != privkey_map.end(); ) {
-                auto oldit = it++;
-                if (import_data.used_keys.count(oldit->first) == 0) {
-                    warnings.push_back("Ignoring irrelevant private key.");
-                    privkey_map.erase(oldit);
-                }
-            }
-            for (auto it = pubkey_map.begin(); it != pubkey_map.end(); ) {
-                auto oldit = it++;
-                auto key_data_it = import_data.used_keys.find(oldit->first);
-                if (key_data_it == import_data.used_keys.end() || !key_data_it->second) {
-                    warnings.push_back("Ignoring public key \"" + HexStr(oldit->first) + "\" as it doesn't appear inside P2PKH or P2WPKH.");
-                    pubkey_map.erase(oldit);
-                }
-            }
-        }
-    }
-
-    return warnings;
-}
-
-static UniValue ProcessImportDescriptor(ImportData& import_data, std::map<CKeyID, CPubKey>& pubkey_map, std::map<CKeyID, CKey>& privkey_map, std::set<CScript>& script_pub_keys, bool& have_solving_data, const UniValue& data, std::vector<CKeyID>& ordered_pubkeys)
-{
-    UniValue warnings(UniValue::VARR);
-
-    const std::string& descriptor = data["desc"].get_str();
-    FlatSigningProvider keys;
-    std::string error;
-    auto parsed_desc = Parse(descriptor, keys, error, /* require_checksum = */ true);
-    if (!parsed_desc) {
-        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, error);
-    }
-    if (parsed_desc->GetOutputType() == OutputType::BECH32M) {
-        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Bech32m descriptors cannot be imported into legacy wallets");
-    }
-
-    have_solving_data = parsed_desc->IsSolvable();
-    const bool watch_only = data.exists("watchonly") ? data["watchonly"].get_bool() : false;
-
-    int64_t range_start = 0, range_end = 0;
-    if (!parsed_desc->IsRange() && data.exists("range")) {
-        throw JSONRPCError(RPC_INVALID_PARAMETER, "Range should not be specified for an un-ranged descriptor");
-    } else if (parsed_desc->IsRange()) {
-        if (!data.exists("range")) {
-            throw JSONRPCError(RPC_INVALID_PARAMETER, "Descriptor is ranged, please specify the range");
-        }
-        std::tie(range_start, range_end) = ParseDescriptorRange(data["range"]);
-    }
-
-    const UniValue& priv_keys = data.exists("keys") ? data["keys"].get_array() : UniValue();
-
-    // Expand all descriptors to get public keys and scripts, and private keys if available.
-    for (int i = range_start; i <= range_end; ++i) {
-        FlatSigningProvider out_keys;
-        std::vector<CScript> scripts_temp;
-        parsed_desc->Expand(i, keys, scripts_temp, out_keys);
-        std::copy(scripts_temp.begin(), scripts_temp.end(), std::inserter(script_pub_keys, script_pub_keys.end()));
-        for (const auto& key_pair : out_keys.pubkeys) {
-            ordered_pubkeys.push_back(key_pair.first);
-        }
-
-        for (const auto& x : out_keys.scripts) {
-            import_data.import_scripts.emplace(x.second);
-        }
-
-        parsed_desc->ExpandPrivate(i, keys, out_keys);
-
-        std::copy(out_keys.pubkeys.begin(), out_keys.pubkeys.end(), std::inserter(pubkey_map, pubkey_map.end()));
-        std::copy(out_keys.keys.begin(), out_keys.keys.end(), std::inserter(privkey_map, privkey_map.end()));
-        import_data.key_origins.insert(out_keys.origins.begin(), out_keys.origins.end());
-    }
-
-    for (size_t i = 0; i < priv_keys.size(); ++i) {
-        const auto& str = priv_keys[i].get_str();
-        CKey key = DecodeSecret(str);
-        if (!key.IsValid()) {
-            throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid private key encoding");
-        }
-        CPubKey pubkey = key.GetPubKey();
-        CKeyID id = pubkey.GetID();
-
-        // Check if this private key corresponds to a public key from the descriptor
-        if (!pubkey_map.count(id)) {
-            warnings.push_back("Ignoring irrelevant private key.");
-        } else {
-            privkey_map.emplace(id, key);
-        }
-    }
-
-    // Check if all the public keys have corresponding private keys in the import for spendability.
-    // This does not take into account threshold multisigs which could be spendable without all keys.
-    // Thus, threshold multisigs without all keys will be considered not spendable here, even if they are,
-    // perhaps triggering a false warning message. This is consistent with the current wallet IsMine check.
-    bool spendable = std::all_of(pubkey_map.begin(), pubkey_map.end(),
-        [&](const std::pair<CKeyID, CPubKey>& used_key) {
-            return privkey_map.count(used_key.first) > 0;
-        }) && std::all_of(import_data.key_origins.begin(), import_data.key_origins.end(),
-        [&](const std::pair<CKeyID, std::pair<CPubKey, KeyOriginInfo>>& entry) {
-            return privkey_map.count(entry.first) > 0;
-        });
-    if (!watch_only && !spendable) {
-        warnings.push_back("Some private keys are missing, outputs will be considered watchonly. If this is intentional, specify the watchonly flag.");
-    }
-    if (watch_only && spendable) {
-        warnings.push_back("All private keys are provided, outputs will be considered spendable. If this is intentional, do not specify the watchonly flag.");
-    }
-
-    return warnings;
-}
-
-static UniValue ProcessImport(CWallet& wallet, const UniValue& data, const int64_t timestamp) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet)
-{
-    UniValue warnings(UniValue::VARR);
-    UniValue result(UniValue::VOBJ);
-
-    try {
-        const bool internal = data.exists("internal") ? data["internal"].get_bool() : false;
-        // Internal addresses should not have a label
-        if (internal && data.exists("label")) {
-            throw JSONRPCError(RPC_INVALID_PARAMETER, "Internal addresses should not have a label");
-        }
-        const std::string label{LabelFromValue(data["label"])};
-        const bool add_keypool = data.exists("keypool") ? data["keypool"].get_bool() : false;
-
-        // Add to keypool only works with privkeys disabled
-        if (add_keypool && !wallet.IsWalletFlagSet(WALLET_FLAG_DISABLE_PRIVATE_KEYS)) {
-            throw JSONRPCError(RPC_INVALID_PARAMETER, "Keys can only be imported to the keypool when private keys are disabled");
-        }
-
-        ImportData import_data;
-        std::map<CKeyID, CPubKey> pubkey_map;
-        std::map<CKeyID, CKey> privkey_map;
-        std::set<CScript> script_pub_keys;
-        std::vector<CKeyID> ordered_pubkeys;
-        bool have_solving_data;
-
-        if (data.exists("scriptPubKey") && data.exists("desc")) {
-            throw JSONRPCError(RPC_INVALID_PARAMETER, "Both a descriptor and a scriptPubKey should not be provided.");
-        } else if (data.exists("scriptPubKey")) {
-            warnings = ProcessImportLegacy(import_data, pubkey_map, privkey_map, script_pub_keys, have_solving_data, data, ordered_pubkeys);
-        } else if (data.exists("desc")) {
-            warnings = ProcessImportDescriptor(import_data, pubkey_map, privkey_map, script_pub_keys, have_solving_data, data, ordered_pubkeys);
-        } else {
-            throw JSONRPCError(RPC_INVALID_PARAMETER, "Either a descriptor or scriptPubKey must be provided.");
-        }
-
-        // If private keys are disabled, abort if private keys are being imported
-        if (wallet.IsWalletFlagSet(WALLET_FLAG_DISABLE_PRIVATE_KEYS) && !privkey_map.empty()) {
-            throw JSONRPCError(RPC_WALLET_ERROR, "Cannot import private keys to a wallet with private keys disabled");
-        }
-
-        // Check whether we have any work to do
-        for (const CScript& script : script_pub_keys) {
-            if (wallet.IsMine(script) & ISMINE_SPENDABLE) {
-                throw JSONRPCError(RPC_WALLET_ERROR, "The wallet already contains the private key for this address or script (\"" + HexStr(script) + "\")");
-            }
-        }
-
-        // All good, time to import
-        wallet.MarkDirty();
-        if (!wallet.ImportScripts(import_data.import_scripts, timestamp)) {
-            throw JSONRPCError(RPC_WALLET_ERROR, "Error adding script to wallet");
-        }
-        if (!wallet.ImportPrivKeys(privkey_map, timestamp)) {
-            throw JSONRPCError(RPC_WALLET_ERROR, "Error adding key to wallet");
-        }
-        if (!wallet.ImportPubKeys(ordered_pubkeys, pubkey_map, import_data.key_origins, add_keypool, internal, timestamp)) {
-            throw JSONRPCError(RPC_WALLET_ERROR, "Error adding address to wallet");
-        }
-        if (!wallet.ImportScriptPubKeys(label, script_pub_keys, have_solving_data, !internal, timestamp)) {
-            throw JSONRPCError(RPC_WALLET_ERROR, "Error adding address to wallet");
-        }
-
-        result.pushKV("success", UniValue(true));
-    } catch (const UniValue& e) {
-        result.pushKV("success", UniValue(false));
-        result.pushKV("error", e);
-    } catch (...) {
-        result.pushKV("success", UniValue(false));
-
-        result.pushKV("error", JSONRPCError(RPC_MISC_ERROR, "Missing required fields"));
-    }
-    PushWarnings(warnings, result);
-    return result;
-}
-
 static int64_t GetImportTimestamp(const UniValue& data, int64_t now)
 {
     if (data.exists("timestamp")) {
@@ -1385,7 +937,93 @@ RPCHelpMan importmulti()
 
         for (const UniValue& data : requests.getValues()) {
             const int64_t timestamp = std::max(GetImportTimestamp(data, now), minimumTimestamp);
-            const UniValue result = ProcessImport(*pwallet, data, timestamp);
+            ImportMultiData multi_data;
+            std::vector<std::string> warnings;
+            UniValue result(UniValue::VOBJ);
+            try {
+                multi_data.internal = data.exists("internal") ? data["internal"].get_bool() : false;
+                // Internal addresses should not have a label
+                if (multi_data.internal && data.exists("label")) {
+                    throw InvalidParameter("Internal addresses should not have a label");
+                }
+                multi_data.label = LabelFromValue(data["label"]);
+                multi_data.keypool = data.exists("keypool") ? data["keypool"].get_bool() : false;
+                multi_data.watch_only = data.exists("watchonly") ? data["watchonly"].get_bool() : false;
+                if (data.exists("keys"))
+                    for (size_t i = 0; i < data["keys"].get_array().size(); ++i)
+                        multi_data.private_keys.push_back(data["keys"].get_array()[i].get_str());
+
+                if (data.exists("scriptPubKey") && data.exists("desc")) {
+                    throw InvalidParameter("Both a descriptor and a scriptPubKey should not be provided.");
+                } else if (data.exists("scriptPubKey")) {
+                    // First ensure scriptPubKey has either a script or JSON with "address" string
+                    const UniValue& scriptPubKey = data["scriptPubKey"];
+                    multi_data.isScript = scriptPubKey.getType() == UniValue::VSTR;
+                    if (!multi_data.isScript && !(scriptPubKey.getType() == UniValue::VOBJ && scriptPubKey.exists("address"))) {
+                        throw InvalidParameter("scriptPubKey must be string with script or JSON with address string");
+                    }
+                    multi_data.scriptPubKey = multi_data.isScript ? scriptPubKey.get_str() : scriptPubKey["address"].get_str();
+
+                    // Optional fields.
+                    multi_data.redeem_script = data.exists("redeemscript") ? data["redeemscript"].get_str() : "";
+                    multi_data.witness_script = data.exists("witnessscript") ? data["witnessscript"].get_str() : "";
+                    if (data.exists("pubkeys"))
+                        for (size_t i = 0; i < data["pubkeys"].get_array().size(); ++i)
+                            multi_data.public_keys.push_back(data["pubkeys"].get_array()[i].get_str());
+
+                    if (data.exists("range")) {
+                        throw InvalidParameter("Range should not be specified for a non-descriptor import");
+                    }
+                } else if (data.exists("desc")) {
+                    std::string error;
+                    multi_data.parsed_desc = Parse(data["desc"].get_str(), multi_data.keys, error, true);
+                    if (!multi_data.parsed_desc) {
+                        throw InvalidAddressOrKey(error);
+                    }
+                    if (multi_data.parsed_desc->GetOutputType() == OutputType::BECH32M) {
+                        throw InvalidAddressOrKey("Bech32m descriptors cannot be imported into legacy wallets");
+                    }
+
+                    if (!multi_data.parsed_desc->IsRange() && data.exists("range")) {
+                        throw InvalidParameter("Range should not be specified for an un-ranged descriptor");
+                    } else if (multi_data.parsed_desc->IsRange()) {
+                        if (!data.exists("range")) {
+                            throw InvalidParameter("Descriptor is ranged, please specify the range");
+                        }
+                        std::tie(multi_data.range_start, multi_data.range_end) = ParseDescriptorRange(data["range"]);
+                    }
+                } else {
+                    throw InvalidParameter("Either a descriptor or scriptPubKey must be provided.");
+                }
+
+                ProcessImport(*pwallet, multi_data, warnings, timestamp);
+                result.pushKV("success", UniValue(true));
+            } catch (const UniValue& e) {
+                result.pushKV("success", UniValue(false));
+                result.pushKV("error", e);
+            } catch (const MiscError& e) {
+                result.pushKV("success", UniValue(false));
+                result.pushKV("error", JSONRPCError(RPC_MISC_ERROR, e.error));
+            } catch (const WalletError& e) {
+                result.pushKV("success", UniValue(false));
+                result.pushKV("error", JSONRPCError(RPC_WALLET_ERROR, e.error));
+            } catch (const InvalidAddressOrKey& e) {
+                result.pushKV("success", UniValue(false));
+                result.pushKV("error", JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, e.error));
+            } catch (const InvalidParameter& e) {
+                result.pushKV("success", UniValue(false));
+                result.pushKV("error", JSONRPCError(RPC_INVALID_PARAMETER, e.error));
+            } catch (...) {
+                result.pushKV("success", UniValue(false));
+                result.pushKV("error", JSONRPCError(RPC_MISC_ERROR, "Missing required fields"));
+            }
+            if (warnings.size()) {
+                UniValue warning(UniValue::VARR);
+                for (const auto& w: warnings)
+                    warning.push_back(w);
+                PushWarnings(warning, result);
+            }
+
             response.push_back(result);
 
             if (!fRescan) {
@@ -1447,146 +1085,6 @@ RPCHelpMan importmulti()
     return response;
 },
     };
-}
-
-static UniValue ProcessDescriptorImport(CWallet& wallet, const UniValue& data, const int64_t timestamp) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet)
-{
-    UniValue warnings(UniValue::VARR);
-    UniValue result(UniValue::VOBJ);
-
-    try {
-        if (!data.exists("desc")) {
-            throw JSONRPCError(RPC_INVALID_PARAMETER, "Descriptor not found.");
-        }
-
-        const std::string& descriptor = data["desc"].get_str();
-        const bool active = data.exists("active") ? data["active"].get_bool() : false;
-        const bool internal = data.exists("internal") ? data["internal"].get_bool() : false;
-        const std::string label{LabelFromValue(data["label"])};
-
-        // Parse descriptor string
-        FlatSigningProvider keys;
-        std::string error;
-        auto parsed_desc = Parse(descriptor, keys, error, /* require_checksum = */ true);
-        if (!parsed_desc) {
-            throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, error);
-        }
-
-        // Range check
-        int64_t range_start = 0, range_end = 1, next_index = 0;
-        if (!parsed_desc->IsRange() && data.exists("range")) {
-            throw JSONRPCError(RPC_INVALID_PARAMETER, "Range should not be specified for an un-ranged descriptor");
-        } else if (parsed_desc->IsRange()) {
-            if (data.exists("range")) {
-                auto range = ParseDescriptorRange(data["range"]);
-                range_start = range.first;
-                range_end = range.second + 1; // Specified range end is inclusive, but we need range end as exclusive
-            } else {
-                warnings.push_back("Range not given, using default keypool range");
-                range_start = 0;
-                range_end = wallet.m_keypool_size;
-            }
-            next_index = range_start;
-
-            if (data.exists("next_index")) {
-                next_index = data["next_index"].getInt<int64_t>();
-                // bound checks
-                if (next_index < range_start || next_index >= range_end) {
-                    throw JSONRPCError(RPC_INVALID_PARAMETER, "next_index is out of range");
-                }
-            }
-        }
-
-        // Active descriptors must be ranged
-        if (active && !parsed_desc->IsRange()) {
-            throw JSONRPCError(RPC_INVALID_PARAMETER, "Active descriptors must be ranged");
-        }
-
-        // Ranged descriptors should not have a label
-        if (data.exists("range") && data.exists("label")) {
-            throw JSONRPCError(RPC_INVALID_PARAMETER, "Ranged descriptors should not have a label");
-        }
-
-        // Internal addresses should not have a label either
-        if (internal && data.exists("label")) {
-            throw JSONRPCError(RPC_INVALID_PARAMETER, "Internal addresses should not have a label");
-        }
-
-        // Combo descriptor check
-        if (active && !parsed_desc->IsSingleType()) {
-            throw JSONRPCError(RPC_WALLET_ERROR, "Combo descriptors cannot be set to active");
-        }
-
-        // If the wallet disabled private keys, abort if private keys exist
-        if (wallet.IsWalletFlagSet(WALLET_FLAG_DISABLE_PRIVATE_KEYS) && !keys.keys.empty()) {
-            throw JSONRPCError(RPC_WALLET_ERROR, "Cannot import private keys to a wallet with private keys disabled");
-        }
-
-        // Need to ExpandPrivate to check if private keys are available for all pubkeys
-        FlatSigningProvider expand_keys;
-        std::vector<CScript> scripts;
-        if (!parsed_desc->Expand(0, keys, scripts, expand_keys)) {
-            throw JSONRPCError(RPC_WALLET_ERROR, "Cannot expand descriptor. Probably because of hardened derivations without private keys provided");
-        }
-        parsed_desc->ExpandPrivate(0, keys, expand_keys);
-
-        // Check if all private keys are provided
-        bool have_all_privkeys = !expand_keys.keys.empty();
-        for (const auto& entry : expand_keys.origins) {
-            const CKeyID& key_id = entry.first;
-            CKey key;
-            if (!expand_keys.GetKey(key_id, key)) {
-                have_all_privkeys = false;
-                break;
-            }
-        }
-
-        // If private keys are enabled, check some things.
-        if (!wallet.IsWalletFlagSet(WALLET_FLAG_DISABLE_PRIVATE_KEYS)) {
-           if (keys.keys.empty()) {
-                throw JSONRPCError(RPC_WALLET_ERROR, "Cannot import descriptor without private keys to a wallet with private keys enabled");
-           }
-           if (!have_all_privkeys) {
-               warnings.push_back("Not all private keys provided. Some wallet functionality may return unexpected errors");
-           }
-        }
-
-        WalletDescriptor w_desc(std::move(parsed_desc), timestamp, range_start, range_end, next_index);
-
-        // Check if the wallet already contains the descriptor
-        auto existing_spk_manager = wallet.GetDescriptorScriptPubKeyMan(w_desc);
-        if (existing_spk_manager) {
-            if (!existing_spk_manager->CanUpdateToWalletDescriptor(w_desc, error)) {
-                throw JSONRPCError(RPC_INVALID_PARAMETER, error);
-            }
-        }
-
-        // Add descriptor to the wallet
-        auto spk_manager = wallet.AddWalletDescriptor(w_desc, keys, label, internal);
-        if (spk_manager == nullptr) {
-            throw JSONRPCError(RPC_WALLET_ERROR, strprintf("Could not add descriptor '%s'", descriptor));
-        }
-
-        // Set descriptor as active if necessary
-        if (active) {
-            if (!w_desc.descriptor->GetOutputType()) {
-                warnings.push_back("Unknown output type, cannot set descriptor to active.");
-            } else {
-                wallet.AddActiveScriptPubKeyMan(spk_manager->GetID(), *w_desc.descriptor->GetOutputType(), internal);
-            }
-        } else {
-            if (w_desc.descriptor->GetOutputType()) {
-                wallet.DeactivateScriptPubKeyMan(spk_manager->GetID(), *w_desc.descriptor->GetOutputType(), internal);
-            }
-        }
-
-        result.pushKV("success", UniValue(true));
-    } catch (const UniValue& e) {
-        result.pushKV("success", UniValue(false));
-        result.pushKV("error", e);
-    }
-    PushWarnings(warnings, result);
-    return result;
 }
 
 RPCHelpMan importdescriptors()
@@ -1681,7 +1179,78 @@ RPCHelpMan importdescriptors()
         for (const UniValue& request : requests.getValues()) {
             // This throws an error if "timestamp" doesn't exist
             const int64_t timestamp = std::max(GetImportTimestamp(request, now), minimum_timestamp);
-            const UniValue result = ProcessDescriptorImport(*pwallet, request, timestamp);
+            ImportDescriptorData descriptor_data;
+            std::vector<std::string> warnings;
+            UniValue result(UniValue::VOBJ);
+            try {
+                if (!request.exists("desc")) {
+                    throw InvalidParameter("Descriptor not found.");
+                }
+
+                descriptor_data.active = request.exists("active") ? request["active"].get_bool() : false;
+                descriptor_data.internal = request.exists("internal") ? request["internal"].get_bool() : false;
+                descriptor_data.label = LabelFromValue(request["label"]);
+
+                // Parse descriptor string
+                FlatSigningProvider keys;
+                std::string error;
+                descriptor_data.parsed_desc = Parse(request["desc"].get_str(), keys, error, /* require_checksum = */ true);
+                if (!descriptor_data.parsed_desc) {
+                    throw InvalidAddressOrKey(error);
+                }
+
+                // Range check
+                descriptor_data.range_start = 0, descriptor_data.range_end = 1, descriptor_data.next_index = 0;
+                if (!descriptor_data.parsed_desc->IsRange() && request.exists("range")) {
+                    throw InvalidParameter("Range should not be specified for an un-ranged descriptor");
+                } else if (descriptor_data.parsed_desc->IsRange()) {
+                    if (request.exists("range")) {
+                        auto range = ParseDescriptorRange(request["range"]);
+                        descriptor_data.range_start = range.first;
+                        descriptor_data.range_end = range.second + 1; // Specified range end is inclusive, but we need range end as exclusive
+                    } else {
+                        warnings.push_back("Range not given, using default keypool range");
+                        descriptor_data.range_start = 0;
+                        descriptor_data.range_end = wallet.m_keypool_size;
+                    }
+                    descriptor_data.next_index = descriptor_data.range_start;
+
+                    if (request.exists("next_index")) {
+                        descriptor_data.next_index = request["next_index"].getInt<int64_t>();
+                        // bound checks
+                        if (descriptor_data.next_index < descriptor_data.range_start || descriptor_data.next_index >= descriptor_data.range_end) {
+                            throw InvalidParameter("next_index is out of range");
+                        }
+                    }
+                }
+
+                bool range_exists = request.exists("range");
+                ProcessDescriptorImport(*pwallet, descriptor_data, warnings, keys, range_exists, timestamp);
+                result.pushKV("success", UniValue(true));
+            } catch (const UniValue& e) {
+                result.pushKV("success", UniValue(false));
+                result.pushKV("error", e);
+            } catch (const MiscError& e) {
+                result.pushKV("success", UniValue(false));
+                result.pushKV("error", JSONRPCError(RPC_MISC_ERROR, e.error));
+            } catch (const WalletError& e) {
+                result.pushKV("success", UniValue(false));
+                result.pushKV("error", JSONRPCError(RPC_WALLET_ERROR, e.error));
+            } catch (const InvalidAddressOrKey& e) {
+                result.pushKV("success", UniValue(false));
+                result.pushKV("error", JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, e.error));
+            } catch (const InvalidParameter& e) {
+                result.pushKV("success", UniValue(false));
+                result.pushKV("error", JSONRPCError(RPC_INVALID_PARAMETER, e.error));
+            }
+
+            if (warnings.size()) {
+                UniValue warning(UniValue::VARR);
+                for (const auto& w: warnings)
+                    warning.push_back(w);
+                PushWarnings(warning, result);
+            }
+
             response.push_back(result);
 
             if (lowest_timestamp > timestamp ) {


### PR DESCRIPTION
resolves #19 

This PR does a few things
- Refactors importmulti and importdescripters RPC code
- Adds functions to interfaces
- Adds GUI's for importpubkey, importprivkey, importaddress, importmulti, and importdescriptors RPCs
- Adds QT Tests for all 5 import GUI's

#### Things to get this merged
- [ ] get the refactor merge on https://github.com/bitcoin/bitcoin/pull/26840
- [ ] after that is done I will split the GUI PR into (importpubkey, importprivkey, importaddress), importmulti, importdescriptors each PR will have its respective tests. I will rebase to remove the commit for the refactor in those PR's it is in this PR so people can test. This is for easier code review

The dialogs are located under File -> Import to Wallet...
The options vary based on what is supported with your specific wallet type.

| Dialogs are Located  |  Import Public Key Dialog  |
|---|---|
| ![image](https://user-images.githubusercontent.com/31669092/183477017-0423b0db-f84c-4729-9a73-b47544d88aaf.png)  | ![image](https://user-images.githubusercontent.com/31669092/183477129-0c212955-bbf3-4bc9-8089-cf2c1da7644d.png)  |

| Import Private Key Dialog  | Import Address Dialog  |
|---|---|
|![image](https://user-images.githubusercontent.com/31669092/183477391-84ea6224-e7f5-4fba-a830-2e7fe3effcec.png)   |  ![image](https://user-images.githubusercontent.com/31669092/183477525-c3ba8cdc-ae0f-4113-8e0b-86db548f1e33.png) |

| Import Multi Dialog scriptPubKey Tab  | Import Multi Dialog Descriptor Tab  |
|---|---|
| ![image](https://user-images.githubusercontent.com/31669092/183477928-232be9c4-fd64-4a20-91ba-00ebe41d66a6.png)  | ![image](https://user-images.githubusercontent.com/31669092/183478127-0b3c8aed-54d9-4fb4-a583-0a6bb5a46d28.png)  |

|  Import Descriptors Dialog  |
|---|
|  ![image](https://user-images.githubusercontent.com/31669092/183478374-7f9c174d-0067-4812-9556-9e34e813b362.png) |

For Range before I had a lineedit with placeholders begin and end, @achow101 suggested I used QSpinBox, but it doesn't have placeholder text. So Currently if both are default value it counts as no input. It would look very nice if I implemented a custom QAbstractSpinBox with placeholder text, but I am not sure if it is overkill for this PR.