### PR TITLE
Drop macOS ForceActivation workaround

### DIFF
--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -80,7 +80,6 @@
 
 #include <QProcess>
 
-void ForceActivation();
 #endif
 
 using namespace std::chrono_literals;
@@ -400,10 +399,6 @@ bool isObscured(QWidget *w)
 
 void bringToFront(QWidget* w)
 {
-#ifdef Q_OS_MACOS
-    ForceActivation();
-#endif
-
     if (w) {
         // activateWindow() (sometimes) helps with keyboard focus on Windows
         if (w->isMinimized()) {

--- a/src/qt/macdockiconhandler.mm
+++ b/src/qt/macdockiconhandler.mm
@@ -41,13 +41,3 @@ void MacDockIconHandler::cleanup()
 {
     delete s_instance;
 }
-
-/**
- * Force application activation on macOS. With Qt 5.5.1 this is required when
- * an action in the Dock menu is triggered.
- * TODO: Define a Qt version where it's no-longer necessary.
- */
-void ForceActivation()
-{
-    [[NSApplication sharedApplication] activateIgnoringOtherApps:YES];
-}


### PR DESCRIPTION
Discussion in https://github.com/bitcoin/bitcoin/pull/16720 seems to point to this being no-longer needed after qt 5.6+. 
We now require 5.11.x+.