### PR TITLE
Bugfix - don't allow multiple dialogs for same tx in TransactionView

### DIFF
--- a/src/qt/transactiondescdialog.cpp
+++ b/src/qt/transactiondescdialog.cpp
@@ -15,7 +15,8 @@ TransactionDescDialog::TransactionDescDialog(const QModelIndex &idx, QWidget *pa
     ui(new Ui::TransactionDescDialog)
 {
     ui->setupUi(this);
-    setWindowTitle(tr("Details for %1").arg(idx.data(TransactionTableModel::TxHashRole).toString()));
+    m_transaction_id = idx.data(TransactionTableModel::TxHashRole).toString();
+    setWindowTitle(tr("Details for %1").arg(m_transaction_id));
     QString desc = idx.data(TransactionTableModel::LongDescriptionRole).toString();
     ui->detailText->setHtml(desc);
 

--- a/src/qt/transactiondescdialog.h
+++ b/src/qt/transactiondescdialog.h
@@ -6,6 +6,7 @@
 #define BITCOIN_QT_TRANSACTIONDESCDIALOG_H
 
 #include <QDialog>
+#include <QString>
 
 namespace Ui {
     class TransactionDescDialog;
@@ -24,8 +25,11 @@ public:
     explicit TransactionDescDialog(const QModelIndex &idx, QWidget *parent = nullptr);
     ~TransactionDescDialog();
 
+    QString getTransactionId() {return m_transaction_id;};
+
 private:
     Ui::TransactionDescDialog *ui;
+    QString m_transaction_id;
 };
 
 #endif // BITCOIN_QT_TRANSACTIONDESCDIALOG_H

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -35,6 +35,7 @@
 #include <QPoint>
 #include <QScrollBar>
 #include <QSettings>
+#include <QString>
 #include <QTableView>
 #include <QTimer>
 #include <QUrl>
@@ -528,13 +529,15 @@ void TransactionView::showDetails()
     QModelIndexList selection = transactionView->selectionModel()->selectedRows();
     if(!selection.isEmpty())
     {
-        TransactionDescDialog *dlg = new TransactionDescDialog(selection.at(0));
-        dlg->setAttribute(Qt::WA_DeleteOnClose);
-        m_opened_dialogs.append(dlg);
-        connect(dlg, &QObject::destroyed, [this, dlg] {
-            m_opened_dialogs.removeOne(dlg);
-        });
-        dlg->show();
+        if(!detailsAlreadyShown(selection.at(0))) {
+            TransactionDescDialog *dlg = new TransactionDescDialog(selection.at(0));
+            dlg->setAttribute(Qt::WA_DeleteOnClose);
+            m_opened_dialogs.append(dlg);
+            connect(dlg, &QObject::destroyed, [this, dlg] {
+                m_opened_dialogs.removeOne(dlg);
+            });
+            dlg->show();
+        }
     }
 }
 
@@ -662,4 +665,15 @@ void TransactionView::closeOpenedDialogs()
         dlg->close();
     }
     m_opened_dialogs.clear();
+}
+
+bool TransactionView::detailsAlreadyShown(const QModelIndex &idx)
+{
+    for (TransactionDescDialog* dlg : m_opened_dialogs) {
+        if (dlg->getTransactionId() == idx.data(TransactionTableModel::TxHashRole).toString()) {
+            GUIUtil::bringToFront(dlg);
+            return true;
+        }
+    }
+    return false;
 }

--- a/src/qt/transactionview.h
+++ b/src/qt/transactionview.h
@@ -108,6 +108,7 @@ private Q_SLOTS:
     void updateWatchOnlyColumn(bool fHaveWatchOnly);
     void abandonTx();
     void bumpFee(bool checked);
+    bool detailsAlreadyShown(const QModelIndex &idx);
 
 Q_SIGNALS:
     void doubleClicked(const QModelIndex&);


### PR DESCRIPTION
Limit to one the transaction details dialogs that a user can open. If a transaction details dialog is already open, bring it to the foreground when a user clicks on its row again - as [suggested](https://github.com/bitcoin-core/gui/pull/817#issuecomment-2051671919..) by flack.

<details>
<summary>Currently a user can open unlimited tx details dialogs for the same tx id.</summary>

![Peek 2024-04-12 00-50](https://github.com/bitcoin-core/gui/assets/110166421/ba5a261b-9234-437f-b496-2f01320f14ce)

</details>
<details>
<summary>This PR fixes the issue.</summary>

![Peek 2024-04-12 00-37](https://github.com/bitcoin-core/gui/assets/110166421/22f0f9e4-ec58-4ee2-bff4-6793435dd6d5)

</details>