### PR TITLE
Update about logo icon (colour) to denote the chain type of the QT instance in About/ Help Message Window/ Dialog

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -260,7 +260,7 @@ bool BitcoinApplication::createOptionsModel(bool resetSettings)
             error.translated += tr("Settings file %1 might be corrupt or invalid.").arg(QString::fromStdString(quoted_path)).toStdString();
         }
         InitError(error);
-        QMessageBox::critical(nullptr, CLIENT_NAME, QString::fromStdString(error.translated));
+        GUIUtil::ShowMessageBox(QString::fromStdString(error.translated), static_cast<QMessageBox::Icon>(QMessageBox::Critical));
         return false;
     }
     return true;
@@ -440,21 +440,25 @@ void BitcoinApplication::initializeResult(bool success, interfaces::BlockAndHead
 
 void BitcoinApplication::handleRunawayException(const QString &message)
 {
-    QMessageBox::critical(
-        nullptr, tr("Runaway exception"),
-        tr("A fatal error occurred. %1 can no longer continue safely and will quit.").arg(CLIENT_NAME) +
-        QLatin1String("<br><br>") + GUIUtil::MakeHtmlLink(message, CLIENT_BUGREPORT));
+    const QString qMessage = tr("A fatal error occurred. %1 can no longer continue safely and will quit.").arg(CLIENT_NAME) +
+                QLatin1String("<br><br>") + GUIUtil::MakeHtmlLink(message, CLIENT_BUGREPORT);
+    GUIUtil::ShowMessageBox(/*message=*/qMessage,
+                /*box_icon=*/static_cast<QMessageBox::Icon>(QMessageBox::Critical),
+                /*network_style=*/nullptr,
+                /*title=*/tr("Runaway exception"));
     ::exit(EXIT_FAILURE);
 }
 
 void BitcoinApplication::handleNonFatalException(const QString& message)
 {
     assert(QThread::currentThread() == thread());
-    QMessageBox::warning(
-        nullptr, tr("Internal error"),
-        tr("An internal error occurred. %1 will attempt to continue safely. This is "
-           "an unexpected bug which can be reported as described below.").arg(CLIENT_NAME) +
-        QLatin1String("<br><br>") + GUIUtil::MakeHtmlLink(message, CLIENT_BUGREPORT));
+    const QString qMessage = tr("An internal error occurred. %1 will attempt to continue safely. This is "
+                "an unexpected bug which can be reported as described below.").arg(CLIENT_NAME) +
+                QLatin1String("<br><br>") + GUIUtil::MakeHtmlLink(message, CLIENT_BUGREPORT);
+    GUIUtil::ShowMessageBox(/*message=*/qMessage,
+                /*box_icon=*/static_cast<QMessageBox::Icon>(QMessageBox::Warning),
+                /*network_style=*/nullptr,
+                /*title=*/tr("Internal error"));
 }
 
 WId BitcoinApplication::getMainWinId() const
@@ -529,11 +533,11 @@ int GuiMain(int argc, char* argv[])
     SetupUIArgs(gArgs);
     std::string error;
     if (!gArgs.ParseParameters(argc, argv, error)) {
-        InitError(Untranslated(strprintf("Error parsing command line arguments: %s", error)));
+        const std::string message = tfm::format("Error parsing command line arguments: %s", error);
+        // message cannot be translated because translations have not been initialized
+        InitError(Untranslated(message));
         // Create a message box, because the gui has neither been created nor has subscribed to core signals
-        QMessageBox::critical(nullptr, CLIENT_NAME,
-            // message cannot be translated because translations have not been initialized
-            QString::fromStdString("Error parsing command line arguments: %1.").arg(QString::fromStdString(error)));
+        GUIUtil::ShowMessageBox(QString::fromStdString(message), static_cast<QMessageBox::Icon>(QMessageBox::Critical));
         return EXIT_FAILURE;
     }
 
@@ -550,17 +554,17 @@ int GuiMain(int argc, char* argv[])
         }
 #endif
         if (payment_server_token_seen && arg.startsWith("-")) {
-            InitError(Untranslated(strprintf("Options ('%s') cannot follow a BIP-21 payment URI", argv[i])));
-            QMessageBox::critical(nullptr, CLIENT_NAME,
-                                  // message cannot be translated because translations have not been initialized
-                                  QString::fromStdString("Options ('%1') cannot follow a BIP-21 payment URI").arg(QString::fromStdString(argv[i])));
+            const std::string message = tfm::format("Options ('%s') cannot follow a BIP-21 payment URI", argv[i]);
+            // message cannot be translated because translations have not been initialized
+            InitError(Untranslated(message));
+            GUIUtil::ShowMessageBox(QString::fromStdString(message), static_cast<QMessageBox::Icon>(QMessageBox::Critical));
             return EXIT_FAILURE;
         }
         if (invalid_token) {
-            InitError(Untranslated(strprintf("Command line contains unexpected token '%s', see bitcoin-qt -h for a list of options.", argv[i])));
-            QMessageBox::critical(nullptr, CLIENT_NAME,
-                                  // message cannot be translated because translations have not been initialized
-                                  QString::fromStdString("Command line contains unexpected token '%1', see bitcoin-qt -h for a list of options.").arg(QString::fromStdString(argv[i])));
+            const std::string message = tfm::format("Command line contains unexpected token '%s', see bitcoin-qt -h for a list of options.", argv[i]);
+            // message cannot be translated because translations have not been initialized
+            InitError(Untranslated(message));
+            GUIUtil::ShowMessageBox(QString::fromStdString(message), static_cast<QMessageBox::Icon>(QMessageBox::Critical));
             return EXIT_FAILURE;
         }
     }
