### PR TITLE
Including exception what() in Runaway dialog box

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -46,7 +46,9 @@
 
 #include <boost/signals2/connection.hpp>
 #include <chrono>
+#include <exception>
 #include <memory>
+#include <string>
 
 #include <QApplication>
 #include <QDebug>
@@ -680,7 +682,13 @@ int GuiMain(int argc, char* argv[])
         }
     } catch (const std::exception& e) {
         PrintExceptionContinue(&e, "Runaway exception");
-        app.handleRunawayException(QString::fromStdString(app.node().getWarnings().translated));
+        std::string message = app.node().getWarnings().translated;
+        const std::string& what = e.what();
+        if (!message.empty() && !what.empty()) {
+            message += "\n\n";
+        }
+        message += what;
+        app.handleRunawayException(QString::fromStdString(message));
     } catch (...) {
         PrintExceptionContinue(nullptr, "Runaway exception");
         app.handleRunawayException(QString::fromStdString(app.node().getWarnings().translated));

--- a/src/qt/initexecutor.cpp
+++ b/src/qt/initexecutor.cpp
@@ -9,6 +9,7 @@
 #include <util/threadnames.h>
 
 #include <exception>
+#include <string>
 
 #include <QDebug>
 #include <QMetaObject>
@@ -34,7 +35,15 @@ InitExecutor::~InitExecutor()
 void InitExecutor::handleRunawayException(const std::exception* e)
 {
     PrintExceptionContinue(e, "Runaway exception");
-    Q_EMIT runawayException(QString::fromStdString(m_node.getWarnings().translated));
+    std::string message = m_node.getWarnings().translated;
+    if (e) {
+        const std::string& what = e->what();
+        if (!message.empty() && !what.empty()) {
+            message += "\n\n";
+        }
+        message += what;
+    }
+    Q_EMIT runawayException(QString::fromStdString(message));
 }
 
 void InitExecutor::initialize()


### PR DESCRIPTION
If an exception happens, including e.what() in the text passed to the dialog box, so that the user can see it.  This is in addition to any text from getWarnings() that might already be present, separated by newlines if so.

This will make it easier for users to find what went wrong and get the help they need, instead of having to tell the user to go back and dig through the debug.log file.
