### PR TITLE
[DRAFT] Expose AssumeUTXO Load Snapshot Functionality To The GUI

### DIFF
--- a/src/interfaces/node.h
+++ b/src/interfaces/node.h
@@ -12,6 +12,7 @@
 #include <net_types.h>
 #include <netaddress.h>
 #include <netbase.h>
+#include <interfaces/snapshot.h>
 #include <node/utxo_snapshot.h>
 #include <support/allocators/secure.h>
 #include <util/translation.h>

--- a/src/interfaces/node.h
+++ b/src/interfaces/node.h
@@ -12,6 +12,7 @@
 #include <net_types.h>
 #include <netaddress.h>
 #include <netbase.h>
+#include <node/utxo_snapshot.h>
 #include <support/allocators/secure.h>
 #include <util/translation.h>
 
@@ -204,6 +205,9 @@ public:
     //! List rpc commands.
     virtual std::vector<std::string> listRpcCommands() = 0;
 
+    //! UTXO Snapshot interface.
+    virtual std::unique_ptr<Snapshot> snapshot(const fs::path& path) = 0;
+
     //! Get unspent output associated with a transaction.
     virtual std::optional<Coin> getUnspentOutput(const COutPoint& output) = 0;
 
@@ -231,6 +235,10 @@ public:
     //! Register handler for progress messages.
     using ShowProgressFn = std::function<void(const std::string& title, int progress, bool resume_possible)>;
     virtual std::unique_ptr<Handler> handleShowProgress(ShowProgressFn fn) = 0;
+
+     //! Register handler for snapshot load progress.
+    using SnapshotLoadProgressFn = std::function<void(double progress)>;
+    virtual std::unique_ptr<Handler> handleSnapshotLoadProgress(SnapshotLoadProgressFn fn) = 0;
 
     //! Register handler for wallet loader constructed messages.
     using InitWalletFn = std::function<void()>;

--- a/src/interfaces/snapshot.h
+++ b/src/interfaces/snapshot.h
@@ -1,0 +1,40 @@
+// Copyright (c) 2024 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_INTERFACES_SNAPSHOT_H
+#define BITCOIN_INTERFACES_SNAPSHOT_H
+
+#include <memory>
+#include <optional>
+#include <uint256.h>
+
+class CBlockIndex;
+namespace node {
+class SnapshotMetadata;
+}
+
+namespace interfaces {
+
+//! Interface for managing UTXO snapshots.
+class Snapshot
+{
+public:
+    virtual ~Snapshot() = default;
+
+    //! Activate the snapshot, making it the active chainstate.
+    virtual bool activate() = 0;
+
+    //! Get the snapshot metadata.
+    virtual const node::SnapshotMetadata& getMetadata() const = 0;
+
+    //! Get the activation result (block index of the snapshot base).
+    virtual std::optional<const CBlockIndex*> getActivationResult() const = 0;
+
+    //! Get the last error message from activation attempt.
+    virtual std::string getLastError() const = 0;
+};
+
+} // namespace interfaces
+
+#endif // BITCOIN_INTERFACES_SNAPSHOT_H

--- a/src/interfaces/snapshot.h
+++ b/src/interfaces/snapshot.h
@@ -33,6 +33,9 @@ public:
 
     //! Get the last error message from activation attempt.
     virtual std::string getLastError() const = 0;
+
+    //! Get the path of the snapshot.
+    virtual fs::path getPath() const = 0;
 };
 
 } // namespace interfaces

--- a/src/kernel/notifications_interface.h
+++ b/src/kernel/notifications_interface.h
@@ -40,6 +40,7 @@ public:
     [[nodiscard]] virtual InterruptResult blockTip(SynchronizationState state, const CBlockIndex& index, double verification_progress) { return {}; }
     virtual void headerTip(SynchronizationState state, int64_t height, int64_t timestamp, bool presync) {}
     virtual void progress(const bilingual_str& title, int progress_percent, bool resume_possible) {}
