### PR TITLE
Prevent wrong handling of `%2` token by Transifex

### DIFF
--- a/src/qt/forms/intro.ui
+++ b/src/qt/forms/intro.ui
@@ -203,7 +203,7 @@
    <item>
     <widget class="QLabel" name="lblExplanation1">
      <property name="text">
-      <string>When you click OK, %1 will begin to download and process the full %4 block chain (%2GB) starting with the earliest transactions in %3 when %4 initially launched.</string>
+      <string>When you click OK, %1 will begin to download and process the full %4 block chain (%2 GB) starting with the earliest transactions in %3 when %4 initially launched.</string>
      </property>
      <property name="wordWrap">
       <bool>true</bool>


### PR DESCRIPTION
On master (124e75a41ea0f3f0e90b63b0c41813184ddce2ab), Transifex translation check fails for https://github.com/bitcoin-core/gui/blob/124e75a41ea0f3f0e90b63b0c41813184ddce2ab/src/qt/forms/intro.ui#L206 with a message:
> The expression '%2G' is not present in the translation.

In "Organization Settings" --> ["Translation checks"](https://www.transifex.com/bitcoin/settings/validations/) I have changed the status of the "**Variable substitution specifiers (like "%s") are preserved in the translations.**" check from "error" to "warning" temporarily. This setting should be reverted after applying this PR change.

[Noted](https://www.transifex.com/bitcoin/bitcoin/translate/#ru/qt-translation-024x/436102928/) by Transifex user [AHOHNMYC](https://www.transifex.com/user/profile/AHOHNMYC/).

I faced the same issue while working on Ukrainian translation.