### PR TITLE
Fix Transaction Relay tooltip text in Peers details window

### DIFF
--- a/src/qt/forms/debugwindow.ui
+++ b/src/qt/forms/debugwindow.ui
@@ -1185,7 +1185,7 @@
                <item row="6" column="0">
                 <widget class="QLabel" name="peerRelayTxesLabel">
                  <property name="toolTip">
-                  <string>Whether we relay transactions to this peer (not available while the peer connection is being set up).</string>
+                  <string>Whether we relay transactions to this peer.</string>
                  </property>
                  <property name="text">
                   <string>Transaction Relay</string>


### PR DESCRIPTION
as a value of N/A could occur due to a lock or a disconnection race but not during connection setup -- see https://github.com/bitcoin/bitcoin/pull/26457#pullrequestreview-1181641835.  Credit to Martin Zumsande for finding this. 
