### PR TITLE
Fix wallet list hover crash on shutdown

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -392,7 +392,7 @@ void BitcoinGUI::createActions()
         connect(usedSendingAddressesAction, &QAction::triggered, walletFrame, &WalletFrame::usedSendingAddresses);
         connect(usedReceivingAddressesAction, &QAction::triggered, walletFrame, &WalletFrame::usedReceivingAddresses);
         connect(openAction, &QAction::triggered, this, &BitcoinGUI::openClicked);
-        connect(m_open_wallet_menu, &QMenu::aboutToShow, [this] {
+        connect(m_open_wallet_menu, &QMenu::aboutToShow, m_wallet_controller, [this] {
             m_open_wallet_menu->clear();
             for (const std::pair<const std::string, bool>& i : m_wallet_controller->listWalletDir()) {
                 const std::string& path = i.first;
@@ -409,7 +409,7 @@ void BitcoinGUI::createActions()
                     continue;
                 }
 
-                connect(action, &QAction::triggered, [this, path] {
+                connect(action, &QAction::triggered, m_wallet_controller, [this, path] {
                     auto activity = new OpenWalletActivity(m_wallet_controller, this);
                     connect(activity, &OpenWalletActivity::opened, this, &BitcoinGUI::setCurrentWallet, Qt::QueuedConnection);
                     connect(activity, &OpenWalletActivity::opened, rpcConsole, &RPCConsole::setCurrentWallet, Qt::QueuedConnection);
@@ -421,7 +421,7 @@ void BitcoinGUI::createActions()
                 action->setEnabled(false);
             }
         });
-        connect(m_restore_wallet_action, &QAction::triggered, [this] {
+        connect(m_restore_wallet_action, &QAction::triggered, m_wallet_controller, [this] {
             //: Name of the wallet data file format.
             QString name_data_file = tr("Wallet Data");
 
@@ -447,14 +447,14 @@ void BitcoinGUI::createActions()
             auto backup_file_path = fs::PathFromString(backup_file.toStdString());
             activity->restore(backup_file_path, wallet_name.toStdString());
         });
-        connect(m_close_wallet_action, &QAction::triggered, [this] {
+        connect(m_close_wallet_action, &QAction::triggered, m_wallet_controller, [this] {
             m_wallet_controller->closeWallet(walletFrame->currentWalletModel(), this);
         });
         connect(m_create_wallet_action, &QAction::triggered, this, &BitcoinGUI::createWallet);
-        connect(m_close_all_wallets_action, &QAction::triggered, [this] {
+        connect(m_close_all_wallets_action, &QAction::triggered, m_wallet_controller, [this] {
             m_wallet_controller->closeAllWallets(this);
         });
-        connect(m_migrate_wallet_action, &QAction::triggered, [this] {
+        connect(m_migrate_wallet_action, &QAction::triggered, m_wallet_controller, [this] {
             auto activity = new MigrateWalletActivity(m_wallet_controller, this);
             connect(activity, &MigrateWalletActivity::migrated, this, &BitcoinGUI::setCurrentWallet);
             activity->migrate(walletFrame->currentWalletModel());

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -650,7 +650,8 @@ void BitcoinGUI::setClientModel(ClientModel *_clientModel, interfaces::BlockAndH
 
         m_mask_values_action->setChecked(_clientModel->getOptionsModel()->getOption(OptionsModel::OptionID::MaskValues).toBool());
     } else {
-        if(trayIconMenu)
+        // Shutdown requested, disable menus
+        if (trayIconMenu)
         {
             // Disable context menu on tray icon
             trayIconMenu->clear();
@@ -664,6 +665,8 @@ void BitcoinGUI::setClientModel(ClientModel *_clientModel, interfaces::BlockAndH
         }
 #endif // ENABLE_WALLET
         unitDisplayControl->setOptionsModel(nullptr);
+        // Disable top bar menu actions
+        appMenuBar->clear();
     }
 }
 


### PR DESCRIPTION
Small follow-up to #751.

Fixes another crash cause during shutdown. Which occurs when the user hovers over the wallets list.

Future Note:
This surely happen in other places as well, we should re-work the way we connect signals. Register
lambas without any precaution can leave dangling pointers.