### PR TITLE
Update peers window "Transaction Relay" label and tooltip

### DIFF
--- a/src/qt/forms/debugwindow.ui
+++ b/src/qt/forms/debugwindow.ui
@@ -1185,10 +1185,10 @@
                <item row="6" column="0">
                 <widget class="QLabel" name="peerRelayTxesLabel">
                  <property name="toolTip">
-                  <string>Whether the peer requested us to relay transactions.</string>
+                  <string>Whether we relay transactions to this peer (not available while the peer connection is being set up).</string>
                  </property>
                  <property name="text">
-                  <string>Wants Tx Relay</string>
+                  <string>Transaction Relay</string>
                  </property>
                 </widget>
                </item>


### PR DESCRIPTION
to current v24.0 p2p behavior.  Similar updates have been made to RPC getpeerinfo and CLI -netinfo.
