### PR TITLE
Avoid pathological QT text/markdown behavior...

### DIFF
--- a/src/qt/forms/debugwindow.ui
+++ b/src/qt/forms/debugwindow.ui
@@ -573,7 +573,7 @@
         </layout>
        </item>
        <item>
-        <widget class="QTextEdit" name="messagesWidget">
+        <widget class="PlainCopyTextEdit" name="messagesWidget">
          <property name="minimumSize">
           <size>
            <width>0</width>
@@ -1867,6 +1867,10 @@
    <slots>
     <slot>clear()</slot>
    </slots>
+  </customwidget>
+  <customwidget>
+   <class>PlainCopyTextEdit</class>
+   <extends>QTextEdit</extends>
   </customwidget>
  </customwidgets>
  <resources>

--- a/src/qt/rpcconsole.h
+++ b/src/qt/rpcconsole.h
@@ -15,6 +15,9 @@
 
 #include <QByteArray>
 #include <QCompleter>
+#include <QMimeData>
+#include <QTextDocumentFragment>
+#include <QTextEdit>
 #include <QThread>
 #include <QWidget>
 
@@ -189,6 +192,22 @@ private:
 
 private Q_SLOTS:
     void updateAlerts(const QString& warnings);
+};
+
+/**
+ * A version of QTextEdit that only populates plaintext mime data from a
+ * selection, this avoids some bad behavior in QT's HTML->Markdown conversion.
+ */
+class PlainCopyTextEdit : public QTextEdit {
+    Q_OBJECT
+public:
+    using QTextEdit::QTextEdit;
+protected:
+    QMimeData* createMimeDataFromSelection() const override {
+        auto md = new QMimeData();
+        md->setText(textCursor().selection().toPlainText());
+        return md;
+    }
 };
 
 #endif // BITCOIN_QT_RPCCONSOLE_H


### PR DESCRIPTION
...during text selection by only setting plaintext mime data.

Fixes the OOM described in #887.

The issue is related to the construction of the [`text/markdown`](https://github.com/qt/qtbase/blob/b617d1176593963a2a9ed21dd5d9a63e84a09400/src/widgets/widgets/qwidgettextcontrol.cpp#L3539) MIME data for the selection. Using the `heaptrack` utility, I observed that nearly all of the allocations when reproducing happen in [`QTextMarkdownWriter::writeFrame`](https://github.com/qt/qtbase/blob/b617d1176593963a2a9ed21dd5d9a63e84a09400/src/gui/text/qtextmarkdownwriter.cpp#L95). I am not 100% sure what is causing this issue in QT's conversion of our HTML to markdown; I have tried changing the [HTML tags](https://github.com/bitcoin/bitcoin/blob/689a32197638e92995dd8eb071425715f5fdc3a4/src/qt/rpcconsole.cpp#L916-L924) (e.g. using `<p></p`> and `<ul><li></li></ul>` in place of tables)  used in our `rpcconsole` messages, but the issue recurs.

The solution applied here is to override `createMimeDataFromSelection()` to avoid construction of the (likely never-used anyways) `text/markdown` mime data, and only set plaintext mime data in the clipboard.