+    virtual void snapshotLoadProgress(double progress) {}
     virtual void warningSet(Warning id, const bilingual_str& message) {}
     virtual void warningUnset(Warning id) {}
 

--- a/src/node/interface_ui.cpp
+++ b/src/node/interface_ui.cpp
@@ -23,6 +23,7 @@ struct UISignals {
     boost::signals2::signal<CClientUIInterface::NotifyNetworkActiveChangedSig> NotifyNetworkActiveChanged;
     boost::signals2::signal<CClientUIInterface::NotifyAlertChangedSig> NotifyAlertChanged;
     boost::signals2::signal<CClientUIInterface::ShowProgressSig> ShowProgress;
+    boost::signals2::signal<CClientUIInterface::SnapshotLoadProgressSig> SnapshotLoadProgress;
     boost::signals2::signal<CClientUIInterface::NotifyBlockTipSig> NotifyBlockTip;
     boost::signals2::signal<CClientUIInterface::NotifyHeaderTipSig> NotifyHeaderTip;
     boost::signals2::signal<CClientUIInterface::BannedListChangedSig> BannedListChanged;
@@ -43,6 +44,7 @@ ADD_SIGNALS_IMPL_WRAPPER(NotifyNumConnectionsChanged);
 ADD_SIGNALS_IMPL_WRAPPER(NotifyNetworkActiveChanged);
 ADD_SIGNALS_IMPL_WRAPPER(NotifyAlertChanged);
 ADD_SIGNALS_IMPL_WRAPPER(ShowProgress);
+ADD_SIGNALS_IMPL_WRAPPER(SnapshotLoadProgress);
 ADD_SIGNALS_IMPL_WRAPPER(NotifyBlockTip);
 ADD_SIGNALS_IMPL_WRAPPER(NotifyHeaderTip);
 ADD_SIGNALS_IMPL_WRAPPER(BannedListChanged);
@@ -55,6 +57,7 @@ void CClientUIInterface::NotifyNumConnectionsChanged(int newNumConnections) { re
 void CClientUIInterface::NotifyNetworkActiveChanged(bool networkActive) { return g_ui_signals.NotifyNetworkActiveChanged(networkActive); }
 void CClientUIInterface::NotifyAlertChanged() { return g_ui_signals.NotifyAlertChanged(); }
 void CClientUIInterface::ShowProgress(const std::string& title, int nProgress, bool resume_possible) { return g_ui_signals.ShowProgress(title, nProgress, resume_possible); }
+void CClientUIInterface::SnapshotLoadProgress(double progress) { return g_ui_signals.SnapshotLoadProgress(progress); }
 void CClientUIInterface::NotifyBlockTip(SynchronizationState s, const CBlockIndex& block, double verification_progress) { return g_ui_signals.NotifyBlockTip(s, block, verification_progress); }
 void CClientUIInterface::NotifyHeaderTip(SynchronizationState s, int64_t height, int64_t timestamp, bool presync) { return g_ui_signals.NotifyHeaderTip(s, height, timestamp, presync); }
 void CClientUIInterface::BannedListChanged() { return g_ui_signals.BannedListChanged(); }

--- a/src/node/interface_ui.h
+++ b/src/node/interface_ui.h
@@ -102,6 +102,9 @@ public:
      */
     ADD_SIGNALS_DECL_WRAPPER(ShowProgress, void, const std::string& title, int nProgress, bool resume_possible);
 
+    /** Snapshot load progress. */
+    ADD_SIGNALS_DECL_WRAPPER(SnapshotLoadProgress, void, double progress);
+
     /** New block has been accepted */
     ADD_SIGNALS_DECL_WRAPPER(NotifyBlockTip, void, SynchronizationState, const CBlockIndex& block, double verification_progress);
 

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -153,6 +153,11 @@ public:
         return m_last_error;
     }
 
+    fs::path getPath() const override
+    {
+        return m_path;
+    }
+
 private:
     ChainstateManager& m_chainman;
     fs::path m_path;

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -18,6 +18,7 @@
 #include <interfaces/handler.h>
 #include <interfaces/mining.h>
 #include <interfaces/node.h>
+#include <interfaces/snapshot.h>
 #include <interfaces/types.h>
 #include <interfaces/wallet.h>
 #include <kernel/chain.h>
@@ -38,6 +39,7 @@
 #include <node/kernel_notifications.h>
 #include <node/transaction.h>
 #include <node/types.h>
+#include <node/utxo_snapshot.h>
 #include <node/warnings.h>
 #include <policy/feerate.h>
 #include <policy/fees/block_policy_estimator.h>
@@ -81,6 +83,7 @@ using interfaces::Handler;
 using interfaces::MakeSignalHandler;
 using interfaces::Mining;
 using interfaces::Node;
+using interfaces::Snapshot;
 using interfaces::WalletLoader;
 using kernel::ChainstateRole;
 using node::BlockAssembler;
@@ -92,6 +95,73 @@ namespace node {
 // All members of the classes in this namespace are intentionally public, as the
 // classes themselves are private.
 namespace {
+class SnapshotImpl : public interfaces::Snapshot
+{
+public:
+    SnapshotImpl(ChainstateManager& chainman, const fs::path& path, bool in_memory)
+        : m_chainman(chainman), m_path(path), m_in_memory(in_memory), m_metadata(chainman.GetParams().MessageStart()) {}
+
+    bool activate() override
+    {
+        m_last_error.clear();
+
+        if (!fs::exists(m_path)) {
+            m_last_error = "Snapshot file does not exist";
+            return false;
+        }
+
+        FILE* snapshot_file{fsbridge::fopen(m_path, "rb")};
+        AutoFile afile{snapshot_file};
+        if (afile.IsNull()) {
+            m_last_error = "Unable to open snapshot file for reading";
+            return false;
+        }
+
+        try {
+            afile >> m_metadata;
+        } catch (const std::ios_base::failure& e) {
+            m_last_error = strprintf("Unable to parse metadata: %s", e.what());
+            return false;
+        }
+
+        auto result = m_chainman.ActivateSnapshot(afile, m_metadata, m_in_memory);
+        if (result.has_value()) {
+            m_activation_result = result.value();
+            return true;
+        } else {
+            m_activation_result = std::nullopt;
+            m_last_error = util::ErrorString(result).original;
+            return false;
+        }
+    }
+
+    const node::SnapshotMetadata& getMetadata() const override
+    {
+        return m_metadata;
+    }
+
+    std::optional<const CBlockIndex*> getActivationResult() const override
+    {
+        if (m_activation_result.has_value()) {
+            return m_activation_result;
+        }
+        return std::nullopt;
+    }
+
+    std::string getLastError() const override
+    {
+        return m_last_error;
+    }
+
+private:
+    ChainstateManager& m_chainman;
+    fs::path m_path;
+    bool m_in_memory;
+    node::SnapshotMetadata m_metadata;
+    std::optional<const CBlockIndex*> m_activation_result;
+    std::string m_last_error;
+};
+
 #ifdef ENABLE_EXTERNAL_SIGNER
 class ExternalSignerImpl : public interfaces::ExternalSigner
 {
@@ -353,6 +423,10 @@ public:
         return ::tableRPC.execute(req);
     }
     std::vector<std::string> listRpcCommands() override { return ::tableRPC.listCommands(); }
+    std::unique_ptr<interfaces::Snapshot> snapshot(const fs::path& path) override
+    {
+        return std::make_unique<SnapshotImpl>(chainman(), path, /*in_memory=*/ false);
+    }
     std::optional<Coin> getUnspentOutput(const COutPoint& output) override
     {
         LOCK(::cs_main);
@@ -386,6 +460,10 @@ public:
     std::unique_ptr<Handler> handleShowProgress(ShowProgressFn fn) override
     {
         return MakeSignalHandler(::uiInterface.ShowProgress_connect(fn));
+    }
+    std::unique_ptr<Handler> handleSnapshotLoadProgress(SnapshotLoadProgressFn fn) override
+    {
+        return MakeSignalHandler(::uiInterface.SnapshotLoadProgress_connect(fn));
     }
     std::unique_ptr<Handler> handleInitWallet(InitWalletFn fn) override
     {

--- a/src/node/kernel_notifications.cpp
+++ b/src/node/kernel_notifications.cpp
@@ -77,6 +77,11 @@ void KernelNotifications::progress(const bilingual_str& title, int progress_perc
     uiInterface.ShowProgress(title.translated, progress_percent, resume_possible);
 }
 
+void KernelNotifications::snapshotLoadProgress(double progress)
+{
+    uiInterface.SnapshotLoadProgress(progress);
+}
+
 void KernelNotifications::warningSet(kernel::Warning id, const bilingual_str& message)
 {
     if (m_warnings.Set(id, message)) {

--- a/src/node/kernel_notifications.h
+++ b/src/node/kernel_notifications.h
@@ -41,6 +41,8 @@ public:
 
     void progress(const bilingual_str& title, int progress_percent, bool resume_possible) override;
 
+    void snapshotLoadProgress(double progress) override;
+
     void warningSet(kernel::Warning id, const bilingual_str& message) override;
 
     void warningUnset(kernel::Warning id) override;

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -14,7 +14,9 @@
 #include <interfaces/handler.h>
 #include <interfaces/init.h>
 #include <interfaces/node.h>
+#include <interfaces/snapshot.h>
 #include <logging.h>
+#include <validation.h>
 #include <node/context.h>
 #include <node/interface_ui.h>
 #include <noui.h>
@@ -35,7 +37,6 @@
 #include <util/string.h>
 #include <util/threadnames.h>
 #include <util/translation.h>
-#include <validation.h>
 
 #ifdef ENABLE_WALLET
 #include <qt/paymentserver.h>
@@ -319,6 +320,12 @@ void BitcoinApplication::InitPruneSetting(int64_t prune_MiB)
     optionsModel->SetPruneTargetGB(PruneMiBtoGB(prune_MiB));
 }
 
+void BitcoinApplication::setSnapshotPath(const QString& snapshot_path)
+{
+    qDebug() << "setSnapshotPath called with:" << snapshot_path;
+    m_snapshot_path = snapshot_path;
+}
+
 void BitcoinApplication::requestInitialize()
 {
     qDebug() << __func__ << ": Requesting initialize";
@@ -388,10 +395,10 @@ void BitcoinApplication::initializeResult(bool success, interfaces::BlockAndHead
     delete m_splash;
     m_splash = nullptr;
 
-    // Log this only after AppInitMain finishes, as then logging setup is guaranteed complete
-    qInfo() << "Platform customization:" << platformStyle->getName();
-    clientModel = new ClientModel(node(), optionsModel);
-    window->setClientModel(clientModel, &tip_info);
+        // Log this only after AppInitMain finishes, as then logging setup is guaranteed complete
+        qInfo() << "Platform customization:" << platformStyle->getName();
+        clientModel = new ClientModel(node(), optionsModel, this, m_snapshot_path);
+        window->setClientModel(clientModel, &tip_info);
 
     // If '-min' option passed, start window minimized (iconified) or minimized to tray
     bool start_minimized = gArgs.GetBoolArg("-min", false);
@@ -576,8 +583,9 @@ int GuiMain(int argc, char* argv[])
     // User language is set up: pick a data directory
     bool did_show_intro = false;
     int64_t prune_MiB = 0;  // Intro dialog prune configuration
+    QString snapshot_path;  // Intro dialog snapshot path
     // Gracefully exit if the user cancels
-    if (!Intro::showIfNeeded(did_show_intro, prune_MiB)) return EXIT_SUCCESS;
+    if (!Intro::showIfNeeded(did_show_intro, prune_MiB, snapshot_path)) return EXIT_SUCCESS;
 
     /// 6-7. Parse bitcoin.conf, determine network, switch to network specific
     /// options, and create datadir and settings.json.
@@ -656,6 +664,11 @@ int GuiMain(int argc, char* argv[])
     if (did_show_intro) {
         // Store intro dialog settings other than datadir (network specific)
         app.InitPruneSetting(prune_MiB);
+    }
+
+    // Store snapshot path for later loading after node initialization
+    if (!snapshot_path.isEmpty()) {
+        app.setSnapshotPath(snapshot_path);
     }
 
     try

--- a/src/qt/bitcoin.h
+++ b/src/qt/bitcoin.h
@@ -16,6 +16,8 @@
 
 #include <QApplication>
 
+enum class SynchronizationState;
+
 class BitcoinGUI;
 class ClientModel;
 class NetworkStyle;
@@ -48,6 +50,12 @@ public:
     [[nodiscard]] bool createOptionsModel(bool resetSettings);
     /// Initialize prune setting
     void InitPruneSetting(int64_t prune_MiB);
+    /// Set snapshot path for loading after node initialization
+    void setSnapshotPath(const QString& snapshot_path);
+    /// Test method to manually trigger snapshot loading (for debugging)
+    void testLoadSnapshot();
+    /// Force load snapshot regardless of sync status (for debugging)
+    void forceLoadSnapshot();
     /// Create main window
     void createWindow(const NetworkStyle *networkStyle);
     /// Create splash screen
@@ -65,6 +73,10 @@ public:
 
     /// Setup platform style
     void setupPlatformStyle();
+
+    void loadSnapshotIfNeeded();
+    bool areHeadersSynced() const;
+    void onHeaderTipChanged(SynchronizationState sync_state, interfaces::BlockTip tip, bool presync);
 
     interfaces::Node& node() const { assert(m_node); return *m_node; }
 
@@ -103,6 +115,9 @@ private:
     std::unique_ptr<QWidget> shutdownWindow;
     SplashScreen* m_splash = nullptr;
     std::unique_ptr<interfaces::Node> m_node;
+    QString m_snapshot_path;
+    std::unique_ptr<interfaces::Handler> m_header_tip_handler;
+    QTimer* m_sync_check_timer;
 
     void startThread();
 };

--- a/src/qt/forms/intro.ui
+++ b/src/qt/forms/intro.ui
@@ -272,6 +272,33 @@
     </layout>
    </item>
    <item>
+    <layout class="QHBoxLayout" name="snapshotPathLayout">
+     <item>
+      <widget class="QPushButton" name="getSnapshotPathButton">
+       <property name="text">
+        <string>Snapshot Path:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="snapshotPath"/>
+     </item>
+     <item>
+      <spacer name="snapshotHorizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>

--- a/src/qt/intro.cpp
+++ b/src/qt/intro.cpp
@@ -17,12 +17,15 @@
 
 #include <common/args.h>
 #include <interfaces/node.h>
+#include <interfaces/snapshot.h>
 #include <util/fs_helpers.h>
 #include <validation.h>
 
 #include <QFileDialog>
 #include <QSettings>
 #include <QMessageBox>
+#include <QProgressDialog>
+#include <QApplication>
 
 #include <cmath>
 
@@ -119,9 +122,16 @@ int64_t Intro::getPruneMiB() const
     }
 }
 
-bool Intro::showIfNeeded(bool& did_show_intro, int64_t& prune_MiB)
+QString Intro::getSnapshotPath() const
+{
+    QString snapshot_path = ui->snapshotPath->text();
+    return snapshot_path;
+}
+
+bool Intro::showIfNeeded(bool& did_show_intro, int64_t& prune_MiB, QString& snapshot_path)
 {
     did_show_intro = false;
+    snapshot_path.clear();
 
     QSettings settings;
     /* If data directory provided on command line, no need to look at settings
@@ -171,6 +181,7 @@ bool Intro::showIfNeeded(bool& did_show_intro, int64_t& prune_MiB)
 
         // Additional preferences:
         prune_MiB = intro.getPruneMiB();
+        snapshot_path = intro.getSnapshotPath();
 
         settings.setValue("strDataDir", dataDir);
         settings.setValue("fReset", false);
@@ -251,6 +262,13 @@ void Intro::on_dataDirCustom_clicked()
 {
     ui->dataDirectory->setEnabled(true);
     ui->ellipsisButton->setEnabled(true);
+}
+
+void Intro::on_getSnapshotPathButton_clicked()
+{
+    QString m_snapshot_path = QFileDialog::getOpenFileName(nullptr, tr("Choose snapshot file"), "", tr("Snapshot Files (*.dat);;"));
+    if(!m_snapshot_path.isEmpty())
+        ui->snapshotPath->setText(m_snapshot_path);
 }
 
 void Intro::startThread()

--- a/src/qt/intro.h
+++ b/src/qt/intro.h
@@ -37,6 +37,7 @@ public:
     QString getDataDirectory();
     void setDataDirectory(const QString &dataDir);
     int64_t getPruneMiB() const;
+    QString getSnapshotPath() const;
 
     /**
      * Determine data directory. Let the user choose if the current one doesn't exist.
@@ -48,7 +49,7 @@ public:
      * @note do NOT call global gArgs.GetDataDirNet() before calling this function, this
      * will cause the wrong path to be cached.
      */
-    static bool showIfNeeded(bool& did_show_intro, int64_t& prune_MiB);
+    static bool showIfNeeded(bool& did_show_intro, int64_t& prune_MiB, QString& snapshot_path);
 
 Q_SIGNALS:
     void requestCheck();
@@ -61,6 +62,7 @@ private Q_SLOTS:
     void on_ellipsisButton_clicked();
     void on_dataDirDefault_clicked();
     void on_dataDirCustom_clicked();
+    void on_getSnapshotPathButton_clicked();
 
 private:
     Ui::Intro *ui;
@@ -75,6 +77,7 @@ private:
     int64_t m_required_space_gb{0};
     uint64_t m_bytes_available{0};
     int64_t m_prune_target_gb;
+    QString m_snapshot_path;
 
     void startThread();
     void checkPath(const QString &dataDir);

--- a/src/qt/optionsdialog.h
+++ b/src/qt/optionsdialog.h
@@ -7,6 +7,10 @@
 
 #include <QDialog>
 #include <QValidator>
+#include <QThread>
+#include <QObject>
+#include <QString>
+#include <util/fs.h>
 
 class ClientModel;
 class OptionsModel;
@@ -19,6 +23,13 @@ QT_END_NAMESPACE
 namespace Ui {
 class OptionsDialog;
 }
+
+namespace interfaces {
+class Handler;
+class Node;
+}
+
+class SnapshotLoadWorker;
 
 /** Proxy address widget validator, checks for a valid proxy address.
  */
@@ -58,6 +69,8 @@ private Q_SLOTS:
     void on_openBitcoinConfButton_clicked();
     void on_okButton_clicked();
     void on_cancelButton_clicked();
+    void on_loadSnapshotButton_clicked();
+
 
     void on_showTrayIcon_stateChanged(int state);
 
@@ -77,6 +90,9 @@ private:
     ClientModel* m_client_model{nullptr};
     OptionsModel* model{nullptr};
     QDataWidgetMapper* mapper{nullptr};
+    // std::unique_ptr<interfaces::Handler> m_snapshot_load_handler;
+    QThread* m_snapshot_thread{nullptr};
+    SnapshotLoadWorker* m_snapshot_worker{nullptr};
 };
 
 #endif // BITCOIN_QT_OPTIONSDIALOG_H

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -5843,6 +5843,12 @@ util::Result<void> ChainstateManager::PopulateAndValidateSnapshot(
                 --coins_left;
                 ++coins_processed;
 
+                // Show Snapshot Loading progress
+                if (coins_processed % 100000 == 0 || coins_left == 0) {
+                    double progress = static_cast<double>(coins_processed) / static_cast<double>(coins_count);
+                    GetNotifications().snapshotLoadProgress(progress);
+                }
+
                 if (coins_processed % 1000000 == 0) {
                     LogInfo("[snapshot] %d coins loaded (%.2f%%, %.2f MB)",
                         coins_processed,


### PR DESCRIPTION
based on the QML PR [424](https://github.com/bitcoin-core/gui-qml/pull/424). For evaluation purposes only!

# GUI Integration for UTXO Snapshot Loading

## Overview
This PR adds initial GUI support for loading a UTXO snapshot, building on Bitcoin Core's `assumeutxo` infrastructure.

## What This PR Does

1. Adds a basic GUI interface for loading UTXO snapshots via the Options Dialog panel
2. Provides visual confirmation of snapshot activation
3. Adds a snapshot progress notification bar accessible via a handler

## Implementation Details

### Core Components Modified

1. **Node Interface** (`src/node/interfaces.cpp`)
- Implements `snapshotLoad()` based on the [`loadtxoutset`](https://github.com/bitcoin/bitcoin/blob/14b8dfb2bd5e2ca2b7c0c9a7f7d50e1e60adf75c/src/rpc/blockchain.cpp#L3227) RPC

2. **QT Integration** (`src/qt/optionsdialog.cpp`)
- Manages snapshot loading state and progress
- makes use of a worker class to manage snapshot metadata (src/qt/snapshotmodel.cpp)
- Provides progress updates via a progress bar

### Key Design Decisions

2. **Extensibility**
- Interface designed to accommodate future `assumeutxo` changes
- Error handling framework in place

## Testing Instructions

1. Build
2. Launch Bitcoin Core GUI (bitcoin-qt)
3. Navigate to Settings -> Options
4. Click `Load Snapshot` button
5. Follow pop-up instructions
6. Test with sample snapshot:

https://bitcoin-snapshots.jaonoctus.dev/ (No affiliation with the maintainer of this site. As always "Don't trust! Verify!")

<details>
  <summary> POC Ubuntu Screenshots `signet`</summary>

 
![Screenshot 2025-04-28 100528](https://github.com/user-attachments/assets/0d66a076-c4a2-46e5-8796-e0b9f6db79f7)
Launch bitcoin-qt on `signet`
![Screenshot 2025-04-28 100541](https://github.com/user-attachments/assets/a6df2934-a1fc-4890-817f-02059ecb1607)
Navigate to Settings -> Options
![Screenshot 2025-04-28 100559](https://github.com/user-attachments/assets/1d5951d8-6c00-4596-87c4-b64fff0a8c8d)
Click the "Load Snapshot..." button
![Select_file](https://github.com/user-attachments/assets/0873c71f-4a38-41eb-bd00-2a09868044fe)
Navigate to where your snapshot file is. The snapshot was downloaded from [here]( https://bitcoin-snapshots.jaonoctus.dev/)
![Screenshot 2025-04-28 100735](https://github.com/user-attachments/assets/ea0272f1-5769-4ac1-a30d-f4d6779d7426)
Click "Yes"
![Screenshot 2025-04-28 100950](https://github.com/user-attachments/assets/01dbb48d-33b2-4629-a67d-69f1cd11168f)
Wait for the snapshot to load and for this pop-up to appear and click "Ok"
![Screenshot 2025-04-28 101743](https://github.com/user-attachments/assets/dabc9f43-3537-4782-a992-2948fbadd1ea)
Verify the "chain_snapshot" directory is present in your `datadir`

</details>

### Expected Behavior
- File selection dialog works
- Success/failure state properly displayed
- Node becomes usable while background validation continues

## Notes for Reviewers

- This is a POC so all feedback is welcomed
- I am not a designer so please feel free to chime in if there's a more elegant way to achieve this

This is a work in progress - feedback welcome on the approach and implementation details.