### PR TITLE
qt6: Handle different signatures of `QANEF::nativeEventFilter`

### DIFF
--- a/src/qt/winshutdownmonitor.cpp
+++ b/src/qt/winshutdownmonitor.cpp
@@ -12,7 +12,11 @@
 
 // If we don't want a message to be processed by Qt, return true and set result to
 // the value that the window procedure should return. Otherwise return false.
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+bool WinShutdownMonitor::nativeEventFilter(const QByteArray &eventType, void *pMessage, qintptr *pnResult)
+#else
 bool WinShutdownMonitor::nativeEventFilter(const QByteArray &eventType, void *pMessage, long *pnResult)
+#endif
 {
        Q_UNUSED(eventType);
 

--- a/src/qt/winshutdownmonitor.h
+++ b/src/qt/winshutdownmonitor.h
@@ -20,7 +20,11 @@ public:
     WinShutdownMonitor(std::function<void()> shutdown_fn) : m_shutdown_fn{std::move(shutdown_fn)} {}
 
     /** Implements QAbstractNativeEventFilter interface for processing Windows messages */
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+    bool nativeEventFilter(const QByteArray &eventType, void *pMessage, qintptr *pnResult) override;
+#else
     bool nativeEventFilter(const QByteArray &eventType, void *pMessage, long *pnResult) override;
+#endif
 
     /** Register the reason for blocking shutdown on Windows to allow clean client exit */
     static void registerShutdownBlockReason(const QString& strReason, const HWND& mainWinId);


### PR DESCRIPTION
Split from https://github.com/bitcoin/bitcoin/pull/30997.

This PR ensures compatibility across all supported Qt versions.

For more details, please refer to https://github.com/qt/qtbase/commit/3b38c73c7ffa71c00c172cf0e05742835a304300.

No behaviour change.