### PR TITLE
clang-tidy: Fix `readability-redundant-string-init` in headers

### DIFF
--- a/src/qt/transactionrecord.h
+++ b/src/qt/transactionrecord.h
@@ -76,12 +76,12 @@ public:
     static const int RecommendedNumConfirmations = 6;
 
     TransactionRecord():
-            hash(), time(0), type(Other), address(""), debit(0), credit(0), idx(0)
+            hash(), time(0), type(Other), debit(0), credit(0), idx(0)
     {
     }
 
     TransactionRecord(uint256 _hash, qint64 _time):
-            hash(_hash), time(_time), type(Other), address(""), debit(0),
+            hash(_hash), time(_time), type(Other), debit(0),
             credit(0), idx(0)
     {
     }


### PR DESCRIPTION
Split from bitcoin/bitcoin#26705 as was requested in https://github.com/bitcoin/bitcoin/pull/26705#issuecomment-1353293405.

To test this PR, consider applying a diff as follows:
```diff
--- a/src/.clang-tidy
+++ b/src/.clang-tidy
@@ -12,17 +12,9 @@ readability-redundant-declaration,
 readability-redundant-string-init,
 '
 WarningsAsErrors: '
-bugprone-argument-comment,
-bugprone-use-after-move,
-misc-unused-using-decls,
-modernize-use-default-member-init,
-modernize-use-nullptr,
-performance-for-range-copy,
-performance-move-const-arg,
-performance-unnecessary-copy-initialization,
-readability-redundant-declaration,
 readability-redundant-string-init,
 '
 CheckOptions:
  - key: performance-move-const-arg.CheckTriviallyCopyableMove
    value: false
+HeaderFilterRegex: '.'
```