### PR TITLE
Fix broken navigation link to files documentation in README_doxygen.md

### DIFF
--- a/doc/README_doxygen.md
+++ b/doc/README_doxygen.md
@@ -11,5 +11,5 @@ The software is a community-driven open source project, released under the MIT l
 See https://github.com/bitcoin/bitcoin and https://bitcoincore.org/ for further information about the project.
 
 \section Navigation
-Use <a href="modules.html"><code>Modules</code></a>, <a href="namespaces.html"><code>Namespaces</code></a>, <a href="classes.html"><code>Classes</code></a>, or <a href="files.html"><code>Files</code></a> at the top of the page to start navigating the code.
+Use <a href="modules.html"><code>Modules</code></a>, <a href="namespaces.html"><code>Namespaces</code></a>, <a href="classes.html"><code>Classes</code></a>, or <a href="files.md"><code>Files</code></a> at the top of the page to start navigating the code.
 


### PR DESCRIPTION
Replaced the outdated link to files.html with the correct files.md in the navigation section of README_doxygen.md, ensuring users are directed to the current documentation format.