### PR TITLE
Persist Mask Values option

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -647,6 +647,8 @@ void BitcoinGUI::setClientModel(ClientModel *_clientModel, interfaces::BlockAndH
             // initialize the disable state of the tray icon with the current value in the model.
             trayIcon->setVisible(optionsModel->getShowTrayIcon());
         }
+
+        m_mask_values_action->setChecked(_clientModel->getOptionsModel()->getOption(OptionsModel::OptionID::MaskValues).toBool());
     } else {
         if(trayIconMenu)
         {

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -227,6 +227,8 @@ bool OptionsModel::Init(bilingual_str& error)
     m_use_embedded_monospaced_font = settings.value("UseEmbeddedMonospacedFont").toBool();
     Q_EMIT useEmbeddedMonospacedFontChanged(m_use_embedded_monospaced_font);
 
+    m_mask_values = settings.value("mask_values", false).toBool();
+
     return true;
 }
 
@@ -435,6 +437,8 @@ QVariant OptionsModel::getOption(OptionID option) const
         return SettingToBool(setting(), DEFAULT_LISTEN);
     case Server:
         return SettingToBool(setting(), false);
+    case MaskValues:
+        return m_mask_values;
     default:
         return QVariant();
     }
@@ -611,6 +615,10 @@ bool OptionsModel::setOption(OptionID option, const QVariant& value)
             update(value.toBool());
             setRestartRequired(true);
         }
+        break;
+    case MaskValues:
+        m_mask_values = value.toBool();
+        settings.setValue("mask_values", m_mask_values);
         break;
     default:
         break;

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -72,6 +72,7 @@ public:
         Listen,                 // bool
         Server,                 // bool
         EnablePSBTControls,     // bool
+        MaskValues,             // bool
         OptionIDRowCount,
     };
 
@@ -120,6 +121,7 @@ private:
     bool fCoinControlFeatures;
     bool m_sub_fee_from_amount;
     bool m_enable_psbt_controls;
+    bool m_mask_values;
 
     //! In-memory settings for display. These are stored persistently by the
     //! bitcoin node but it's also nice to store them in memory to prevent them

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -173,6 +173,7 @@ void OverviewPage::handleTransactionClicked(const QModelIndex &index)
 void OverviewPage::setPrivacy(bool privacy)
 {
     m_privacy = privacy;
+    clientModel->getOptionsModel()->setOption(OptionsModel::OptionID::MaskValues, privacy);
     const auto& balances = walletModel->getCachedBalance();
     if (balances.balance != -1) {
         setBalance(balances);


### PR DESCRIPTION
The mask values option is memory only. If a user has enabled this option, it's reasonable to expect that they would want to have it enabled on the next start.