### PR TITLE
Avoid non-self-contained Windows header

### DIFF
--- a/src/qt/winshutdownmonitor.h
+++ b/src/qt/winshutdownmonitor.h
@@ -10,7 +10,7 @@
 #include <QString>
 #include <functional>
 
-#include <windef.h> // for HWND
+#include <windows.h>
 
 #include <QAbstractNativeEventFilter>
 


### PR DESCRIPTION
Using the `windows.h` header guarantees correctness regardless of the content of other headers.

For more details, please refer to https://stackoverflow.com/questions/4845198/fatal-error-no-target-architecture-in-visual-studio

Fixes the MSVC build when using the upcoming CMake-based build system and Qt packages installed via the vcpkg package manager.

Related to https://github.com/hebasto/bitcoin/pull/77.