### PR TITLE
Fix display issues for IPv6 proxy setup in Options Dialog  (UI only, no functionality impact)

### DIFF
--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -320,10 +320,15 @@ static ProxySetting ParseProxyString(const QString& proxy)
     if (proxy.isEmpty()) {
         return default_val;
     }
-    // contains IP at index 0 and port at index 1
-    QStringList ip_port = GUIUtil::SplitSkipEmptyParts(proxy, ":");
-    if (ip_port.size() == 2) {
-        return {true, ip_port.at(0), ip_port.at(1)};
+    uint16_t port{0};
+    std::string hostname;
+    if (SplitHostPort(proxy.toStdString(), port, hostname) && port != 0) {
+        // Valid and port within the valid range
+        // Check if the hostname contains a colon, indicating an IPv6 address
+        if (hostname.find(':') != std::string::npos) {
+            hostname = "[" + hostname + "]"; // Wrap IPv6 address in brackets
+        }
+        return {true, QString::fromStdString(hostname), QString::number(port)};
     } else { // Invalid: return default
         return default_val;
     }


### PR DESCRIPTION
Currently, setting up a proxy (whether SOCKS5 or Tor) with an IPv6 address works correctly via the command line or configuration file in both `bitcoind` and `bitcoin-qt` (also from the UI the ipv6 address gets saved properly in `settings.json`). However, the UI does not reflect this properly, which can create confusion. Since some ISPs and VPNs still experience issues with IPv6, users may mistakenly think there is a problem with Bitcoin Core, when in fact the proxy setup is functioning as expected.

So this PR ensures that the proxy IP is displayed correctly in the UI when using an IPv6 address.

No functionality impact; changes only affect UI display.

<details>
<summary>Click her to see <b>before</b> and <b>after</b> screenshots.</summary>

- Before:

  ![image](https://github.com/user-attachments/assets/073d9022-3174-4eef-8e0c-8c1b73b17226)

- After:

  ![image](https://github.com/user-attachments/assets/293e4e07-83e5-44ec-8ab3-df9d1f601a6f)

  
</details>

---

<details>
<summary>Test instructions</summary>

(Ubuntu 22.04)

1. Start ssh service on localhost.

   `ssh -D [::1]:1080 -f -C -q -N localhost`

2. Check that the service is up and running.

   ```
   ps aux | grep ssh
   pepe    2860289  0.0  0.0  20456  5576 ?        Ss   06:59   0:00 ssh -D [::1]:1080 -f -C -q -N localhost
   ```

3. Check with `bitcoind` if it works correctly.

   `bitcoind -onlynet=ipv6 -proxy=[::1]:1080`
   
4. Check for established connections.

   ```
   netstat -natl |grep 1080
   tcp6       0      0 ::1:1080                :::*                    LISTEN     
   tcp6       0      0 ::1:47610               ::1:1080                ESTABLISHED
   tcp6       0      0 ::1:1080                ::1:47610               ESTABLISHED
   tcp6       0      0 ::1:1080                ::1:47606               TIME_WAIT    
   ```

   ```./build/src/bitcoin-cli getpeerinfo
   [
      {
        "id": 0,
        "addr": "[2a01:4f9:4a:2a07::2]:8333",
        "addrbind": "[::1]:47638",
        "network": "ipv6",
   ...
   ```

   
   

5. Stop `bitcoind` and run `bitcoin-qt` adding the corresponding configuration in `settings.json`.

    ```
   {
       "onlynet": "ipv6",
       "proxy": "[::1]:1080",
   }
   ```
   
6. Open the Peers window to check available connections or run `getpeerinfo` on the rpc-console window.

7. Same can be done for Tor setting up `tor` service (I'll add instructions later) and configuring on its default port 9050 and forcing `"onlynet": "onion"` to verify easily the net traffic.

</details>

---

Thanks jarolrod and vasild for your help on validating ipv6 was not broken.