### PR TITLE
qt6: Handle deprecated `QLocale::nativeCountryName`

### DIFF
--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -169,8 +169,15 @@ OptionsDialog::OptionsDialog(QWidget* parent, bool enableWallet)
         /** check if the locale name consists of 2 parts (language_country) */
         if(langStr.contains("_"))
         {
-            /** display language strings as "native language - native country (locale name)", e.g. "Deutsch - Deutschland (de)" */
-            ui->lang->addItem(locale.nativeLanguageName() + QString(" - ") + locale.nativeCountryName() + QString(" (") + langStr + QString(")"), QVariant(langStr));
+            /** display language strings as "native language - native country/territory (locale name)", e.g. "Deutsch - Deutschland (de)" */
+            ui->lang->addItem(locale.nativeLanguageName() + QString(" - ") +
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 2, 0))
+                              locale.nativeTerritoryName() +
+#else
+                              locale.nativeCountryName() +
+#endif
+                              QString(" (") + langStr + QString(")"), QVariant(langStr));
+
         }
         else
         {


### PR DESCRIPTION
Split from https://github.com/bitcoin/bitcoin/pull/30997.

[`QLocale::nativeCountryName()`](https://doc.qt.io/qt-6/qlocale-obsolete.html#nativeCountryName) has been deprecated since Qt 6.6.

[`QLocale::nativeTerritoryName()`](https://doc.qt.io/qt-6/qlocale.html#nativeTerritoryName) was introduced in Qt 6.2.

This PR ensures compatibility across all supported Qt versions.

No behaviour change for the current codebase, which uses Qt 5.

---

This PR can be tested on macOS using the first commit from https://github.com/bitcoin/bitcoin/pull/30997 and Homebrew's `qt` package.