@@ -613,7 +617,9 @@ int GuiMain(int argc, char* argv[])
         } else if (error->status != common::ConfigStatus::ABORTED) {
             // Show a generic message in other cases, and no additional error
             // message in the case of a read error if the user decided to abort.
-            QMessageBox::critical(nullptr, CLIENT_NAME, QObject::tr("Error: %1").arg(QString::fromStdString(error->message.translated)));
+            GUIUtil::ShowMessageBox(
+                QObject::tr("Error: %1").arg(QString::fromStdString(error->message.translated)),
+                static_cast<QMessageBox::Icon>(QMessageBox::Critical));
         }
         return EXIT_FAILURE;
     }

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2022 The Bitcoin Core developers
+// Copyright (c) 2011-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -583,7 +583,7 @@ int GuiMain(int argc, char* argv[])
     // Show help message immediately after parsing command-line options (for "-lang") and setting locale,
     // but before showing splash screen.
     if (HelpRequested(gArgs) || gArgs.GetBoolArg("-version", false)) {
-        HelpMessageDialog help(nullptr, gArgs.GetBoolArg("-version", false));
+        HelpMessageDialog help(/*parent=*/nullptr, /*about=*/gArgs.GetBoolArg("-version", false));
         help.showOrPrint();
         return EXIT_SUCCESS;
     }

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2022 The Bitcoin Core developers
+// Copyright (c) 2011-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -105,7 +105,7 @@ BitcoinGUI::BitcoinGUI(interfaces::Node& node, const PlatformStyle *_platformSty
     updateWindowTitle();
 
     rpcConsole = new RPCConsole(node, _platformStyle, nullptr);
-    helpMessageDialog = new HelpMessageDialog(this, false);
+    helpMessageDialog = new HelpMessageDialog(/*parent=*/this, /*about=*/false, /*network_style=*/m_network_style);
 #ifdef ENABLE_WALLET
     if(enableWallet)
     {
@@ -936,7 +936,7 @@ void BitcoinGUI::aboutClicked()
     if(!clientModel)
         return;
 
-    auto dlg = new HelpMessageDialog(this, /*about=*/true);
+    auto dlg = new HelpMessageDialog(/*parent=*/this, /*about=*/true, /*network_style=*/m_network_style);
     GUIUtil::ShowModalDialogAsynchronously(dlg);
 }
 

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -1,6 +1,8 @@
-// Copyright (c) 2011-2022 The Bitcoin Core developers
+// Copyright (c) 2011-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <bitcoin-build-config.h> // IWYU pragma: keep
 
 #include <qt/guiutil.h>
 
@@ -1006,6 +1008,29 @@ void ShowModalDialogAsynchronously(QDialog* dialog)
     dialog->setAttribute(Qt::WA_DeleteOnClose);
     dialog->setWindowModality(Qt::ApplicationModal);
     dialog->show();
+}
+
+void ShowMessageBox(const QString& message,
+                            QMessageBox::Icon box_icon,
+                            const NetworkStyle* network_style,
+                            const QString& title)
+{
+    QString qTitle = CLIENT_NAME;
+    if (!title.isEmpty()) qTitle = title;
+    QMessageBox mBox(box_icon, qTitle, message);
+
+    mBox.setTextFormat(Qt::PlainText);
+
+    if (network_style) {
+        mBox.setWindowIcon(network_style->getTrayAndWindowIcon());
+    } else if (!gArgs.GetChainTypeString().empty()) {
+        std::unique_ptr<const NetworkStyle> fallback(NetworkStyle::instantiate(gArgs.GetChainType()));
+        if (fallback) {
+            mBox.setWindowIcon(fallback->getTrayAndWindowIcon());
+        }
+    }
+
+    mBox.exec();
 }
 
 QString WalletDisplayName(const QString& name)

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2022 The Bitcoin Core developers
+// Copyright (c) 2011-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -8,6 +8,7 @@
 #include <consensus/amount.h>
 #include <net.h>
 #include <netaddress.h>
+#include <qt/networkstyle.h>
 #include <util/check.h>
 #include <util/fs.h>
 
