### PR TITLE
Move `FreespaceChecker` class into its own module

### DIFF
--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -75,6 +75,8 @@ add_library(bitcoinqt STATIC EXCLUDE_FROM_ALL
   clientmodel.h
   csvmodelwriter.cpp
   csvmodelwriter.h
+  freespacechecker.cpp
+  freespacechecker.h
   guiutil.cpp
   guiutil.h
   initexecutor.cpp

--- a/src/qt/freespacechecker.cpp
+++ b/src/qt/freespacechecker.cpp
@@ -1,0 +1,64 @@
+// Copyright (c) 2011-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <qt/freespacechecker.h>
+
+#include <qt/guiutil.h>
+#include <qt/intro.h>
+#include <util/fs.h>
+
+#include <QDir>
+#include <QString>
+
+#include <cstdint>
+
+FreespaceChecker::FreespaceChecker(Intro *_intro)
+{
+    this->intro = _intro;
+}
+
+void FreespaceChecker::check()
+{
+    QString dataDirStr = intro->getPathToCheck();
+    fs::path dataDir = GUIUtil::QStringToPath(dataDirStr);
+    uint64_t freeBytesAvailable = 0;
+    int replyStatus = ST_OK;
+    QString replyMessage = tr("A new data directory will be created.");
+
+    /* Find first parent that exists, so that fs::space does not fail */
+    fs::path parentDir = dataDir;
+    fs::path parentDirOld = fs::path();
+    while(parentDir.has_parent_path() && !fs::exists(parentDir))
+    {
+        parentDir = parentDir.parent_path();
+
+        /* Check if we make any progress, break if not to prevent an infinite loop here */
+        if (parentDirOld == parentDir)
+            break;
+
+        parentDirOld = parentDir;
+    }
+
+    try {
+        freeBytesAvailable = fs::space(parentDir).available;
+        if(fs::exists(dataDir))
+        {
+            if(fs::is_directory(dataDir))
+            {
+                QString separator = "<code>" + QDir::toNativeSeparators("/") + tr("name") + "</code>";
+                replyStatus = ST_OK;
+                replyMessage = tr("Directory already exists. Add %1 if you intend to create a new directory here.").arg(separator);
+            } else {
+                replyStatus = ST_ERROR;
+                replyMessage = tr("Path already exists, and is not a directory.");
+            }
+        }
+    } catch (const fs::filesystem_error&)
+    {
+        /* Parent directory does not exist or is not accessible */
+        replyStatus = ST_ERROR;
+        replyMessage = tr("Cannot create data directory here.");
+    }
+    Q_EMIT reply(replyStatus, replyMessage, freeBytesAvailable);
+}

--- a/src/qt/freespacechecker.cpp
+++ b/src/qt/freespacechecker.cpp
@@ -5,18 +5,12 @@
 #include <qt/freespacechecker.h>
 
 #include <qt/guiutil.h>
-#include <qt/intro.h>
 #include <util/fs.h>
 
 #include <QDir>
 #include <QString>
 
 #include <cstdint>
-
-FreespaceChecker::FreespaceChecker(Intro *_intro)
-{
-    this->intro = _intro;
-}
 
 void FreespaceChecker::check()
 {

--- a/src/qt/freespacechecker.h
+++ b/src/qt/freespacechecker.h
@@ -1,0 +1,46 @@
+// Copyright (c) 2011-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QT_FREESPACECHECKER_H
+#define BITCOIN_QT_FREESPACECHECKER_H
+
+#include <QObject>
+#include <QString>
+#include <QtGlobal>
+
+class Intro;
+
+/* Check free space asynchronously to prevent hanging the UI thread.
+
+   Up to one request to check a path is in flight to this thread; when the check()
+   function runs, the current path is requested from the associated Intro object.
+   The reply is sent back through a signal.
+
+   This ensures that no queue of checking requests is built up while the user is
+   still entering the path, and that always the most recently entered path is checked as
+   soon as the thread becomes available.
+*/
+class FreespaceChecker : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit FreespaceChecker(Intro *intro);
+
+    enum Status {
+        ST_OK,
+        ST_ERROR
+    };
+
+public Q_SLOTS:
+    void check();
+
+Q_SIGNALS:
+    void reply(int status, const QString &message, quint64 available);
+
+private:
+    Intro *intro;
+};
+
+#endif // BITCOIN_QT_FREESPACECHECKER_H

--- a/src/qt/freespacechecker.h
+++ b/src/qt/freespacechecker.h
@@ -9,8 +9,6 @@
 #include <QString>
 #include <QtGlobal>
 
-class Intro;
-
 /* Check free space asynchronously to prevent hanging the UI thread.
 
    Up to one request to check a path is in flight to this thread; when the check()
@@ -26,7 +24,13 @@ class FreespaceChecker : public QObject
     Q_OBJECT
 
 public:
-    explicit FreespaceChecker(Intro *intro);
+    class PathQuery
+    {
+    public:
+        virtual QString getPathToCheck() = 0;
+    };
+
+    explicit FreespaceChecker(PathQuery* intro) : intro{intro} {}
 
     enum Status {
         ST_OK,
@@ -40,7 +44,7 @@ Q_SIGNALS:
     void reply(int status, const QString &message, quint64 available);
 
 private:
-    Intro *intro;
+    PathQuery* intro;
 };
 
 #endif // BITCOIN_QT_FREESPACECHECKER_H

--- a/src/qt/intro.cpp
+++ b/src/qt/intro.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2022 The Bitcoin Core developers
+// Copyright (c) 2011-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -10,6 +10,7 @@
 #include <util/chaintype.h>
 #include <util/fs.h>
 
+#include <qt/freespacechecker.h>
 #include <qt/guiconstants.h>
 #include <qt/guiutil.h>
 #include <qt/optionsmodel.h>
@@ -24,90 +25,6 @@
 #include <QMessageBox>
 
 #include <cmath>
-
-/* Check free space asynchronously to prevent hanging the UI thread.
-
-   Up to one request to check a path is in flight to this thread; when the check()
-   function runs, the current path is requested from the associated Intro object.
-   The reply is sent back through a signal.
-
-   This ensures that no queue of checking requests is built up while the user is
-   still entering the path, and that always the most recently entered path is checked as
-   soon as the thread becomes available.
-*/
-class FreespaceChecker : public QObject
-{
-    Q_OBJECT
-
-public:
-    explicit FreespaceChecker(Intro *intro);
-
-    enum Status {
-        ST_OK,
-        ST_ERROR
-    };
-
-public Q_SLOTS:
-    void check();
-
-Q_SIGNALS:
-    void reply(int status, const QString &message, quint64 available);
-
-private:
-    Intro *intro;
-};
-
-#include <qt/intro.moc>
-
-FreespaceChecker::FreespaceChecker(Intro *_intro)
-{
-    this->intro = _intro;
-}
-
-void FreespaceChecker::check()
-{
-    QString dataDirStr = intro->getPathToCheck();
-    fs::path dataDir = GUIUtil::QStringToPath(dataDirStr);
-    uint64_t freeBytesAvailable = 0;
-    int replyStatus = ST_OK;
-    QString replyMessage = tr("A new data directory will be created.");
-
-    /* Find first parent that exists, so that fs::space does not fail */
-    fs::path parentDir = dataDir;
-    fs::path parentDirOld = fs::path();
-    while(parentDir.has_parent_path() && !fs::exists(parentDir))
-    {
-        parentDir = parentDir.parent_path();
-
-        /* Check if we make any progress, break if not to prevent an infinite loop here */
-        if (parentDirOld == parentDir)
-            break;
-
-        parentDirOld = parentDir;
-    }
-
-    try {
-        freeBytesAvailable = fs::space(parentDir).available;
-        if(fs::exists(dataDir))
-        {
-            if(fs::is_directory(dataDir))
-            {
-                QString separator = "<code>" + QDir::toNativeSeparators("/") + tr("name") + "</code>";
-                replyStatus = ST_OK;
-                replyMessage = tr("Directory already exists. Add %1 if you intend to create a new directory here.").arg(separator);
-            } else {
-                replyStatus = ST_ERROR;
-                replyMessage = tr("Path already exists, and is not a directory.");
-            }
-        }
-    } catch (const fs::filesystem_error&)
-    {
-        /* Parent directory does not exist or is not accessible */
-        replyStatus = ST_ERROR;
-        replyMessage = tr("Cannot create data directory here.");
-    }
-    Q_EMIT reply(replyStatus, replyMessage, freeBytesAvailable);
-}
 
 namespace {
 //! Return pruning size that will be used if automatic pruning is enabled.

--- a/src/qt/intro.h
+++ b/src/qt/intro.h
@@ -5,13 +5,13 @@
 #ifndef BITCOIN_QT_INTRO_H
 #define BITCOIN_QT_INTRO_H
 
+#include <qt/freespacechecker.h>
+
 #include <QDialog>
 #include <QMutex>
 #include <QThread>
 
 static const bool DEFAULT_CHOOSE_DATADIR = false;
-
-class FreespaceChecker;
 
 namespace interfaces {
     class Node;
@@ -25,7 +25,7 @@ namespace Ui {
   Allows the user to choose a data directory,
   in which the wallet and block chain will be stored.
  */
-class Intro : public QDialog
+class Intro : public QDialog, public FreespaceChecker::PathQuery
 {
     Q_OBJECT
 
@@ -78,7 +78,7 @@ private:
 
     void startThread();
     void checkPath(const QString &dataDir);
-    QString getPathToCheck();
+    QString getPathToCheck() override;
     void UpdatePruneLabels(bool prune_checked);
     void UpdateFreeSpaceLabel();
 

--- a/src/qt/intro.h
+++ b/src/qt/intro.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2021 The Bitcoin Core developers
+// Copyright (c) 2011-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/test/lint/lint-circular-dependencies.py
+++ b/test/lint/lint-circular-dependencies.py
@@ -16,6 +16,7 @@ EXPECTED_CIRCULAR_DEPENDENCIES = (
     "node/blockstorage -> validation -> node/blockstorage",
     "node/utxo_snapshot -> validation -> node/utxo_snapshot",
     "qt/addresstablemodel -> qt/walletmodel -> qt/addresstablemodel",
+    "qt/freespacechecker -> qt/intro -> qt/freespacechecker",
     "qt/recentrequeststablemodel -> qt/walletmodel -> qt/recentrequeststablemodel",
     "qt/sendcoinsdialog -> qt/walletmodel -> qt/sendcoinsdialog",
     "qt/transactiontablemodel -> qt/walletmodel -> qt/transactiontablemodel",

--- a/test/lint/lint-circular-dependencies.py
+++ b/test/lint/lint-circular-dependencies.py
@@ -16,7 +16,6 @@ EXPECTED_CIRCULAR_DEPENDENCIES = (
     "node/blockstorage -> validation -> node/blockstorage",
     "node/utxo_snapshot -> validation -> node/utxo_snapshot",
     "qt/addresstablemodel -> qt/walletmodel -> qt/addresstablemodel",
-    "qt/freespacechecker -> qt/intro -> qt/freespacechecker",
     "qt/recentrequeststablemodel -> qt/walletmodel -> qt/recentrequeststablemodel",
     "qt/sendcoinsdialog -> qt/walletmodel -> qt/sendcoinsdialog",
     "qt/transactiontablemodel -> qt/walletmodel -> qt/transactiontablemodel",


### PR DESCRIPTION
For some reason, the MOC compiler in older versions of Qt 6 fails to parse `qt/intro.cpp`, as noted in [this comment](https://github.com/bitcoin/bitcoin/pull/32998#issuecomment-3082011233).

This PR proposes a move-only refactoring to simplify the source structure by eliminating the need for the inline `#include <qt/intro.moc>`, thereby effectively working around the issue.

Required for https://github.com/bitcoin/bitcoin/pull/32998.