### PR TITLE
Add new "address type" column to the "receiving tab" address book page

### DIFF
--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -101,6 +101,9 @@ public:
     //! Get public key.
     virtual bool getPubKey(const CScript& script, const CKeyID& address, CPubKey& pub_key) = 0;
 
+    //! Get Output type from a Destination.
+    virtual OutputType getOutputType(const CTxDestination& dest) = 0;
+
     //! Sign message
     virtual SigningResult signMessage(const std::string& message, const PKHash& pkhash, std::string& str_sig) = 0;
 

--- a/src/qt/addressbookpage.h
+++ b/src/qt/addressbookpage.h
@@ -5,6 +5,8 @@
 #ifndef BITCOIN_QT_ADDRESSBOOKPAGE_H
 #define BITCOIN_QT_ADDRESSBOOKPAGE_H
 
+#include <outputtype.h>
+
 #include <QDialog>
 
 class AddressBookSortFilterProxyModel;
@@ -57,6 +59,13 @@ private:
     QMenu *contextMenu;
     QString newAddressToSelect;
     void updateWindowsTitleWithWalletName();
+    void initializeAddressTypeCombo();
+    /** Default selected item of the address type combo to display all address types */
+    QString showAllTypes() const;
+    QString showAllTypesToolTip() const;
+    /** Tooltip for each address type that will be displayed on the combo*/
+    std::map<OutputType, QString> addressTypeTooltipMap();
+    void setupAddressTypeCombo();
 
 private Q_SLOTS:
     /** Delete currently selected address entry */
@@ -78,9 +87,16 @@ private Q_SLOTS:
     void contextualMenu(const QPoint &point);
     /** New entry/entries were added to address table */
     void selectNewAddress(const QModelIndex &parent, int begin, int /*end*/);
+    /** Address type combo selection changed */
+    void handleAddressTypeChanged(int index);
 
 Q_SIGNALS:
     void sendCoins(QString addr);
+    /** Emitted when the addressType combobox is changed (handled by handleAddressTypeChange).
+     * This signal is used as a workaround to connect the combobox and the proxy model filter,
+     * preventing the compiler error "Signal and slot arguments are not compatible."*/
+    void addressTypeChanged(const QString &addressType);
+
 };
 
 #endif // BITCOIN_QT_ADDRESSBOOKPAGE_H

--- a/src/qt/addressbookpage.h
+++ b/src/qt/addressbookpage.h
@@ -53,7 +53,7 @@ private:
     Mode mode;
     Tabs tab;
     QString returnValue;
-    AddressBookSortFilterProxyModel *proxyModel;
+    std::unique_ptr<AddressBookSortFilterProxyModel> proxyModel{nullptr};
     QMenu *contextMenu;
     QString newAddressToSelect;
     void updateWindowsTitleWithWalletName();

--- a/src/qt/addresstablemodel.h
+++ b/src/qt/addresstablemodel.h
@@ -35,7 +35,8 @@ public:
 
     enum ColumnIndex {
         Label = 0,   /**< User specified label */
-        Address = 1  /**< Bitcoin address */
+        Type = 1,    /**< Address type */
+        Address = 2  /**< Bitcoin address */
     };
 
     enum RoleIndex {
@@ -104,8 +105,7 @@ private:
 public Q_SLOTS:
     /* Update address list from core.
      */
-    void updateEntry(const QString &address, const QString &label, bool isMine, wallet::AddressPurpose purpose, int status);
-
+    void updateEntry(const QString &address, const QString &label, bool isMine, wallet::AddressPurpose purpose, int status, const OutputType &address_type);
     friend class AddressTablePriv;
 };
 

--- a/src/qt/forms/addressbookpage.ui
+++ b/src/qt/forms/addressbookpage.ui
@@ -110,6 +110,16 @@
       </widget>
      </item>
      <item>
+      <widget class="QLabel" name="labelAddressType">
+       <property name="text">
+        <string>Show address type:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="addressType"/>
+     </item>
+     <item>
       <spacer name="horizontalSpacer">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -8,6 +8,7 @@
 #include <consensus/amount.h>
 #include <net.h>
 #include <netaddress.h>
+#include <outputtype.h>
 #include <util/check.h>
 #include <util/fs.h>
 
@@ -40,6 +41,7 @@ QT_BEGIN_NAMESPACE
 class QAbstractButton;
 class QAbstractItemView;
 class QAction;
+class QComboBox;
 class QDateTime;
 class QDialog;
 class QFont;
@@ -439,6 +441,13 @@ namespace GUIUtil
     QString WalletDisplayName(const std::string& name);
     QString WalletDisplayName(const QString& name);
 
+    struct OutputTypeInfo {
+        const QString description;
+        const bool requiresTaprootEnabled;
+    };
+    std::map<OutputType, OutputTypeInfo> outputTypeDescriptionsMap();
+
+    void AddItemsToAddressTypeCombo(QComboBox* addressType, bool taprootEnabled, const std::map<OutputType, QString>& outputTypeTooltipsMap, std::optional<OutputType> defaultType = std::nullopt);
 } // namespace GUIUtil
 
 #endif // BITCOIN_QT_GUIUTIL_H

