### PR TITLE
test: Add missed header

### DIFF
--- a/src/qt/test/util.cpp
+++ b/src/qt/test/util.cpp
@@ -2,6 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <qt/test/util.h>
+
 #include <chrono>
 
 #include <QApplication>

--- a/src/qt/test/util.h
+++ b/src/qt/test/util.h
@@ -7,6 +7,8 @@
 
 #include <chrono>
 
+#include <qglobal.h>
+
 QT_BEGIN_NAMESPACE
 class QString;
 QT_END_NAMESPACE


### PR DESCRIPTION
Should fix MSVC link errors like [that](https://api.cirrus-ci.com/v1/task/4870882892447744/logs/build.log):
```
addressbooktests.obj : error LNK2019: unresolved external symbol "void __cdecl ConfirmMessage(class QString *,class std::chrono::duration<__int64,struct std::ratio<1,1000> >)" (?ConfirmMessage@@YAXPEAVQString@@V?$duration@_JU?$ratio@$00$0DOI@@std@@@chrono@std@@@Z) referenced in function "void __cdecl `anonymous namespace'::EditAddressAndSubmit(class EditAddressDialog *,class QString const &,class QString const &,class QString)" (?EditAddressAndSubmit@?A0x2e52698e@@YAXPEAVEditAddressDialog@@AEBVQString@@1V3@@Z) [C:\Users\ContainerAdministrator\AppData\Local\Temp\cirrus-ci-build\build_msvc\test_bitcoin-qt\test_bitcoin-qt.vcxproj]
wallettests.obj : error LNK2001: unresolved external symbol "void __cdecl ConfirmMessage(class QString *,class std::chrono::duration<__int64,struct std::ratio<1,1000> >)" (?ConfirmMessage@@YAXPEAVQString@@V?$duration@_JU?$ratio@$00$0DOI@@std@@@chrono@std@@@Z) [C:\Users\ContainerAdministrator\AppData\Local\Temp\cirrus-ci-build\build_msvc\test_bitcoin-qt\test_bitcoin-qt.vcxproj]
C:\Users\ContainerAdministrator\AppData\Local\Temp\cirrus-ci-build\build_msvc\x64\Release\test_bitcoin-qt.exe : fatal error LNK1120: 1 unresolved externals [C:\Users\ContainerAdministrator\AppData\Local\Temp\cirrus-ci-build\build_msvc\test_bitcoin-qt\test_bitcoin-qt.vcxproj]
```