### PR TITLE
qt: doc: adapt outdated binary paths to CMake changes

### DIFF
--- a/src/qt/README.md
+++ b/src/qt/README.md
@@ -120,5 +120,5 @@ sudo apt-get install qtcreator
  - Under `Debuggers`: select `"GDB"` as debugger
 
 8. While in the `Projects` tab, ensure that you have the `bitcoin-qt` executable specified under `Run`
- - If the executable is not specified: click `"Choose..."`, navigate to `src/qt`, and select `bitcoin-qt`
+ - If the executable is not specified: click `"Choose..."`, navigate to `build/bin`, and select `bitcoin-qt`
 9. You're all set! Start developing, building, and debugging the Bitcoin Core GUI

--- a/src/qt/test/wallettests.cpp
+++ b/src/qt/test/wallettests.cpp
@@ -268,9 +268,9 @@ public:
 //
 // This also requires overriding the default minimal Qt platform:
 //
-//     QT_QPA_PLATFORM=xcb     src/qt/test/test_bitcoin-qt  # Linux
-//     QT_QPA_PLATFORM=windows src/qt/test/test_bitcoin-qt  # Windows
-//     QT_QPA_PLATFORM=cocoa   src/qt/test/test_bitcoin-qt  # macOS
+//     QT_QPA_PLATFORM=xcb     build/bin/test_bitcoin-qt  # Linux
+//     QT_QPA_PLATFORM=windows build/bin/test_bitcoin-qt  # Windows
+//     QT_QPA_PLATFORM=cocoa   build/bin/test_bitcoin-qt  # macOS
 void TestGUI(interfaces::Node& node, const std::shared_ptr<CWallet>& wallet)
 {
     // Create widgets for sending coins and listing transactions.


### PR DESCRIPTION
Adapt the qt-related instances of outdated binary paths to `./build/bin/...` (see [#30454](https://github.com/bitcoin/bitcoin/pull/30454) and the more recently merged [#31161](https://github.com/bitcoin/bitcoin/pull/31161)). According to `$ git grep src/qt.*bitcoin` there should be no more left to address.