### PR TITLE
qt, docs: Unify term "clipboard"

### DIFF
--- a/src/qt/forms/addressbookpage.ui
+++ b/src/qt/forms/addressbookpage.ui
@@ -78,7 +78,7 @@
      <item>
       <widget class="QPushButton" name="copyAddress">
        <property name="toolTip">
-        <string>Copy the currently selected address to the system clipboard</string>
+        <string>Copy the currently selected address to the clipboard</string>
        </property>
        <property name="text">
         <string>&amp;Copy</string>

--- a/src/qt/forms/signverifymessagedialog.ui
+++ b/src/qt/forms/signverifymessagedialog.ui
@@ -137,7 +137,7 @@
          <item>
           <widget class="QPushButton" name="copySignatureButton_SM">
            <property name="toolTip">
-            <string>Copy the current signature to the system clipboard</string>
+            <string>Copy the current signature to the clipboard</string>
            </property>
            <property name="text">
             <string/>


### PR DESCRIPTION
A translator on Transifex noticed:
> The term "system clipboard" appears twice. The term "clipboard" appears 10 times. Perhaps we could standardize on just saying "clipboard"?

This PR addresses this issue.