### PR TITLE
Load PSBTs using istreambuf_iterator rather than istream_iterator

### DIFF
--- a/src/qt/walletframe.cpp
+++ b/src/qt/walletframe.cpp
@@ -212,7 +212,7 @@ void WalletFrame::gotoLoadPSBT(bool from_clipboard)
             return;
         }
         std::ifstream in{filename.toLocal8Bit().data(), std::ios::binary};
-        data.assign(std::istream_iterator<unsigned char>{in}, {});
+        data.assign(std::istreambuf_iterator<char>{in}, {});
 
         // Some psbt files may be base64 strings in the file rather than binary data
         std::string b64_str{data.begin(), data.end()};


### PR DESCRIPTION
`istream_iterator` eats whitespace charactesr which causes parsing failures for PSBTs that contain the bytes corresponding to those characters. `istreambuf_iterator` is the correct thing to use here.

This is a regression in 24.0. https://github.com/bitcoin/bitcoin/pull/25001 accidentally changed the original `istreambuf_iterator` to `istream_iterator`.