### PR TITLE
Use the stored CSubNet entry when unbanning

### DIFF
--- a/src/qt/bantablemodel.cpp
+++ b/src/qt/bantablemodel.cpp
@@ -43,7 +43,7 @@ public:
     /** Order (ascending or descending) to sort nodes by */
     Qt::SortOrder sortOrder;
 
-    /** Pull a full list of banned nodes from CNode into our cache */
+    /** Pull a full list of banned nodes from interfaces::Node into our cache */
     void refreshBanlist(interfaces::Node& node)
     {
         banmap_t banMap;

--- a/src/qt/bantablemodel.cpp
+++ b/src/qt/bantablemodel.cpp
@@ -178,3 +178,9 @@ bool BanTableModel::shouldShow()
 {
     return priv->size() > 0;
 }
+
+bool BanTableModel::unban(const QModelIndex& index)
+{
+    CCombinedBan* ban{static_cast<CCombinedBan*>(index.internalPointer())};
+    return ban != nullptr && m_node.unban(ban->subnet);
+}

--- a/src/qt/bantablemodel.h
+++ b/src/qt/bantablemodel.h
@@ -68,6 +68,8 @@ public:
 
     bool shouldShow();
 
+    bool unban(const QModelIndex& index);
+
 public Q_SLOTS:
     void refresh();
 

--- a/src/qt/bantablemodel.h
+++ b/src/qt/bantablemodel.h
@@ -37,7 +37,7 @@ private:
 };
 
 /**
-   Qt model providing information about connected peers, similar to the
+   Qt model providing information about banned peers, similar to the
    "getpeerinfo" RPC call. Used by the rpc console UI.
  */
 class BanTableModel : public QAbstractTableModel

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -11,7 +11,6 @@
 
 #include <chainparams.h>
 #include <interfaces/node.h>
-#include <netbase.h>
 #include <qt/bantablemodel.h>
 #include <qt/clientmodel.h>
 #include <qt/guiutil.h>
@@ -1308,17 +1307,13 @@ void RPCConsole::unbanSelectedNode()
 
     // Get selected ban addresses
     QList<QModelIndex> nodes = GUIUtil::getEntryData(ui->banlistWidget, BanTableModel::Address);
-    for(int i = 0; i < nodes.count(); i++)
-    {
-        // Get currently selected ban address
-        QString strNode = nodes.at(i).data().toString();
-        CSubNet possibleSubnet;
-
-        LookupSubNet(strNode.toStdString(), possibleSubnet);
-        if (possibleSubnet.IsValid() && m_node.unban(possibleSubnet))
-        {
-            clientModel->getBanTableModel()->refresh();
-        }
+    BanTableModel* ban_table_model{clientModel->getBanTableModel()};
+    bool unbanned{false};
+    for (const auto& node_index : nodes) {
+        unbanned |= ban_table_model->unban(node_index);
+    }
+    if (unbanned) {
+        ban_table_model->refresh();
     }
 }
 


### PR DESCRIPTION
The previous code visualized the `CSubNet` object as string, then parsed that string back to `CSubNet`. This is sub-optimal given that the original `CSubNet` object can be used directly instead.

This avoids calling `LookupSubNet()` from the GUI.
