### PR TITLE
gui: Show labels for multiple SendToSelf addresses

### DIFF
--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -18,6 +18,7 @@
 #include <core_io.h>
 #include <interfaces/handler.h>
 #include <uint256.h>
+#include <util/string.h>
 
 #include <algorithm>
 #include <functional>
@@ -424,8 +425,15 @@ QString TransactionTableModel::formatTxToAddress(const TransactionRecord *wtx, b
         return lookupAddress(wtx->address, tooltip) + watchAddress;
     case TransactionRecord::SendToOther:
         return QString::fromStdString(wtx->address) + watchAddress;
-    case TransactionRecord::SendToSelf:
-        return lookupAddress(wtx->address, tooltip) + watchAddress;
+    case TransactionRecord::SendToSelf: {
+        std::vector<std::string> addresses = SplitString(wtx->address, ',');
+        QString display_string;
+        for (auto it = addresses.begin(); it != addresses.end(); ++it) {
+            if (it != addresses.begin()) display_string += ", ";
+            display_string += lookupAddress(TrimString(*it), tooltip) + watchAddress;
+        }
+        return display_string;
+    }
     default:
         return tr("(n/a)") + watchAddress;
     }


### PR DESCRIPTION
Currently, the transaction table will display an address label for self-payments only if there's one recipient (ie - if you've sent your entire balance to one address you own).

This PR changes it to show labels for any addresses that have labels in the address book. It's a follow-up to https://github.com/bitcoin/bitcoin/pull/15098.

Before:

<img width="1523" alt="image" src="https://user-images.githubusercontent.com/116917595/213289483-816c2580-d9fc-4cda-9aae-6f1b212dd020.png">

After:

<img width="1521" alt="image" src="https://user-images.githubusercontent.com/116917595/213289838-b05d838d-745c-4d64-a874-ec31bd62ef99.png">

The addresses are [stored](https://github.com/bitcoin-core/gui/blob/8ae2808a4354e8dcc697f76bacc5e2f2befe9220/src/qt/transactionrecord.cpp#L96-L103) in `wtx->address` separated by `, `, so split the string and call `lookupAddress` for each one.

