### PR TITLE
Add used balance to overview page

### DIFF
--- a/src/qt/forms/overviewpage.ui
+++ b/src/qt/forms/overviewpage.ui
@@ -168,14 +168,40 @@
               </property>
              </widget>
             </item>
-            <item row="4" column="0" colspan="2">
+            <item row="4" column="0">
+             <widget class="QLabel" name="labelUsedText">
+              <property name="text">
+               <string>Used:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="4" column="1">
+             <widget class="QLabel" name="labelUsed">
+              <property name="cursor">
+               <cursorShape>IBeamCursor</cursorShape>
+              </property>
+              <property name="toolTip">
+               <string>Your current used balance</string>
+              </property>
+              <property name="text">
+               <string notr="true">21 000 000.00000000 BTC</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+              </property>
+              <property name="textInteractionFlags">
+               <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+              </property>
+             </widget>
+            </item>
+            <item row="5" column="0" colspan="2">
              <widget class="Line" name="line">
               <property name="orientation">
                <enum>Qt::Horizontal</enum>
               </property>
              </widget>
             </item>
-            <item row="4" column="2">
+            <item row="5" column="2">
              <widget class="Line" name="lineWatchBalance">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -194,7 +220,7 @@
               </property>
              </widget>
             </item>
-            <item row="5" column="0">
+            <item row="6" column="0">
              <widget class="QLabel" name="labelTotalText">
               <property name="text">
                <string>Total:</string>
@@ -240,7 +266,7 @@
               </property>
              </widget>
             </item>
-            <item row="5" column="1">
+            <item row="6" column="1">
              <widget class="QLabel" name="labelTotal">
               <property name="cursor">
                <cursorShape>IBeamCursor</cursorShape>
@@ -259,7 +285,7 @@
               </property>
              </widget>
             </item>
-            <item row="5" column="2">
+            <item row="6" column="2">
              <widget class="QLabel" name="labelWatchTotal">
               <property name="cursor">
                <cursorShape>IBeamCursor</cursorShape>

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -226,6 +226,15 @@ void OverviewPage::setBalance(const interfaces::WalletBalances& balances)
     ui->labelImmature->setVisible(showImmature || showWatchOnlyImmature);
     ui->labelImmatureText->setVisible(showImmature || showWatchOnlyImmature);
     ui->labelWatchImmature->setVisible(!walletModel->wallet().privateKeysDisabled() && showWatchOnlyImmature); // show watch-only immature balance
+
+    // only show used balance when on wallet with 'avoid_reuse' flag
+    bool showUsed = walletModel->isAvoidReuseEnabled();
+
+    if (showUsed) {
+        ui->labelUsed->setText(BitcoinUnits::formatWithPrivacy(unit, balances.used, BitcoinUnits::SeparatorStyle::ALWAYS, m_privacy));
+    }
+    ui->labelUsedText->setVisible(showUsed);
+    ui->labelUsed->setVisible(showUsed);
 }
 
 // show/hide watch-only labels
@@ -352,4 +361,5 @@ void OverviewPage::setMonospacedFont(bool use_embedded_font)
     ui->labelWatchPending->setFont(f);
     ui->labelWatchImmature->setFont(f);
     ui->labelWatchTotal->setFont(f);
+    ui->labelUsed->setFont(f);
 }

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -599,6 +599,11 @@ bool WalletModel::isMultiwallet() const
     return m_node.walletLoader().getWallets().size() > 1;
 }
 
+bool WalletModel::isAvoidReuseEnabled() const
+{
+    return m_wallet->isAvoidReuseEnabled();
+}
+
 void WalletModel::refresh(bool pk_hash_only)
 {
     addressTableModel = new AddressTableModel(this, pk_hash_only);

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -148,6 +148,8 @@ public:
 
     bool isMultiwallet() const;
 
+    bool isAvoidReuseEnabled() const;
+
     void refresh(bool pk_hash_only = false);
 
     uint256 getLastBlockProcessed() const;


### PR DESCRIPTION
**Second part:** Fixes https://github.com/bitcoin-core/gui/issues/769

Add used balance to the overview page for wallets with the avoid_reuse flag enabled

### Prerequsite:

- **Part one (should be merged first)**: https://github.com/bitcoin/bitcoin/pull/28776

overview page when avoid_reuse is enabled
![Screenshot from 2023-11-02 18-10-06](https://github.com/bitcoin-core/gui/assets/15610188/825a29f9-0558-4957-a079-1cb707421986)

overview page when avoid_reuse is not enabled
![Screenshot from 2023-11-03 11-07-45](https://github.com/bitcoin-core/gui/assets/15610188/2761272f-0c51-4c06-96fd-bd6c8d874ee7)
