### PR TITLE
refactor: Readable widget naming for debug window

### DIFF
--- a/src/qt/forms/debugwindow.ui
+++ b/src/qt/forms/debugwindow.ui
@@ -47,7 +47,7 @@
         <number>12</number>
        </property>
        <item row="0" column="0">
-        <widget class="QLabel" name="label_9">
+        <widget class="QLabel" name="labelGeneral">
          <property name="font">
           <font>
            <weight>75</weight>
@@ -60,7 +60,7 @@
         </widget>
        </item>
        <item row="1" column="0">
-        <widget class="QLabel" name="label_6">
+        <widget class="QLabel" name="labelClientVersion">
          <property name="text">
           <string>Client version</string>
          </property>
@@ -87,9 +87,6 @@
          <property name="text">
           <string>User Agent</string>
          </property>
-         <property name="indent">
-          <number>10</number>
-         </property>
         </widget>
        </item>
        <item row="2" column="1" colspan="2">
@@ -109,7 +106,7 @@
         </widget>
        </item>
        <item row="3" column="0">
-        <widget class="QLabel" name="label_12">
+        <widget class="QLabel" name="labelDataDir">
          <property name="text">
           <string>Datadir</string>
          </property>
@@ -138,7 +135,7 @@
         </widget>
        </item>
        <item row="4" column="0">
-        <widget class="QLabel" name="label_11">
+        <widget class="QLabel" name="labelBlocksDir">
          <property name="text">
           <string>Blocksdir</string>
          </property>
@@ -167,7 +164,7 @@
         </widget>
        </item>
        <item row="5" column="0">
-        <widget class="QLabel" name="label_13">
+        <widget class="QLabel" name="labelStartupTime">
          <property name="text">
           <string>Startup time</string>
          </property>
@@ -203,7 +200,7 @@
         </widget>
        </item>
        <item row="7" column="0">
-        <widget class="QLabel" name="label_8">
+        <widget class="QLabel" name="labelNetworkName">
          <property name="text">
           <string>Name</string>
          </property>
@@ -226,7 +223,7 @@
         </widget>
        </item>
        <item row="8" column="0">
-        <widget class="QLabel" name="label_7">
+        <widget class="QLabel" name="labelNumberOfConnections">
          <property name="text">
           <string>Number of connections</string>
          </property>
@@ -249,7 +246,7 @@
         </widget>
        </item>
        <item row="9" column="0">
-        <widget class="QLabel" name="label_10">
+        <widget class="QLabel" name="labelBlockChain">
          <property name="font">
           <font>
            <weight>75</weight>
@@ -262,7 +259,7 @@
         </widget>
        </item>
        <item row="10" column="0">
-        <widget class="QLabel" name="label_3">
+        <widget class="QLabel" name="labelNumberOfBlocks">
          <property name="text">
           <string>Current block height</string>
          </property>
@@ -321,7 +318,7 @@
         </widget>
        </item>
        <item row="13" column="0">
-        <widget class="QLabel" name="labelNumberOfTransactions">
+        <widget class="QLabel" name="labelMempoolNumberTxs">
          <property name="text">
           <string>Current number of transactions</string>
          </property>
@@ -372,7 +369,7 @@
           <number>3</number>
          </property>
          <item>
-          <spacer name="verticalSpacer_2">
+          <spacer name="verticalSpacer_DebugButton">
            <property name="orientation">
             <enum>Qt::Vertical</enum>
            </property>
@@ -614,7 +611,7 @@
       </attribute>
       <layout class="QHBoxLayout" name="horizontalLayout_3">
        <item>
-        <layout class="QVBoxLayout" name="verticalLayout_4">
+        <layout class="QVBoxLayout" name="verticalLayout_nettraffic">
          <item>
           <widget class="TrafficGraphWidget" name="trafficGraph" native="true">
            <property name="sizePolicy">
@@ -626,7 +623,7 @@
           </widget>
          </item>
          <item>
