### PR TITLE
Prevent re-execution of sensitive commands from console history

### DIFF
--- a/src/qt/test/rpcnestedtests.cpp
+++ b/src/qt/test/rpcnestedtests.cpp
@@ -86,23 +86,33 @@ void RPCNestedTests::rpcNestedTests()
     QVERIFY(filtered == "getblock(getbestblockhash())[tx][0]");
 
     RPCConsole::RPCParseCommandLine(nullptr, result, "createwallet test true", false, &filtered);
-    QVERIFY(filtered == "createwallet(…)");
+    QVERIFY(filtered == "!createwallet(…)");
     RPCConsole::RPCParseCommandLine(nullptr, result, "createwalletdescriptor abc", false, &filtered);
-    QVERIFY(filtered == "createwalletdescriptor(…)");
+    QVERIFY(filtered == "!createwalletdescriptor(…)");
     RPCConsole::RPCParseCommandLine(nullptr, result, "migratewallet abc abc", false, &filtered);
-    QVERIFY(filtered == "migratewallet(…)");
+    QVERIFY(filtered == "!migratewallet(…)");
     RPCConsole::RPCParseCommandLine(nullptr, result, "signmessagewithprivkey abc", false, &filtered);
-    QVERIFY(filtered == "signmessagewithprivkey(…)");
+    QVERIFY(filtered == "!signmessagewithprivkey(…)");
     RPCConsole::RPCParseCommandLine(nullptr, result, "signmessagewithprivkey abc,def", false, &filtered);
-    QVERIFY(filtered == "signmessagewithprivkey(…)");
+    QVERIFY(filtered == "!signmessagewithprivkey(…)");
     RPCConsole::RPCParseCommandLine(nullptr, result, "signrawtransactionwithkey(abc)", false, &filtered);
-    QVERIFY(filtered == "signrawtransactionwithkey(…)");
+    QVERIFY(filtered == "!signrawtransactionwithkey(…)");
     RPCConsole::RPCParseCommandLine(nullptr, result, "walletpassphrase(help())", false, &filtered);
-    QVERIFY(filtered == "walletpassphrase(…)");
+    QVERIFY(filtered == "!walletpassphrase(…)");
     RPCConsole::RPCParseCommandLine(nullptr, result, "walletpassphrasechange(help(walletpassphrasechange(abc)))", false, &filtered);
-    QVERIFY(filtered == "walletpassphrasechange(…)");
+    QVERIFY(filtered == "!walletpassphrasechange(…)");
     RPCConsole::RPCParseCommandLine(nullptr, result, "help(encryptwallet(abc, def))", false, &filtered);
-    QVERIFY(filtered == "help(encryptwallet(…))");
+    QVERIFY(filtered == "!help(encryptwallet(…))");
+
+    // Test filtering for sensitive commands
+    RPCConsole::RPCParseCommandLine(nullptr, result, "send abc abc", false, &filtered);
+    QVERIFY(filtered == "!send abc abc");
+    RPCConsole::RPCParseCommandLine(nullptr, result, "sendall abc abc", false, &filtered);
+    QVERIFY(filtered == "!sendall abc abc");
+    RPCConsole::RPCParseCommandLine(nullptr, result, "sendmany abc abc", false, &filtered);
+    QVERIFY(filtered == "!sendmany abc abc");
+    RPCConsole::RPCParseCommandLine(nullptr, result, "sendtoaddress abc abc", false, &filtered);
+    QVERIFY(filtered == "!sendtoaddress abc abc");
 
     RPCConsole::RPCExecuteCommandLine(m_node, result, "rpcNestedTest");
     QVERIFY(result == "[]");


### PR DESCRIPTION
Sensitive RPC commands such as `walletpassphrase` or `createwallet`
have their arguments redacted when stored in the console history.
Even though their parameters are hidden, these commands could still
be recalled and executed again, which might lead to unintended or
harmful actions.

This change extends the existing blocking filter that prevents
re-execution of commands considered sensitive or risky when recalled
from history. Such entries are prefixed with a leading character (`!`),
marking them as non-executable. When the user attempts to run them
again from history, the console blocks the action and displays an
informational message. Commands entered manually remain unaffected.

In addition to wallet and key-related RPCs, this filter now also
covers transaction-related commands such as `send`, `sendall`,
`sendmany`, and `sendtoaddress`, which may cause unwanted effects
if repeated from history.

Test coverage has been expanded to verify redaction and blocking
behavior, ensuring that sensitive commands are correctly identified
and prefixed. The console help text has been updated to describe
this functionality.
