### PR TITLE
Bugfix: Address broken things around Peers detail view

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3224,6 +3224,10 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
         // Change version
         const int greatest_common_version = std::min(nVersion, PROTOCOL_VERSION);
         pfrom.SetCommonVersion(greatest_common_version);
+        {
+            LOCK(pfrom.m_subver_mutex);
+            pfrom.cleanSubVer = cleanSubVer;
+        }
         pfrom.nVersion = nVersion;
 
         const CNetMsgMaker msg_maker(greatest_common_version);
@@ -3246,10 +3250,6 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
         pfrom.m_has_all_wanted_services = HasAllDesirableServiceFlags(nServices);
         peer->m_their_services = nServices;
         pfrom.SetAddrLocal(addrMe);
-        {
-            LOCK(pfrom.m_subver_mutex);
-            pfrom.cleanSubVer = cleanSubVer;
-        }
         peer->m_starting_height = starting_height;
 
         // We only initialize the m_tx_relay data structure if:

--- a/src/qt/forms/debugwindow.ui
+++ b/src/qt/forms/debugwindow.ui
@@ -1034,7 +1034,7 @@
                 <height>426</height>
                </rect>
               </property>
-              <layout class="QGridLayout" name="gridLayout_2" columnstretch="0,1">
+              <layout class="QGridLayout" name="peerDetailsGrid" columnstretch="0,1">
                <item row="0" column="0">
                 <widget class="QLabel" name="label_30">
                  <property name="text">

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -1180,8 +1180,6 @@ void RPCConsole::updateDetailWidget()
     ui->timeoffset->setText(GUIUtil::formatTimeOffset(stats->nodeStats.nTimeOffset));
     if (stats->nodeStats.nVersion) {
         ui->peerVersion->setText(QString::number(stats->nodeStats.nVersion));
-    }
-    if (!stats->nodeStats.cleanSubVer.empty()) {
         ui->peerSubversion->setText(QString::fromStdString(stats->nodeStats.cleanSubVer));
     }
     ui->peerConnectionType->setText(GUIUtil::ConnectionTypeToQString(stats->nodeStats.m_conn_type, /*prepend_direction=*/true));

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -704,7 +704,10 @@ void RPCConsole::setClientModel(ClientModel *model, int bestblock_height, int64_
         connect(ui->peerWidget, &QTableView::customContextMenuRequested, this, &RPCConsole::showPeersTableContextMenu);
 
         // peer table signal handling - update peer details when selecting new node
-        connect(ui->peerWidget->selectionModel(), &QItemSelectionModel::selectionChanged, this, &RPCConsole::updateDetailWidget);
+        connect(ui->peerWidget->selectionModel(), &QItemSelectionModel::selectionChanged, [this] {
+            resetDetailWidget();
+            updateDetailWidget();
+        });
         connect(model->getPeerTableModel(), &QAbstractItemModel::dataChanged, [this] { updateDetailWidget(); });
 
         // set up ban table
@@ -1145,6 +1148,15 @@ void RPCConsole::updateTrafficStats(quint64 totalBytesIn, quint64 totalBytesOut)
 {
     ui->lblBytesIn->setText(GUIUtil::formatBytes(totalBytesIn));
     ui->lblBytesOut->setText(GUIUtil::formatBytes(totalBytesOut));
+}
+
+void RPCConsole::resetDetailWidget()
+{
+    for (int row = 0; QLayoutItem * const item = ui->peerDetailsGrid->itemAtPosition(row, 1); ++row) {
+        QLabel * const value_label = qobject_cast<QLabel*>(item->widget());
+        if (!value_label) continue;
+        value_label->setText(ts.na);
+    }
 }
 
 void RPCConsole::updateDetailWidget()

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -1197,7 +1197,7 @@ void RPCConsole::updateDetailWidget()
     ui->peerConnectionType->setText(GUIUtil::ConnectionTypeToQString(stats->nodeStats.m_conn_type, /*prepend_direction=*/true));
     ui->peerNetwork->setText(GUIUtil::NetworkToQString(stats->nodeStats.m_network));
     if (stats->nodeStats.m_permission_flags == NetPermissionFlags::None) {
-        ui->peerPermissions->setText(ts.na);
+        ui->peerPermissions->setText(ts.no_permissions);
     } else {
         QStringList permissions;
         for (const auto& permission : NetPermissions::ToStrings(stats->nodeStats.m_permission_flags)) {

--- a/src/qt/rpcconsole.h
+++ b/src/qt/rpcconsole.h
@@ -142,7 +142,7 @@ public Q_SLOTS:
 private:
     struct TranslatedStrings {
         const QString yes{tr("Yes")}, no{tr("No")}, to{tr("To")}, from{tr("From")},
-            ban_for{tr("Ban for")}, na{tr("N/A")}, unknown{tr("Unknown")};
+            ban_for{tr("Ban for")}, na{tr("N/A")}, unknown{tr("Unknown")}, no_permissions{tr("None")};
     } const ts;
 
     void startExecutor();

--- a/src/qt/rpcconsole.h
+++ b/src/qt/rpcconsole.h
@@ -105,6 +105,8 @@ private Q_SLOTS:
     void showOrHideBanTableIfRequired();
     /** clear the selected node */
     void clearSelectedNode();
+    /** reset all fields in UI detailed information to N/A */
+    void resetDetailWidget();
     /** show detailed information on ui about selected node */
     void updateDetailWidget();
 


### PR DESCRIPTION
* Ensure data for previously-selected peer doesn't remain when a new peer is selected (reset all fields to N/A before loading data for a new peer)
* Load user-agent along with peer version (so a blank UA actually shows as blank)
* Display actually having no permissions as "None" rather than "N/A"