### PR TITLE
Fix bitcoin-qt visual glitches on Wayland

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -1511,7 +1511,7 @@ void BitcoinGUI::showNormalIfMinimized(bool fToggleHidden)
     if (!isHidden() && !isMinimized() && !GUIUtil::isObscured(this) && fToggleHidden) {
         hide();
     } else {
-        GUIUtil::bringToFront(this);
+        show();
     }
 }
 


### PR DESCRIPTION
The main window (BitcoinGUI) does not need to be passed to bringToFront(), doing so sets Qt::WindowStaysOnTopHint on the main window and causes it to flicker.

Fixes https://github.com/bitcoin-core/gui/issues/903.