### PR TITLE
Fix dark mode detection on Linux

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -505,6 +505,18 @@ int GuiMain(int argc, char* argv[])
     QApplication::setAttribute(Qt::AA_DontUseNativeDialogs);
 #endif
 
+#ifdef Q_OS_LINUX
+    // Enable proper dark mode detection on Linux
+    // This must be done before creating the QApplication
+
+    // Use the system palette (works with GTK integration)
+    if (!qEnvironmentVariableIsSet("QT_QPA_PLATFORMTHEME")) {
+        // Try to use GTK theme integration for better dark mode support
+        // This will be ignored if the gtk platformtheme plugin is not available
+        qputenv("QT_QPA_PLATFORMTHEME", "gtk3");
+    }
+#endif
+
     BitcoinApplication app;
     GUIUtil::LoadFont(QStringLiteral(":/fonts/monospace"));
 


### PR DESCRIPTION
  Enable GTK3 platform theme integration on Linux to properly detect
  system dark/light mode settings. Without this, Qt applications on
  Linux don't automatically adapt to the system theme, unlike macOS
  where it works out of the box.

  The fix sets QT_QPA_PLATFORMTHEME to "gtk3" before QApplication
  initialization, but only if the user hasn't already set a platform
  theme. This respects existing user configurations while providing
  better defaults for desktop environments using GTK (GNOME, Unity,
  XFCE, MATE).

  The change is non-breaking as Qt falls back gracefully if the GTK
  platform theme plugin is unavailable

<!--
*** Please remove the following help text before submitting: ***

Pull requests without a rationale and clear improvement may be closed
immediately.

GUI-related pull requests should be opened against
https://github.com/bitcoin-core/gui
first. See CONTRIBUTING.md
-->

<!--
Please provide clear motivation for your patch and explain how it improves
Bitcoin Core user experience or Bitcoin Core developer experience
significantly:

* Any test improvements or new tests that improve coverage are always welcome.
* All other changes should have accompanying unit tests (see `src/test/`) or
  functional tests (see `test/`). Contributors should note which tests cover
  modified code. If no tests exist for a region of modified code, new tests
  should accompany the change.
* Bug fixes are most welcome when they come with steps to reproduce or an
  explanation of the potential issue as well as reasoning for the way the bug
  was fixed.
* Features are welcome, but might be rejected due to design or scope issues.
  If a feature is based on a lot of dependencies, contributors should first
  consider building the system outside of Bitcoin Core, if possible.
* Refactoring changes are only accepted if they are required for a feature or
  bug fix or otherwise improve developer experience significantly. For example,
  most "code style" refactoring changes require a thorough explanation why they
  are useful, what downsides they have and why they *significantly* improve
  developer experience or avoid serious programming bugs. Note that code style
  is often a subjective matter. Unless they are explicitly mentioned to be
  preferred in the [developer notes](/doc/developer-notes.md), stylistic code
  changes are usually rejected.
-->

<!--
Bitcoin Core has a thorough review process and even the most trivial change
needs to pass a lot of eyes and requires non-zero or even substantial time
effort to review. There is a huge lack of active reviewers on the project, so
patches often sit for a long time.
-->