-          <layout class="QHBoxLayout" name="horizontalLayout_2">
+          <layout class="QHBoxLayout" name="horizontalLayout_nettraffic">
            <item>
             <widget class="QSlider" name="sldGraphRange">
              <property name="minimum">
@@ -674,7 +671,7 @@
         </layout>
        </item>
        <item>
-        <layout class="QVBoxLayout" name="verticalLayout">
+        <layout class="QVBoxLayout" name="verticalLayout_nettraffic_totals">
          <item>
           <widget class="QGroupBox" name="groupBox">
            <property name="title">
@@ -682,7 +679,7 @@
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_5">
             <item>
-             <layout class="QHBoxLayout" name="horizontalLayout_4">
+             <layout class="QHBoxLayout" name="horizontalLayout_received">
               <item>
                <widget class="Line" name="line">
                 <property name="sizePolicy">
@@ -740,7 +737,7 @@
                </widget>
               </item>
               <item>
-               <widget class="QLabel" name="label_16">
+               <widget class="QLabel" name="labelReceived">
                 <property name="text">
                  <string>Received</string>
                 </property>
@@ -762,7 +759,7 @@
              </layout>
             </item>
             <item>
-             <layout class="QHBoxLayout" name="horizontalLayout_5">
+             <layout class="QHBoxLayout" name="horizontalLayout_Sent">
               <item>
                <widget class="Line" name="line_2">
                 <property name="sizePolicy">
@@ -820,7 +817,7 @@
                </widget>
               </item>
               <item>
-               <widget class="QLabel" name="label_17">
+               <widget class="QLabel" name="labelSent">
                 <property name="text">
                  <string>Sent</string>
                 </property>
@@ -842,7 +839,7 @@
              </layout>
             </item>
             <item>
-             <spacer name="verticalSpacer_4">
+             <spacer name="verticalSpacer_totals">
               <property name="orientation">
                <enum>Qt::Vertical</enum>
               </property>
@@ -874,7 +871,7 @@
          <property name="childrenCollapsible">
           <bool>false</bool>
          </property>
-         <widget class="QWidget" name="widget_1" native="true">
+         <widget class="QWidget" name="peersWidget" native="true">
           <property name="sizePolicy">
            <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
             <horstretch>1</horstretch>
@@ -1036,7 +1033,7 @@
               </property>
               <layout class="QGridLayout" name="gridLayout_2" columnstretch="0,1">
                <item row="0" column="0">
-                <widget class="QLabel" name="label_30">
+                <widget class="QLabel" name="peerPermissionsLabel">
                  <property name="text">
                   <string>Permissions</string>
                  </property>
@@ -1163,7 +1160,7 @@
                 </widget>
                </item>
                <item row="5" column="0">
-                <widget class="QLabel" name="label_21">
+                <widget class="QLabel" name="peerVersionLabel">
                  <property name="text">
                   <string>Version</string>
                  </property>
@@ -1186,7 +1183,7 @@
                 </widget>
                </item>
                <item row="6" column="0">
-                <widget class="QLabel" name="label_28">
+                <widget class="QLabel" name="peerSubversionLabel">
                  <property name="text">
                   <string>User Agent</string>
                  </property>
@@ -1209,7 +1206,7 @@
                 </widget>
                </item>
                <item row="7" column="0">
-                <widget class="QLabel" name="label_4">
+                <widget class="QLabel" name="peerServicesLabel">
                  <property name="text">
                   <string>Services</string>
                  </property>
@@ -1287,7 +1284,7 @@
                 </widget>
                </item>
                <item row="10" column="0">
-                <widget class="QLabel" name="label_29">
+                <widget class="QLabel" name="peerHeightLabel">
                  <property name="text">
                   <string>Starting Block</string>
                  </property>
@@ -1310,7 +1307,7 @@
                 </widget>
                </item>
                <item row="11" column="0">
-                <widget class="QLabel" name="label_27">
+                <widget class="QLabel" name="peerSyncHeightLabel">
                  <property name="text">
                   <string>Synced Headers</string>
                  </property>
