### PR TITLE
Correct tooltip wording for watch-only wallets

### DIFF
--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -197,7 +197,10 @@ void OverviewPage::setBalance(const interfaces::WalletBalances& balances)
     BitcoinUnit unit = walletModel->getOptionsModel()->getDisplayUnit();
     if (walletModel->wallet().isLegacy()) {
         if (walletModel->wallet().privateKeysDisabled()) {
+            ui->labelSpendable->setText(tr("Watch-only:"));
+            ui->labelSpendable->setVisible(true);
             ui->labelBalance->setText(BitcoinUnits::formatWithPrivacy(unit, balances.watch_only_balance, BitcoinUnits::SeparatorStyle::ALWAYS, m_privacy));
+            ui->labelBalance->setToolTip(tr("Your current balance in watch-only addresses"));
             ui->labelUnconfirmed->setText(BitcoinUnits::formatWithPrivacy(unit, balances.unconfirmed_watch_only_balance, BitcoinUnits::SeparatorStyle::ALWAYS, m_privacy));
             ui->labelImmature->setText(BitcoinUnits::formatWithPrivacy(unit, balances.immature_watch_only_balance, BitcoinUnits::SeparatorStyle::ALWAYS, m_privacy));
             ui->labelTotal->setText(BitcoinUnits::formatWithPrivacy(unit, balances.watch_only_balance + balances.unconfirmed_watch_only_balance + balances.immature_watch_only_balance, BitcoinUnits::SeparatorStyle::ALWAYS, m_privacy));


### PR DESCRIPTION
This is a continuation of https://github.com/bitcoin-core/gui/pull/37
This is a simple change, but imho necessary because it leads to confusion.
The objective of this change is to provide a better description for the tooltip for the "Available Balance" balance because the current version on master mentions the word "You current spendable balance" which is a bit misleading, because that balance is not always spendable , or not always yours on watch only wallets.
