### PR TITLE
Use WitnessV0KeyHash in TestAddAddressesToSendBook

### DIFF
--- a/src/qt/test/addressbooktests.cpp
+++ b/src/qt/test/addressbooktests.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022 The Bitcoin Core developers
+// Copyright (c) 2017-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -85,8 +85,7 @@ void TestAddAddressesToSendBook(interfaces::Node& node)
     }
 
     auto build_address{[]() {
-        CKey key = GenerateRandomKey();
-        const PKHash dest{key.GetPubKey()};
+        const WitnessV0KeyHash dest{GenerateRandomKey().GetPubKey()};
         return std::make_pair(dest, QString::fromStdString(EncodeDestination(dest)));
     }};
 


### PR DESCRIPTION
Fixes https://github.com/bitcoin/bitcoin/issues/32558
Fixes https://github.com/bitcoin-core/gui/issues/874

This fixes a bug introduced in commit fafee85358397289aa4c6b799d2603a5d89e83a2, which changed the type of the dummy address from `WitnessV0KeyHash` to `PKHash`. It was expected that this is fine, given that this is just a dummy address. However, the base58 characters can include the substring "io", leading to test failures later on.

Fix it by just using `WitnessV0KeyHash` again.

For reference, a passing test could look like:

```
Model contains 2 rows and 2 columns.
--- Model Data ---
Row 0 : "io - new A\tmxgkqJWAwfUwbgzZUsWrG1stKWV6fDn8YH"
Row 1 : "io - new B\tmhsxP2yrYDQiEncT8HzKxQSFSFJmUsudsP"
------------------
```

A failing test could look like:

```
Model contains 3 rows and 2 columns.
--- Model Data ---
Row 0 : "already here (s)\tmyDFZSKDQdPMMoSQgzkDtq2yioo8DA8qCX" 
Row 1 : "io - new A\tmsAqQKjMrbxYRDhGXBBJ3yUEQxj5Bf5Njz"
Row 2 : "io - new B\tmtALQiit8dw33kznVfHDgE38ohfgz2Pchc"
------------------
FAIL!  : AddressBookTests::addressBookTests() Compared values are not the same
   Actual   (table_view->model()->rowCount()): 3
   Expected (2)                              : 2
   Loc: [qt/test/addressbooktests.cpp(219)]
```