@@ -1333,7 +1330,7 @@
                 </widget>
                </item>
                <item row="12" column="0">
-                <widget class="QLabel" name="label_25">
+                <widget class="QLabel" name="peerCommonHeightLabel">
                  <property name="text">
                   <string>Synced Blocks</string>
                  </property>
@@ -1356,7 +1353,7 @@
                 </widget>
                </item>
                <item row="13" column="0">
-                <widget class="QLabel" name="label_22">
+                <widget class="QLabel" name="peerConnTimeLabel">
                  <property name="text">
                   <string>Connection Time</string>
                  </property>
@@ -1431,7 +1428,7 @@
                 </widget>
                </item>
                <item row="16" column="0">
-                <widget class="QLabel" name="label_15">
+                <widget class="QLabel" name="peerLastSendLabel">
                  <property name="text">
                   <string>Last Send</string>
                  </property>
@@ -1454,7 +1451,7 @@
                 </widget>
                </item>
                <item row="17" column="0">
-                <widget class="QLabel" name="label_19">
+                <widget class="QLabel" name="peerLastRecvLabel">
                  <property name="text">
                   <string>Last Receive</string>
                  </property>
@@ -1477,7 +1474,7 @@
                 </widget>
                </item>
                <item row="18" column="0">
-                <widget class="QLabel" name="label_18">
+                <widget class="QLabel" name="peerBytesSentLabel">
                  <property name="text">
                   <string>Sent</string>
                  </property>
@@ -1500,7 +1497,7 @@
                 </widget>
                </item>
                <item row="19" column="0">
-                <widget class="QLabel" name="label_20">
+                <widget class="QLabel" name="peerBytesRecvLabel">
                  <property name="text">
                   <string>Received</string>
                  </property>
@@ -1523,7 +1520,7 @@
                 </widget>
                </item>
                <item row="20" column="0">
-                <widget class="QLabel" name="label_26">
+                <widget class="QLabel" name="peerPingTimeLabel">
                  <property name="text">
                   <string>Ping Time</string>
                  </property>
@@ -1595,14 +1592,14 @@
                 </widget>
                </item>
                <item row="23" column="0">
-                <widget class="QLabel" name="label_timeoffset">
+                <widget class="QLabel" name="peerTimeOffsetLabel">
                  <property name="text">
                   <string>Time Offset</string>
                  </property>
                 </widget>
                </item>
                <item row="23" column="1">
-                <widget class="QLabel" name="timeoffset">
+                <widget class="QLabel" name="peerTimeOffset">
                  <property name="cursor">
                   <cursorShape>IBeamCursor</cursorShape>
                  </property>
@@ -1722,7 +1719,7 @@
                 </widget>
                </item>
                <item row="28" column="0">
-                <spacer name="verticalSpacer_3">
+                <spacer name="peerVerticalSpacer">
                  <property name="orientation">
                   <enum>Qt::Vertical</enum>
                  </property>

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -1193,7 +1193,7 @@ void RPCConsole::updateDetailWidget()
     ui->peerBytesRecv->setText(GUIUtil::formatBytes(stats->nodeStats.nRecvBytes));
     ui->peerPingTime->setText(GUIUtil::formatPingTime(stats->nodeStats.m_last_ping_time));
     ui->peerMinPing->setText(GUIUtil::formatPingTime(stats->nodeStats.m_min_ping_time));
-    ui->timeoffset->setText(GUIUtil::formatTimeOffset(stats->nodeStats.nTimeOffset));
+    ui->peerTimeOffset->setText(GUIUtil::formatTimeOffset(stats->nodeStats.nTimeOffset));
     if (stats->nodeStats.nVersion) {
         ui->peerVersion->setText(QString::number(stats->nodeStats.nVersion));
     }


### PR DESCRIPTION
Fixed widget names in the debug window. Make it more developer friendly to avoid confusion inside Qt Designer.