--- a/src/qt/receivecoinsdialog.cpp
+++ b/src/qt/receivecoinsdialog.cpp
@@ -86,19 +86,15 @@ void ReceiveCoinsDialog::setModel(WalletModel *_model)
             &QItemSelectionModel::selectionChanged, this,
             &ReceiveCoinsDialog::recentRequestsView_selectionChanged);
 
+        /** Tooltip for each address type that will be displayed on the combo*/
+        std::map<OutputType, QString> addressTypeTooltipMap{
+            {OutputType::LEGACY, QObject::tr("Not recommended due to higher fees and less protection against typos.")},
+            {OutputType::P2SH_SEGWIT, QObject::tr("Generates an address compatible with older wallets.")},
+            {OutputType::BECH32, QObject::tr("Generates a native segwit address (BIP-173). Some old wallets don't support it.")},
+            {OutputType::BECH32M, QObject::tr("Bech32m (BIP-350) is an upgrade to Bech32, wallet support is still limited.")}};
+
         // Populate address type dropdown and select default
-        auto add_address_type = [&](OutputType type, const QString& text, const QString& tooltip) {
-            const auto index = ui->addressType->count();
-            ui->addressType->addItem(text, (int) type);
-            ui->addressType->setItemData(index, tooltip, Qt::ToolTipRole);
-            if (model->wallet().getDefaultAddressType() == type) ui->addressType->setCurrentIndex(index);
-        };
-        add_address_type(OutputType::LEGACY, tr("Base58 (Legacy)"), tr("Not recommended due to higher fees and less protection against typos."));
-        add_address_type(OutputType::P2SH_SEGWIT, tr("Base58 (P2SH-SegWit)"), tr("Generates an address compatible with older wallets."));
-        add_address_type(OutputType::BECH32, tr("Bech32 (SegWit)"), tr("Generates a native segwit address (BIP-173). Some old wallets don't support it."));
-        if (model->wallet().taprootEnabled()) {
-            add_address_type(OutputType::BECH32M, tr("Bech32m (Taproot)"), tr("Bech32m (BIP-350) is an upgrade to Bech32, wallet support is still limited."));
-        }
+        GUIUtil::AddItemsToAddressTypeCombo(ui->addressType, model->wallet().taprootEnabled(), addressTypeTooltipMap, model->wallet().getDefaultAddressType());
 
         // Set the button to be enabled or disabled based on whether the wallet can give out new addresses.
         ui->receiveButton->setEnabled(model->wallet().canGetAddresses());

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -137,8 +137,10 @@ void WalletModel::updateTransaction()
 void WalletModel::updateAddressBook(const QString &address, const QString &label,
         bool isMine, wallet::AddressPurpose purpose, int status)
 {
-    if(addressTableModel)
-        addressTableModel->updateEntry(address, label, isMine, purpose, status);
+    if (addressTableModel) {
+        CTxDestination destination = DecodeDestination(address.toStdString());
+        addressTableModel->updateEntry(address, label, isMine, purpose, status, m_wallet->getOutputType(destination));
+    }
 }
 
 void WalletModel::updateWatchOnlyFlag(bool fHaveWatchonly)

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -166,6 +166,13 @@ public:
         }
         return false;
     }
+    OutputType getOutputType(const CTxDestination& dest) override
+    {
+        CScript script = GetScriptForDestination(dest);
+        std::unique_ptr<SigningProvider> provider = m_wallet->GetSolvingProvider(script);
+        std::unique_ptr<Descriptor> desc = provider ? InferDescriptor(script, *provider) : InferDescriptor(script, FlatSigningProvider());
+        return desc->GetOutputType().value_or(OutputType::UNKNOWN);
+    }
     SigningResult signMessage(const std::string& message, const PKHash& pkhash, std::string& str_sig) override
     {
         return m_wallet->SignMessage(message, pkhash, str_sig);


### PR DESCRIPTION
This PR fixes #646 and introduces some enhancements to the Address Book functionality.

A new "Address Type" column has been added to the address book table page, only visible for the "Receiving address" tab. Users can employ an also new added combo box at the bottom of the page to filter address by their type, this filtering can be combined with the current search line text box.
When the export feature is used, this new field will be included.

![Peek 2023-09-10 19-25](https://github.com/bitcoin-core/gui/assets/110166421/24c674a2-417e-4309-8fb3-8c099a562cc1)

As highlighted with the performed manual testing shown in the image above:
- address type combo box has been reused from receive coins dialog, but each widget container can specify different tool-tips for their items;
- "Sending address" tab doesn't display the new column, combo box or its label, and the search text specify only the fields to be filtered out;
-  "Receiving address" tab display the new added widgets, filter works fine in combination of either text, combo item selection or combination of both, tool-tip texts differs from the ones on the receive coins dialog where the address can be created specifying their types.

Tested in `mainnet` and all test networks.

For code reviewers, please check the commit messages for a detailed breakdown.
