### PR TITLE
refactor: Post Qt 6 cleanup

### DIFF
--- a/src/qt/addressbookpage.cpp
+++ b/src/qt/addressbookpage.cpp
@@ -15,11 +15,7 @@
 #include <QMenu>
 #include <QMessageBox>
 #include <QSortFilterProxyModel>
-#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
 #include <QRegularExpression>
-#else
-#include <QRegExp>
-#endif
 
 class AddressBookSortFilterProxyModel final : public QSortFilterProxyModel
 {
@@ -47,11 +43,7 @@ protected:
 
         auto address = model->index(row, AddressTableModel::Address, parent);
 
-#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
         const auto pattern = filterRegularExpression();
-#else
-        const auto pattern = filterRegExp();
-#endif
         return (model->data(address).toString().contains(pattern) ||
                 model->data(label).toString().contains(pattern));
     }

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -90,12 +90,7 @@ static void RegisterMetaTypes()
     qRegisterMetaType<std::function<void()>>("std::function<void()>");
     qRegisterMetaType<QMessageBox::Icon>("QMessageBox::Icon");
     qRegisterMetaType<interfaces::BlockAndHeaderTipInfo>("interfaces::BlockAndHeaderTipInfo");
-
-#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
-    qRegisterMetaTypeStreamOperators<BitcoinUnit>("BitcoinUnit");
-#else
     qRegisterMetaType<BitcoinUnit>("BitcoinUnit");
-#endif
 }
 
 static QString GetLangTerritory()
@@ -134,11 +129,7 @@ static void initTranslations(QTranslator &qtTranslatorBase, QTranslator &qtTrans
     // - First load the translator for the base language, without territory
     // - Then load the more specific locale translator
 
-#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
-    const QString translation_path{QLibraryInfo::location(QLibraryInfo::TranslationsPath)};
-#else
     const QString translation_path{QLibraryInfo::path(QLibraryInfo::TranslationsPath)};
-#endif
     // Load e.g. qt_de.qm
     if (qtTranslatorBase.load("qt_" + lang, translation_path)) {
         QApplication::installTranslator(&qtTranslatorBase);
@@ -507,12 +498,6 @@ int GuiMain(int argc, char* argv[])
     /// 1. Basic Qt initialization (not dependent on parameters or configuration)
     Q_INIT_RESOURCE(bitcoin);
     Q_INIT_RESOURCE(bitcoin_locale);
-
-#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
-    // Generate high-dpi pixmaps
-    QApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
-    QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
-#endif
 
 #if defined(QT_QPA_PLATFORM_ANDROID)
     QApplication::setAttribute(Qt::AA_DontUseNativeMenuBar);

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -962,15 +962,6 @@ bool HasPixmap(const QLabel* label)
     return !label->pixmap(Qt::ReturnByValue).isNull();
 }
 
-QImage GetImage(const QLabel* label)
-{
-    if (!HasPixmap(label)) {
-        return QImage();
-    }
-
-    return label->pixmap(Qt::ReturnByValue).toImage();
-}
-
 QString MakeHtmlLink(const QString& source, const QString& link)
 {
     return QString(source).replace(

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -954,20 +954,12 @@ void PopupMenu(QMenu* menu, const QPoint& point, QAction* at_action)
 
 QDateTime StartOfDay(const QDate& date)
 {
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
     return date.startOfDay();
-#else
-    return QDateTime(date);
-#endif
 }
 
 bool HasPixmap(const QLabel* label)
 {
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 15, 0))
     return !label->pixmap(Qt::ReturnByValue).isNull();
-#else
-    return label->pixmap() != nullptr;
-#endif
 }
 
 QImage GetImage(const QLabel* label)
@@ -976,11 +968,7 @@ QImage GetImage(const QLabel* label)
         return QImage();
     }
 
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 15, 0))
     return label->pixmap(Qt::ReturnByValue).toImage();
-#else
-    return label->pixmap()->toImage();
-#endif
 }
 
 QString MakeHtmlLink(const QString& source, const QString& link)

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -347,7 +347,6 @@ namespace GUIUtil
      * QPixmap* QLabel::pixmap() is deprecated since Qt 5.15.
      */
     bool HasPixmap(const QLabel* label);
