### PR TITLE
interface: Expose load utxo snapshot functionality

### DIFF
--- a/src/interfaces/node.h
+++ b/src/interfaces/node.h
@@ -10,6 +10,7 @@
 #include <logging.h>                   // For BCLog::CategoryMask
 #include <net.h>                       // For NodeId
 #include <net_types.h>                 // For banmap_t
+#include <node/utxo_snapshot.h>        // For SnapshotMetadata
 #include <netaddress.h>                // For Network
 #include <netbase.h>                   // For ConnectionDirection
 #include <support/allocators/secure.h> // For SecureString
@@ -204,6 +205,9 @@ public:
 
     //! List rpc commands.
     virtual std::vector<std::string> listRpcCommands() = 0;
+
+    //! Load and activate a snapshot file
+    virtual bool loadSnapshot(AutoFile& coins_file, const node::SnapshotMetadata& metadata, bool in_memory) = 0;
 
     //! Set RPC timer interface if unset.
     virtual void rpcSetTimerInterfaceIfUnset(RPCTimerInterface* iface) = 0;

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -355,6 +355,11 @@ public:
         return ::tableRPC.execute(req);
     }
     std::vector<std::string> listRpcCommands() override { return ::tableRPC.listCommands(); }
+    bool loadSnapshot(AutoFile& coins_file, const SnapshotMetadata& metadata, bool in_memory) override
+    {
+        auto activation_result{chainman().ActivateSnapshot(coins_file, metadata, in_memory)};
+        return activation_result.has_value();
+    }
     void rpcSetTimerInterfaceIfUnset(RPCTimerInterface* iface) override { RPCSetTimerInterfaceIfUnset(iface); }
     void rpcUnsetTimerInterface(RPCTimerInterface* iface) override { RPCUnsetTimerInterface(iface); }
     std::optional<Coin> getUnspentOutput(const COutPoint& output) override


### PR DESCRIPTION
Expose load/activate AssumeUTXO snapshot functionality so that it can be loaded through the GUI.

This can be tested and viewed in action in the qml repository with legacy code (https://github.com/bitcoin-core/gui-qml/pull/424)

Also for further examination please check out the [POC](https://github.com/D33r-Gee/bitcoin-gui/tree/2025_gui_interfaces_loadsnapshot_poc) branch

<details>
  <summary> POC Ubuntu Screenshots `signet`</summary>

 
![Screenshot 2025-04-28 100528](https://github.com/user-attachments/assets/0d66a076-c4a2-46e5-8796-e0b9f6db79f7)
Launch bitcoin-qt on `signet`
![Screenshot 2025-04-28 100541](https://github.com/user-attachments/assets/a6df2934-a1fc-4890-817f-02059ecb1607)
Navigate to Settings -> Options
![Screenshot 2025-04-28 100559](https://github.com/user-attachments/assets/1d5951d8-6c00-4596-87c4-b64fff0a8c8d)
Click the "Load Snapshot..." button
![Select_file](https://github.com/user-attachments/assets/0873c71f-4a38-41eb-bd00-2a09868044fe)
Navigate to where your snapshot file is. The snapshot was downloaded from [here]( https://bitcoin-snapshots.jaonoctus.dev/)
![Screenshot 2025-04-28 100735](https://github.com/user-attachments/assets/ea0272f1-5769-4ac1-a30d-f4d6779d7426)
Click "Yes"
![Screenshot 2025-04-28 100950](https://github.com/user-attachments/assets/01dbb48d-33b2-4629-a67d-69f1cd11168f)
Wait for the snapshot to load and for this pop-up to appear and click "Ok"
![Screenshot 2025-04-28 101743](https://github.com/user-attachments/assets/dabc9f43-3537-4782-a992-2948fbadd1ea)
Verify the "chain_snapshot" directory is present in your `datadir`

</details>
