### PR TITLE
wallet: Allow user to navigate options while encrypting at creation

### DIFF
--- a/src/qt/askpassphrasedialog.cpp
+++ b/src/qt/askpassphrasedialog.cpp
@@ -104,10 +104,14 @@ void AskPassphraseDialog::accept()
             // Cannot encrypt with empty passphrase
             break;
         }
-        QMessageBox::StandardButton retval = QMessageBox::question(this, tr("Confirm wallet encryption"),
-                 tr("Warning: If you encrypt your wallet and lose your passphrase, you will <b>LOSE ALL OF YOUR BITCOINS</b>!") + "<br><br>" + tr("Are you sure you wish to encrypt your wallet?"),
-                 QMessageBox::Yes|QMessageBox::Cancel,
-                 QMessageBox::Cancel);
+        QMessageBox msgBoxConfirm(QMessageBox::Question,
+                                  tr("Confirm wallet encryption"),
+                                  tr("Warning: If you encrypt your wallet and lose your passphrase, you will <b>LOSE ALL OF YOUR BITCOINS</b>!") + "<br><br>" + tr("Are you sure you wish to encrypt your wallet?"),
+                                  QMessageBox::Cancel | QMessageBox::Yes, this);
+        msgBoxConfirm.button(QMessageBox::Yes)->setText(tr("Continue"));
+        msgBoxConfirm.button(QMessageBox::Cancel)->setText(tr("Back"));
+        msgBoxConfirm.setDefaultButton(QMessageBox::Cancel);
+        QMessageBox::StandardButton retval = (QMessageBox::StandardButton)msgBoxConfirm.exec();
         if(retval == QMessageBox::Yes)
         {
             if(newpass1 == newpass2)
@@ -116,10 +120,19 @@ void AskPassphraseDialog::accept()
                 "your bitcoins from being stolen by malware infecting your computer.");
                 if (m_passphrase_out) {
                     m_passphrase_out->assign(newpass1);
-                    QMessageBox::warning(this, tr("Wallet to be encrypted"),
-                                         "<qt>" +
-                                         tr("Your wallet is about to be encrypted. ") + encryption_reminder +
-                                         "</b></qt>");
+                    QMessageBox msgBoxWarning(QMessageBox::Warning,
+                                              tr("Wallet to be encrypted"),
+                                              "<qt>" +
+                                                  tr("Your wallet is about to be encrypted. ") + encryption_reminder + " " +
+                                                  tr("Are you sure you wish to encrypt your wallet?") +
+                                                  "</b></qt>",
+                                              QMessageBox::Cancel | QMessageBox::Yes, this);
+                    msgBoxWarning.setDefaultButton(QMessageBox::Cancel);
+                    QMessageBox::StandardButton retval = (QMessageBox::StandardButton)msgBoxWarning.exec();
+                    if (retval == QMessageBox::Cancel) {
+                        QDialog::reject();
+                        return;
+                    }
                 } else {
                     assert(model != nullptr);
                     if (model->setWalletEncrypted(newpass1)) {
@@ -145,11 +158,7 @@ void AskPassphraseDialog::accept()
                                      tr("The supplied passphrases do not match."));
             }
         }
-        else
-        {
-            QDialog::reject(); // Cancelled
-        }
-        } break;
+    } break;
     case Unlock:
         try {
             if (!model->setWalletLocked(false, oldpass)) {


### PR DESCRIPTION
This fixes https://github.com/bitcoin-core/gui/issues/394. 
It adds a  "Go back" button to the "Confirm wallet encryption" window, allowing the users to change the password if they want to. It also adds a Cancel button to the "Wallet to be encrypted" window.
Prior to this change users had no option to alter the password, and were forced to either go ahead with wallet creation or cancel the whole process. Also, at the final window, they were shown a warning but with no option to cancel.
The new workflow for wallet encryption and creation is similar to the following:

![videoNavigation](https://user-images.githubusercontent.com/87907936/225705434-22d3c678-fa01-4079-ba10-ca5a0e8d3922.gif)
