### PR TITLE
Update Node window title with the chain type

### DIFF
--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -571,6 +571,8 @@ RPCConsole::RPCConsole(interfaces::Node& node, const PlatformStyle *_platformSty
     clear();
 
     GUIUtil::handleCloseWindowShortcut(this);
+
+    updateWindowTitle();
 }
 
 RPCConsole::~RPCConsole()
@@ -1367,4 +1369,14 @@ void RPCConsole::updateAlerts(const QString& warnings)
 {
     this->ui->label_alerts->setVisible(!warnings.isEmpty());
     this->ui->label_alerts->setText(warnings);
+}
+
+void RPCConsole::updateWindowTitle()
+{
+    const ChainType chain = Params().GetChainType();
+    if (chain == ChainType::MAIN) return;
+
+    const QString chainType = QString::fromStdString(Params().GetChainTypeString());
+    const QString title = tr("Node window - [%1]").arg(chainType);
+    this->setWindowTitle(title);
 }

--- a/src/qt/rpcconsole.h
+++ b/src/qt/rpcconsole.h
@@ -189,6 +189,8 @@ private:
         return time_at_event.count() ? GUIUtil::formatDurationStr(time_now - time_at_event) : tr("Never");
     }
 
+    void updateWindowTitle();
+
 private Q_SLOTS:
     void updateAlerts(const QString& warnings);
 };


### PR DESCRIPTION
It fixes #544.

Enhance the Node window title by appending the chain type to it, except for the `mainnet`, mirroring the behavior in the main window.

![image](https://github.com/bitcoin-core/gui/assets/110166421/6b81675c-6e53-411f-9ea7-921e74cd2359)

There was also some [interest](https://github.com/bitcoin-core/gui/issues/78#issuecomment-695755972) on this while discussing network switching.