### PR TITLE
Modernize custom filtering

### DIFF
--- a/src/qt/transactionfilterproxy.cpp
+++ b/src/qt/transactionfilterproxy.cpp
@@ -7,6 +7,8 @@
 #include <qt/transactiontablemodel.h>
 #include <qt/transactionrecord.h>
 
+#include <QtVersionChecks>
+
 #include <algorithm>
 #include <cstdlib>
 #include <optional>
@@ -52,32 +54,77 @@ bool TransactionFilterProxy::filterAcceptsRow(int sourceRow, const QModelIndex &
 
 void TransactionFilterProxy::setDateRange(const std::optional<QDateTime>& from, const std::optional<QDateTime>& to)
 {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 10, 0)
+    beginFilterChange();
+#endif
+
     dateFrom = from;
     dateTo = to;
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 10, 0)
+    endFilterChange(QSortFilterProxyModel::Direction::Rows);
+#else
     invalidateFilter();
+#endif
 }
 
 void TransactionFilterProxy::setSearchString(const QString &search_string)
 {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 10, 0)
+    beginFilterChange();
+#endif
+
     if (m_search_string == search_string) return;
     m_search_string = search_string;
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 10, 0)
+    endFilterChange(QSortFilterProxyModel::Direction::Rows);
+#else
     invalidateFilter();
+#endif
 }
 
 void TransactionFilterProxy::setTypeFilter(quint32 modes)
 {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 10, 0)
+    beginFilterChange();
+#endif
+
     this->typeFilter = modes;
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 10, 0)
+    endFilterChange(QSortFilterProxyModel::Direction::Rows);
+#else
     invalidateFilter();
+#endif
 }
 
 void TransactionFilterProxy::setMinAmount(const CAmount& minimum)
 {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 10, 0)
+    beginFilterChange();
+#endif
+
     this->minAmount = minimum;
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 10, 0)
+    endFilterChange(QSortFilterProxyModel::Direction::Rows);
+#else
     invalidateFilter();
+#endif
 }
 
 void TransactionFilterProxy::setShowInactive(bool _showInactive)
 {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 10, 0)
+    beginFilterChange();
+#endif
+
     this->showInactive = _showInactive;
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 10, 0)
+    endFilterChange(QSortFilterProxyModel::Direction::Rows);
+#else
     invalidateFilter();
+#endif
 }


### PR DESCRIPTION
In [`QSortFilterProxyModel::invalidateFilter()`](https://doc.qt.io/qt-6/qsortfilterproxymodel.html#invalidateFilter) is scheduled for deprecation in Qt 6.13. and emits warnings in Qt 6.10

[`QSortFilterProxyModel::beginFilterChange()`](https://doc.qt.io/qt-6/qsortfilterproxymodel.html#beginFilterChange) was introduced in Qt 6.9.

[`QSortFilterProxyModel::endFilterChange()`](https://doc.qt.io/qt-6/qsortfilterproxymodel.html#endFilterChange) was introduced in Qt 6.10.

Fixes https://github.com/bitcoin/bitcoin/issues/33571.

<img width="724" height="509" alt="image" src="https://github.com/user-attachments/assets/877740c4-7fdf-4478-963c-c639f0b80ad9" />