### PR TITLE
contrib: add desktop file

### DIFF
--- a/contrib/debian/bitcoin-qt.desktop
+++ b/contrib/debian/bitcoin-qt.desktop
@@ -1,0 +1,14 @@
+[Desktop Entry]
+Version=1.0
+Name=Bitcoin Core
+Comment=Connect to the Bitcoin P2P Network
+Comment[de]=Verbinde mit dem Bitcoin peer-to-peer Netzwerk
+Comment[fr]=Bitcoin, monnaie virtuelle cryptographique pair à pair
+Comment[tr]=Bitcoin, eşten eşe kriptografik sanal para birimi
+Exec=bitcoin-qt %u
+Terminal=false
+Type=Application
+Icon=bitcoin128
+MimeType=x-scheme-handler/bitcoin;
+Categories=Office;Finance;P2P;Network;Qt;
+StartupWMClass=Bitcoin-qt


### PR DESCRIPTION
from https://github.com/bitcoin-core/packaging

=> https://github.com/bitcoin-core/packaging/blob/main/debian/bitcoin-qt.desktop

this simplifies packaging, because currently one needs to fetch a desktop file from another repo instead of using just the main source code one
