### PR TITLE
rpcconsole: display signet challenge

### DIFF
--- a/src/qt/forms/debugwindow.ui
+++ b/src/qt/forms/debugwindow.ui
@@ -210,7 +210,7 @@
         </widget>
        </item>
        <item row="7" column="1" colspan="2">
-        <widget class="QLabel" name="networkName">
+        <widget class="NetworkName" name="networkName">
          <property name="cursor">
           <cursorShape>IBeamCursor</cursorShape>
          </property>
@@ -1871,6 +1871,11 @@
   <customwidget>
    <class>PlainCopyTextEdit</class>
    <extends>QTextEdit</extends>
+  </customwidget>
+  <customwidget>
+   <class>NetworkName</class>
+   <extends>QLabel</extends>
+   <header>qt/rpcconsole.h</header>
   </customwidget>
  </customwidgets>
  <resources>

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -57,6 +57,9 @@ const int INITIAL_TRAFFIC_GRAPH_MINS = 30;
 const QSize FONT_RANGE(4, 40);
 const char fontSizeSettingsKey[] = "consoleFontSize";
 
+const std::string DEFAULT_CHALLENGE_STRING =
+    "512103ad5e0edad18cb1f0fc0d28a3d4f1f3e445640337489abb10404f2d1e086be430210359ef5021964fe22d6f8e05b2463c9540ce96883fe3b278760f048f5189f2e6c452ae";
+
 const struct {
     const char *url;
     const char *source;
@@ -717,6 +720,39 @@ void RPCConsole::setClientModel(ClientModel *model, int bestblock_height, int64_
         ui->blocksDir->setText(model->blocksDir());
         ui->startupTime->setText(model->formatClientStartupTime());
         ui->networkName->setText(QString::fromStdString(Params().GetChainTypeString()));
+        ui->networkName->setWordWrap(true);
+
+        if (Params().GetChainTypeString() == "signet") {
+            std::vector<uint8_t> vChallenge = Params().GetConsensus().signet_challenge;
+            std::string challengeString = HexStr(vChallenge);
+            if (challengeString != DEFAULT_CHALLENGE_STRING) {
+                LogDebug(BCLog::QT, "rpcconsole:challengeString=%s\n", challengeString);
+                if (challengeString.length() > 16) { // a sane minimum
+                    std::string challenge_fingerprint = challengeString.substr(0, 8);
+                    const QString title = tr("Node window - [signet] (%1)").arg(QString::fromStdString(challenge_fingerprint));
+                    // display fingerprint in Node window title
+                    this->setWindowTitle(title);
+                } else {
+                    // A trivial challenge is supported. Example: signetchallenge=51
+                    std::string challenge_fingerprint = challengeString.substr(0, challengeString.length());
+                    const QString title = tr("Node window - [signet] (%1)").arg(QString::fromStdString(challenge_fingerprint));
+                    // display fingerprint in Node window title
+                    this->setWindowTitle(title);
+                }
+                if (challengeString.length() > (size_t)ui->networkName->width()) {
+                    challengeString.insert(0, "\n");  // break after Signet:
+                    challengeString.insert(65, "\n"); // then split at (130/2)
+                }
+                ui->networkName->setToolTip(
+                    tr("%1").arg(QString::fromStdString(challengeString)));
+                ui->networkName->setText(
+                    tr("%1\nChallenge: %2").arg("Signet").arg(QString::fromStdString(challengeString)));
+            } else {
+                ui->networkName->setText(tr("Signet: Default"));
+                ui->networkName->setToolTip(QString());
+                this->setWindowTitle(tr("[signet] Default"));
+            }
+        }
 
         //Setup autocomplete and attach it
         QStringList wordList;

--- a/src/qt/rpcconsole.h
+++ b/src/qt/rpcconsole.h
@@ -15,6 +15,8 @@
 
 #include <QByteArray>
 #include <QCompleter>
+#include <QFontMetrics>
+#include <QLabel>
 #include <QMimeData>
 #include <QTextDocumentFragment>
 #include <QTextEdit>
@@ -207,6 +209,58 @@ protected:
         auto md = new QMimeData();
         md->setText(textCursor().selection().toPlainText());
         return md;
+    }
+};
+
+class NetworkName : public QLabel
+{
+    Q_OBJECT
+
+public:
+    explicit NetworkName(QWidget *parent = nullptr) : QLabel(parent) {}
+
+    void setText(const QString& text) {
+        m_fullText = text;
+        recalculateElidedText();
+    }
+
+    const QString& fullText() const { return m_fullText; }
+    QString selectedText() const {
+        return m_fullText;
+    }
+
+protected:
+    void resizeEvent(QResizeEvent *event) override {
+        QLabel::resizeEvent(event);
+        recalculateElidedText();
+    }
+
+    // Provide the full challenge when Copy&Paste
+    QMimeData* createMimeDataFromSelection() const {
+        auto md = new QMimeData();
+        md->setText(m_fullText);
+        return md;
+    }
+
+private:
+    QString m_fullText;
+
+    void recalculateElidedText() {
+        if (m_fullText.isEmpty()) {
+            QLabel::setText(QString());
+            return;
+        }
+
+        QFontMetrics fm(font());
+        int availableWidth = width()-1;
+        //int availableWidth = contentsRect().width()-1;
+
+        QString elidedText = fm.elidedText(m_fullText, Qt::ElideMiddle, availableWidth);
+
+        if (QLabel::text() != elidedText) {
+            QLabel::setText(elidedText);
+            //QLabel::setText(m_fullText);
+        }
     }
 };
 


### PR DESCRIPTION
### Motivation:
This pull request aims to enhance the RPC console by displaying the signet challenge, providing users with crucial network configuration information directly within the console. This improves usability and clarity, especially for users interacting with custom signet networks.

Use Cases:
1.  **Verifying Signet Configuration:** Users can quickly verify the active signet challenge when connecting to a custom signet, ensuring they are on the intended network.

2.  **Improved User Experience:** For developers and advanced users working with multiple signet environments, having the challenge readily visible in the RPC console reduces the need to look up configuration details elsewhere.
