### PR TITLE
Remove HD seed reference from blank wallet tooltip

### DIFF
--- a/src/qt/forms/createwalletdialog.ui
+++ b/src/qt/forms/createwalletdialog.ui
@@ -146,7 +146,7 @@
       <item>
        <widget class="QCheckBox" name="blank_wallet_checkbox">
         <property name="toolTip">
-         <string>Make a blank wallet. Blank wallets do not initially have private keys or scripts. Private keys and addresses can be imported, or an HD seed can be set, at a later time.</string>
+         <string>Make a blank wallet. Blank wallets do not initially have private keys or scripts. Private keys and addresses can be imported using descriptors at a later time.</string>
         </property>
         <property name="text">
          <string>Make Blank Wallet</string>


### PR DESCRIPTION
Blank descriptor wallets currently do not have HD seeds and none can be added (or 'set') by the user, so remove the reference in the tooltip.

As I understand it, descriptor wallets don't have a global HD seed and don't store the HD seeds for keys they generate. Currently, no new HD seeds can be added by the user (even for old wallets since `sethdseed` was removed), though it may be possible in the future, eg -  https://github.com/bitcoin/bitcoin/pull/33043