### PR TITLE
test: Set organization name

### DIFF
--- a/src/qt/test/optiontests.cpp
+++ b/src/qt/test/optiontests.cpp
@@ -50,6 +50,17 @@ void OptionTests::migrateSettings()
 
     settings.sync();
 
+    QVERIFY(settings.contains("nDatabaseCache"));
+    QVERIFY(settings.contains("nThreadsScriptVerif"));
+    QVERIFY(settings.contains("fUseUPnP"));
+    QVERIFY(settings.contains("fListen"));
+    QVERIFY(settings.contains("bPrune"));
+    QVERIFY(settings.contains("nPruneSize"));
+    QVERIFY(settings.contains("fUseProxy"));
+    QVERIFY(settings.contains("addrProxy"));
+    QVERIFY(settings.contains("fUseSeparateProxyTor"));
+    QVERIFY(settings.contains("addrSeparateProxyTor"));
+
     OptionsModel options{m_node};
     bilingual_str error;
     QVERIFY(options.Init(error));

--- a/src/qt/test/test_main.cpp
+++ b/src/qt/test/test_main.cpp
@@ -9,6 +9,7 @@
 #include <interfaces/init.h>
 #include <interfaces/node.h>
 #include <qt/bitcoin.h>
+#include <qt/guiconstants.h>
 #include <qt/test/apptests.h>
 #include <qt/test/optiontests.h>
 #include <qt/test/rpcnestedtests.h>
@@ -24,6 +25,7 @@
 #include <QApplication>
 #include <QDebug>
 #include <QObject>
+#include <QSettings>
 #include <QTest>
 
 #include <functional>
@@ -84,7 +86,8 @@ int main(int argc, char* argv[])
     #endif
 
     BitcoinApplication app;
-    app.setApplicationName("Bitcoin-Qt-test");
+    app.setOrganizationName(QAPP_ORG_NAME);
+    app.setApplicationName(QAPP_APP_NAME_DEFAULT "-test");
     app.createNode(*init);
 
     int num_test_failures{0};

--- a/src/qt/test/test_main.cpp
+++ b/src/qt/test/test_main.cpp
@@ -117,5 +117,9 @@ int main(int argc, char* argv[])
     } else {
         qDebug("\nAll tests passed.\n");
     }
+
+    QSettings settings;
+    settings.clear();
+
     return num_test_failures;
 }


### PR DESCRIPTION
From Qt [docs](https://doc.qt.io/qt-5/qsettings.html#QSettings-4):

> If [`QCoreApplication::setOrganizationName()`](https://doc.qt.io/qt-5/qcoreapplication.html#organizationName-prop) and [`QCoreApplication::setApplicationName()`](https://doc.qt.io/qt-5/qcoreapplication.html#applicationName-prop) has not been previously called, the `QSettings` object will not be able to read or write any settings, and [`status()`](https://doc.qt.io/qt-5/qsettings.html#status) will return [`AccessError`](https://doc.qt.io/qt-5/qsettings.html#Status-enum).

Fixes https://github.com/bitcoin-core/gui/issues/799.