### PR TITLE
Add console commands for clearing output and history

### DIFF
--- a/doc/release-notes-gui-882.md
+++ b/doc/release-notes-gui-882.md
@@ -1,0 +1,12 @@
+GUI changes
+-----------
+
+- Added new console commands to the `Debug window -> Console` for improved privacy:
+
+    - `clear` -- clears the console output area
+    - `clear-all` -- clears both output and command history.
+    - `history` -- lists stored command history.
+    - `history-clear` -- clears command history only.
+
+  These additions improve privacy and convenience in shared or long-lived
+  sessions by allowing users to remove sensitive commands and output from view.


### PR DESCRIPTION
Adds new console commands for clearing the screen and managing command history in the GUI RPC console.

Introduces four new commands:

- `clear` - clears the console output area.
- `clear-all` - clears both output and command history.
- `history` - lists stored command history.
- `history-clear` - clears command history only.

Provides explicit, privacy-orientd ways to clear console history and output without altering default behavior.
Useful in shared or long-running sessions.