@@ -426,6 +427,11 @@ namespace GUIUtil
      * Shows a QDialog instance asynchronously, and deletes it on close.
      */
     void ShowModalDialogAsynchronously(QDialog* dialog);
+
+    void ShowMessageBox(const QString& message,
+                                QMessageBox::Icon box_icon,
+                                const NetworkStyle* network_style = nullptr,
+                                const QString& title = "");
 
     inline bool IsEscapeOrBack(int key)
     {

--- a/src/qt/utilitydialog.cpp
+++ b/src/qt/utilitydialog.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2022 The Bitcoin Core developers
+// Copyright (c) 2011-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -9,6 +9,8 @@
 #include <qt/forms/ui_helpmessagedialog.h>
 
 #include <qt/guiutil.h>
+
+#include <qt/networkstyle.h>
 
 #include <clientversion.h>
 #include <common/args.h>
@@ -27,7 +29,7 @@
 #include <QVBoxLayout>
 
 /** "Help message" or "About" dialog box */
-HelpMessageDialog::HelpMessageDialog(QWidget *parent, bool about) :
+HelpMessageDialog::HelpMessageDialog(QWidget* parent, bool about, const NetworkStyle* network_style) :
     QDialog(parent, GUIUtil::dialog_flags),
     ui(new Ui::HelpMessageDialog)
 {
@@ -37,8 +39,8 @@ HelpMessageDialog::HelpMessageDialog(QWidget *parent, bool about) :
 
     if (about)
     {
-        setWindowTitle(tr("About %1").arg(CLIENT_NAME));
-
+        this->setAboutWindowTitle(network_style);
+        this->setChainTypeIconOnAboutLogo(network_style);
         std::string licenseInfo = LicenseInfo();
         /// HTML-format the license message from the core
         QString licenseInfoHTML = QString::fromStdString(LicenseInfo());
@@ -135,6 +137,21 @@ void HelpMessageDialog::showOrPrint()
 void HelpMessageDialog::on_okButton_accepted()
 {
     close();
+}
+
+void HelpMessageDialog::setAboutWindowTitle(const NetworkStyle* network_style)
+{
+    QString aboutTitle = tr("About %1").arg(CLIENT_NAME);
+    if (network_style && Params().GetChainType() != ChainType::MAIN) {
+        aboutTitle.append(" " + network_style->getTitleAddText());
+    }
+    setWindowTitle(aboutTitle);
+}
+
+void HelpMessageDialog::setChainTypeIconOnAboutLogo(const NetworkStyle* network_style)
+{
+    const QSize requiredSize(1024, 1024);
+    if (network_style) ui->aboutLogo->setPixmap(network_style->getAppIcon().pixmap(requiredSize));
 }
 
 

--- a/src/qt/utilitydialog.h
+++ b/src/qt/utilitydialog.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2020 The Bitcoin Core developers
+// Copyright (c) 2011-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -7,6 +7,8 @@
 
 #include <QDialog>
 #include <QWidget>
+
+class NetworkStyle;
 
 QT_BEGIN_NAMESPACE
 class QMainWindow;
@@ -22,7 +24,7 @@ class HelpMessageDialog : public QDialog
     Q_OBJECT
 
 public:
-    explicit HelpMessageDialog(QWidget *parent, bool about);
+    explicit HelpMessageDialog(QWidget* parent, bool about, const NetworkStyle* network_style = nullptr);
     ~HelpMessageDialog();
 
     void printToConsole();
@@ -31,6 +33,8 @@ public:
 private:
     Ui::HelpMessageDialog *ui;
     QString text;
+    void setAboutWindowTitle(const NetworkStyle* network_style = nullptr);
+    void setChainTypeIconOnAboutLogo(const NetworkStyle* network_style = nullptr);
 
 private Q_SLOTS:
     void on_okButton_accepted();


### PR DESCRIPTION
It fixes https://github.com/bitcoin-core/gui/issues/761.

About logo icon is updated now with the correct colour indicating the chain type of the QT instance that user is running (as the splash screen), plus the title of the about window also is updated with the chain type string as in the main window.
<details>
<summary>Before PR changes screenshot</summary>

![image](https://github.com/bitcoin-core/gui/assets/110166421/63945955-2e29-4dc9-8a2e-2a5567983e9b)
</details>

<details>
<summary>After PR changes screenshot</summary>

![image](https://github.com/bitcoin-core/gui/assets/110166421/b6ce187f-ca81-4c4b-b2f6-a2e3b15e6010)
</details>

<details>
<summary>Current splash screen screenshot</summary>
(this hasn't been touched, just to show consistency with this PR changes)


![image](https://github.com/bitcoin-core/gui/assets/110166421/2a1c329b-baa6-4603-bf20-dac2746682f4)
</details>

Tested it also with:
- mainnet (no command line args after `bitcoin-qt` or `bitcoin-qt -chain=main`), 
- `-regtest` and 
- `-testnet`.