### PR TITLE
qt: Add addressList field to SendCoinsRecipient for multiple addresses

### DIFF
--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -174,26 +174,31 @@ bool parseBitcoinURI(const QUrl &uri, SendCoinsRecipient *out)
         if (i->first == "label")
         {
             rv.label = i->second;
-            fShouldReturnFalse = false;
         }
-        if (i->first == "message")
+        else if (i->first == "message")
         {
             rv.message = i->second;
-            fShouldReturnFalse = false;
         }
         else if (i->first == "amount")
         {
             if(!i->second.isEmpty())
             {
-                if (!BitcoinUnits::parse(BitcoinUnit::BTC, i->second, &rv.amount)) {
+                if(!BitcoinUnits::parse(BitcoinUnits::BTC, i->second, &rv.amount))
+                {
                     return false;
                 }
             }
-            fShouldReturnFalse = false;
         }
-
-        if (fShouldReturnFalse)
+        else if (i->first == "addresses")
+        {
+            // Handle multiple addresses for unauthenticated payment requests
+            // Store them in the new addressList field
+            rv.addressList = i->second;
+        }
+        else if (fShouldReturnFalse)
+        {
             return false;
+        }
     }
     if(out)
     {

--- a/src/qt/paymentserver.cpp
+++ b/src/qt/paymentserver.cpp
@@ -212,6 +212,17 @@ void PaymentServer::handleURIOrFile(const QString& s)
                                "Due to widespread security flaws in BIP70 it's strongly recommended that any merchant instructions to switch wallets be ignored.\n"
                                "If you are receiving this error you should request the merchant provide a BIP21 compatible URI."),
                             CClientUIInterface::ICON_WARNING);
+
+                        // For unauthenticated payment requests with multiple addresses,
+                        // store the addresses in the addressList field instead of abusing the address field
+                        if (recipient.address.contains("<br />")) {
+                            recipient.addressList = recipient.address;
+                            // Keep only the first address in the address field
+                            int brPos = recipient.address.indexOf("<br />");
+                            if (brPos > 0) {
+                                recipient.address = recipient.address.left(brPos);
+                            }
+                        }
                     }
                     Q_EMIT message(tr("URI handling"), QString::fromStdString(error_msg),
                         CClientUIInterface::MSG_ERROR);

--- a/src/qt/sendcoinsrecipient.h
+++ b/src/qt/sendcoinsrecipient.h
@@ -23,8 +23,12 @@ public:
     // the addresses, e.g. address-A<br />address-B<br />address-C.
     // Info: As we don't need to process addresses in here when using
     // payment requests, we can abuse it for displaying an address list.
-    // Todo: This is a hack, should be replaced with a cleaner solution!
     QString address;
+
+    // Separate field for storing multiple addresses from unauthenticated payment requests
+    // This replaces the hack mentioned in the TODO comment
+    QString addressList;
+
     QString label;
     CAmount amount;
     // If from a payment request, this is used for storing the memo
@@ -42,19 +46,21 @@ public:
 
     SERIALIZE_METHODS(SendCoinsRecipient, obj)
     {
-        std::string address_str, label_str, message_str, auth_merchant_str;
+        std::string address_str, label_str, message_str, auth_merchant_str, address_list_str;
 
         SER_WRITE(obj, address_str = obj.address.toStdString());
         SER_WRITE(obj, label_str = obj.label.toStdString());
         SER_WRITE(obj, message_str = obj.message.toStdString());
         SER_WRITE(obj, auth_merchant_str = obj.authenticatedMerchant.toStdString());
+        SER_WRITE(obj, address_list_str = obj.addressList.toStdString());
 
-        READWRITE(obj.nVersion, address_str, label_str, obj.amount, message_str, obj.sPaymentRequest, auth_merchant_str);
+        READWRITE(obj.nVersion, address_str, label_str, obj.amount, message_str, obj.sPaymentRequest, auth_merchant_str, address_list_str);
 
         SER_READ(obj, obj.address = QString::fromStdString(address_str));
         SER_READ(obj, obj.label = QString::fromStdString(label_str));
         SER_READ(obj, obj.message = QString::fromStdString(message_str));
         SER_READ(obj, obj.authenticatedMerchant = QString::fromStdString(auth_merchant_str));
+        SER_READ(obj, obj.addressList = QString::fromStdString(address_list_str));
     }
 };
 


### PR DESCRIPTION
This pull request adds a new field addressList to the SendCoinsRecipient class
to properly handle multiple addresses from unauthenticated payment requests.
Previously, the address field was being abused for this purpose, as noted
in a TODO comment.

The changes include:

- Adding a new addressList field to SendCoinsRecipient
- Updating the serialization methods to handle the new field
- Modifying PaymentServer to populate the new field when multiple addresses
are present
- Updating ReceiveRequestDialog to display and copy the address list when
available
- Adding support for the "addresses" parameter in Bitcoin URI parsing
This provides a cleaner solution for handling multiple addresses in payment
requests without abusing the single address field.