### PR TITLE
Revert "gui, qt: brintToFront workaround for Wayland"

### DIFF
--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -405,26 +405,19 @@ bool isObscured(QWidget *w)
 
 void bringToFront(QWidget* w)
 {
-    if (w) {
-        if (QGuiApplication::platformName() == "wayland") {
-            auto flags = w->windowFlags();
-            w->setWindowFlags(flags|Qt::WindowStaysOnTopHint);
-            w->show();
-            w->setWindowFlags(flags);
-            w->show();
-        } else {
 #ifdef Q_OS_MACOS
-            ForceActivation();
+    ForceActivation();
 #endif
-            // activateWindow() (sometimes) helps with keyboard focus on Windows
-            if (w->isMinimized()) {
-                w->showNormal();
-            } else {
-                w->show();
-            }
-            w->activateWindow();
-            w->raise();
+
+    if (w) {
+        // activateWindow() (sometimes) helps with keyboard focus on Windows
+        if (w->isMinimized()) {
+            w->showNormal();
+        } else {
+            w->show();
         }
+        w->activateWindow();
+        w->raise();
     }
 }
 


### PR DESCRIPTION
This PR reverts a Wayland-specific workaround introduced in https://github.com/bitcoin-core/gui/pull/831, which appears to break the UI, as reported in:
- https://github.com/bitcoin/bitcoin/issues/33432
- https://github.com/bitcoin-core/gui/pull/903

An alternative to https://github.com/bitcoin-core/gui/pull/904, as suggested in https://github.com/bitcoin-core/gui/pull/904#discussion_r2435752838.

Fixes https://github.com/bitcoin-core/gui/pull/903.-