### PR TITLE
FIX:When opening or autoloading wallets there should be clear messages about rescanning in progress and wallets' names.

### DIFF
--- a/src/qt/receivecoinsdialog.cpp
+++ b/src/qt/receivecoinsdialog.cpp
@@ -72,6 +72,9 @@ void ReceiveCoinsDialog::setModel(WalletModel *_model)
 {
     this->model = _model;
 
+        setWindowTitle(tr("Request payments - %1").arg(model->getWalletName()));
+
+
     if(_model && _model->getOptionsModel())
     {
         _model->getRecentRequestsTableModel()->sort(RecentRequestsTableModel::Date, Qt::DescendingOrder);

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -145,7 +145,9 @@ void SendCoinsDialog::setClientModel(ClientModel *_clientModel)
 void SendCoinsDialog::setModel(WalletModel *_model)
 {
     this->model = _model;
-
+    
+      setWindowTitle(tr("Send Coins - %1").arg(model->getWalletName()));
+  
     if(_model && _model->getOptionsModel())
     {
         for(int i = 0; i < ui->entries->count(); ++i)


### PR DESCRIPTION
issue-: #259

The "Opening Wallet" popup would now show "Opening Wallet: " instead of just "Opening Wallet". This identifies the specific wallet.

The "Rescanning" popup would show "Rescanning: " or "Rescanning - 0%" if a progress bar is added. Again, this identifies the wallet.

The main window title would include the wallet name after being opened/loaded thanks to the change in WalletView::showNormalIfMinimized().

Other dialogs like Send/Receive coins would also show the wallet name in the title.

So in summary, by appending the wallet name retrieved from WalletModel::getWalletName() to titles and popup messages, it provides clearer feedback to users about which wallet is being loaded and rescanned. No more confusion about which wallet Bitcoin Core is working on.