-    QImage GetImage(const QLabel* label);
 
     /**
      * Splits the string into substrings wherever separator occurs, and returns

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -362,11 +362,7 @@ namespace GUIUtil
     template <typename SeparatorType>
     QStringList SplitSkipEmptyParts(const QString& string, const SeparatorType& separator)
     {
-    #if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
         return string.split(separator, Qt::SkipEmptyParts);
-    #else
-        return string.split(separator, QString::SkipEmptyParts);
-    #endif
     }
 
 

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -349,23 +349,6 @@ namespace GUIUtil
     bool HasPixmap(const QLabel* label);
 
     /**
-     * Splits the string into substrings wherever separator occurs, and returns
-     * the list of those strings. Empty strings do not appear in the result.
-     *
-     * QString::split() signature differs in different Qt versions:
-     *  - QString::SplitBehavior is deprecated since Qt 5.15
-     *  - Qt::SplitBehavior was introduced in Qt 5.14
-     * If {QString|Qt}::SkipEmptyParts behavior is required, use this
-     * function instead of QString::split().
-     */
-    template <typename SeparatorType>
-    QStringList SplitSkipEmptyParts(const QString& string, const SeparatorType& separator)
-    {
-        return string.split(separator, Qt::SkipEmptyParts);
-    }
-
-
-    /**
      * Replaces a plain text link with an HTML tagged one.
      */
     QString MakeHtmlLink(const QString& source, const QString& link);

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -164,11 +164,7 @@ OptionsDialog::OptionsDialog(QWidget* parent, bool enableWallet)
         {
             /** display language strings as "native language - native country/territory (locale name)", e.g. "Deutsch - Deutschland (de)" */
             ui->lang->addItem(locale.nativeLanguageName() + QString(" - ") +
-#if (QT_VERSION >= QT_VERSION_CHECK(6, 2, 0))
                               locale.nativeTerritoryName() +
-#else
-                              locale.nativeCountryName() +
-#endif
                               QString(" (") + langStr + QString(")"), QVariant(langStr));
 
         }

--- a/src/qt/qrimagewidget.cpp
+++ b/src/qt/qrimagewidget.cpp
@@ -92,7 +92,11 @@ bool QRImageWidget::setQR(const QString& data, const QString& text)
 
 QImage QRImageWidget::exportImage()
 {
-    return GUIUtil::GetImage(this);
+    if (!GUIUtil::HasPixmap(this)) {
+        return QImage();
+    }
+
+    return this->pixmap(Qt::ReturnByValue).toImage();
 }
 
 void QRImageWidget::mousePressEvent(QMouseEvent *event)

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -178,13 +178,8 @@ void SendCoinsDialog::setModel(WalletModel *_model)
         connect(ui->confTargetSelector, qOverload<int>(&QComboBox::currentIndexChanged), this, &SendCoinsDialog::updateSmartFeeLabel);
         connect(ui->confTargetSelector, qOverload<int>(&QComboBox::currentIndexChanged), this, &SendCoinsDialog::coinControlUpdateLabels);
 
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 15, 0))
         connect(ui->groupFee, &QButtonGroup::idClicked, this, &SendCoinsDialog::updateFeeSectionControls);
         connect(ui->groupFee, &QButtonGroup::idClicked, this, &SendCoinsDialog::coinControlUpdateLabels);
-#else
-        connect(ui->groupFee, qOverload<int>(&QButtonGroup::buttonClicked), this, &SendCoinsDialog::updateFeeSectionControls);
-        connect(ui->groupFee, qOverload<int>(&QButtonGroup::buttonClicked), this, &SendCoinsDialog::coinControlUpdateLabels);
-#endif
 
         connect(ui->customFee, &BitcoinAmountField::valueChanged, this, &SendCoinsDialog::coinControlUpdateLabels);
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 7, 0))

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -221,7 +221,7 @@ void TransactionView::setModel(WalletModel *_model)
         if (_model->getOptionsModel())
         {
             // Add third party transaction URLs to context menu
-            QStringList listUrls = GUIUtil::SplitSkipEmptyParts(_model->getOptionsModel()->getThirdPartyTxUrls(), "|");
+            QStringList listUrls = _model->getOptionsModel()->getThirdPartyTxUrls().split("|", Qt::SkipEmptyParts);
             bool actions_created = false;
             for (int i = 0; i < listUrls.size(); ++i)
             {

--- a/src/qt/winshutdownmonitor.cpp
+++ b/src/qt/winshutdownmonitor.cpp
@@ -12,11 +12,7 @@
 
 // If we don't want a message to be processed by Qt, return true and set result to
 // the value that the window procedure should return. Otherwise return false.
-#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
 bool WinShutdownMonitor::nativeEventFilter(const QByteArray &eventType, void *pMessage, qintptr *pnResult)
-#else
-bool WinShutdownMonitor::nativeEventFilter(const QByteArray &eventType, void *pMessage, long *pnResult)
-#endif
 {
        Q_UNUSED(eventType);
 

--- a/src/qt/winshutdownmonitor.h
+++ b/src/qt/winshutdownmonitor.h
@@ -20,11 +20,7 @@ public:
     WinShutdownMonitor(std::function<void()> shutdown_fn) : m_shutdown_fn{std::move(shutdown_fn)} {}
 
     /** Implements QAbstractNativeEventFilter interface for processing Windows messages */
-#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
     bool nativeEventFilter(const QByteArray &eventType, void *pMessage, qintptr *pnResult) override;
-#else
-    bool nativeEventFilter(const QByteArray &eventType, void *pMessage, long *pnResult) override;
-#endif
 
     /** Register the reason for blocking shutdown on Windows to allow clean client exit */
     static void registerShutdownBlockReason(const QString& strReason, const HWND& mainWinId);


### PR DESCRIPTION
This PR:
- Removes outdated Qt version-specific code.
- Inlines two functions from `GUIUtil`.