### PR TITLE
Defer transaction signing until user clicks Send

### DIFF
--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -281,6 +281,8 @@ bool SendCoinsDialog::PrepareSendText(QString& question_string, QString& informa
     }
 
     // prepare transaction for getting txFee earlier
+    // Create unsigned transaction to support creating unsigned PSBTs.
+    // Signing is deferred until the user clicks "Send".
     m_current_transaction = std::make_unique<WalletModelTransaction>(recipients);
     WalletModel::SendCoinsReturn prepareStatus;
 
@@ -357,7 +359,7 @@ bool SendCoinsDialog::PrepareSendText(QString& question_string, QString& informa
 
         // append transaction size
         //: When reviewing a newly created PSBT (via Send flow), the transaction fee is shown, with "virtual size" of the transaction displayed for context
-        question_string.append(" (" + tr("%1 kvB", "PSBT transaction creation").arg((double)m_current_transaction->getTransactionSize() / 1000, 0, 'g', 3) + "): ");
+        question_string.append(" (" + tr("%1 kvB (unsigned)", "PSBT transaction creation").arg((double)m_current_transaction->getTransactionSize() / 1000, 0, 'g', 3) + "): ");
 
         // append transaction fee value
         question_string.append("<span style='color:#aa0000; font-weight:bold;'>");
@@ -515,6 +517,12 @@ void SendCoinsDialog::sendButtonClicked([[maybe_unused]] bool checked)
         presentPSBT(psbtx);
     } else {
         // "Send" clicked
+        WalletModel::UnlockContext ctx(model->requestUnlock());
+        if (!ctx.isValid()) {
+            fNewRecipientAllowed = true;
+            return;
+        }
+
         assert(!model->wallet().privateKeysDisabled() || model->wallet().hasExternalSigner());
         bool broadcast = true;
         if (model->wallet().hasExternalSigner()) {
@@ -539,6 +547,24 @@ void SendCoinsDialog::sendButtonClicked([[maybe_unused]] bool checked)
                 } else {
                     presentPSBT(psbtx);
                 }
+            }
+        } else {
+            // Sign the transaction now that the user has confirmed they want to send.
+            CMutableTransaction mtx = CMutableTransaction{*(m_current_transaction->getWtx())};
+            PartiallySignedTransaction psbtx(mtx);
+            bool complete = false;
+            // Fill and sign the PSBT
+            const auto err{model->wallet().fillPSBT(std::nullopt, /*sign=*/true, /*bip32derivs=*/false, /*n_signed=*/nullptr, psbtx, complete)};
+            if (err || !complete) {
+                Q_EMIT message(tr("Send Coins"), tr("Failed to sign transaction."),
+                    CClientUIInterface::MSG_ERROR);
+                send_failure = true;
+                broadcast = false;
+            } else {
+                // Extract the signed transaction
+                CHECK_NONFATAL(FinalizeAndExtractPSBT(psbtx, mtx));
+                const CTransactionRef tx = MakeTransactionRef(mtx);
+                m_current_transaction->setWtx(tx);
             }
         }
 

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -268,6 +268,8 @@ bool SendCoinsDialog::PrepareSendText(QString& question_string, QString& informa
     }
 
     // prepare transaction for getting txFee earlier
+    // Create unsigned transaction to support creating unsigned PSBTs.
+    // Signing is deferred until the user clicks "Send".
     m_current_transaction = std::make_unique<WalletModelTransaction>(recipients);
     WalletModel::SendCoinsReturn prepareStatus;
 
@@ -344,7 +346,7 @@ bool SendCoinsDialog::PrepareSendText(QString& question_string, QString& informa
 
         // append transaction size
         //: When reviewing a newly created PSBT (via Send flow), the transaction fee is shown, with "virtual size" of the transaction displayed for context
-        question_string.append(" (" + tr("%1 kvB", "PSBT transaction creation").arg((double)m_current_transaction->getTransactionSize() / 1000, 0, 'g', 3) + "): ");
+        question_string.append(" (" + tr("%1 kvB (unsigned)", "PSBT transaction creation").arg((double)m_current_transaction->getTransactionSize() / 1000, 0, 'g', 3) + "): ");
 
         // append transaction fee value
         question_string.append("<span style='color:#aa0000; font-weight:bold;'>");
@@ -497,6 +499,12 @@ void SendCoinsDialog::sendButtonClicked([[maybe_unused]] bool checked)
         presentPSBT(psbtx);
     } else {
         // "Send" clicked
+        WalletModel::UnlockContext ctx(model->requestUnlock());
+        if (!ctx.isValid()) {
+            fNewRecipientAllowed = true;
+            return;
+        }
+
         assert(!model->wallet().privateKeysDisabled() || model->wallet().hasExternalSigner());
         bool broadcast = true;
         if (model->wallet().hasExternalSigner()) {
@@ -521,6 +529,21 @@ void SendCoinsDialog::sendButtonClicked([[maybe_unused]] bool checked)
                 } else {
                     presentPSBT(psbtx);
                 }
+            }
+        } else {
+            // Sign the transaction now that the user has confirmed they want to send.
+            CMutableTransaction mtx = CMutableTransaction{*(m_current_transaction->getWtx())};
+            PartiallySignedTransaction psbtx(mtx);
+            bool complete = false;
+            const auto err{model->wallet().fillPSBT({.sign = true, .bip32_derivs = false}, /*n_signed=*/nullptr, psbtx, complete)};
+            if (err || !complete) {
+                Q_EMIT message(tr("Send Coins"), tr("Failed to sign transaction."),
+                    CClientUIInterface::MSG_ERROR);
+                send_failure = true;
+                broadcast = false;
+            } else {
+                CHECK_NONFATAL(FinalizeAndExtractPSBT(psbtx, mtx));
+                m_current_transaction->setWtx(MakeTransactionRef(mtx));
             }
         }
 

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -203,7 +203,7 @@ WalletModel::SendCoinsReturn WalletModel::prepareTransaction(WalletModelTransact
 
     try {
         auto& newTx = transaction.getWtx();
-        const auto& res = m_wallet->createTransaction(vecSend, coinControl, /*sign=*/!wallet().privateKeysDisabled(), /*change_pos=*/std::nullopt);
+        const auto& res = m_wallet->createTransaction(vecSend, coinControl, /*sign=*/false, /*change_pos=*/std::nullopt);
         if (!res) {
             Q_EMIT message(tr("Send Coins"), QString::fromStdString(util::ErrorString(res).translated),
                            CClientUIInterface::MSG_ERROR);
@@ -215,6 +215,10 @@ WalletModel::SendCoinsReturn WalletModel::prepareTransaction(WalletModelTransact
         transaction.setTransactionFee(nFeeRequired);
         if (fSubtractFeeFromAmount && newTx) {
             transaction.reassignAmounts(static_cast<int>(res->change_pos.value_or(-1)));
+        }
+
+        if (!fSubtractFeeFromAmount && (total + nFeeRequired) > nBalance) {
+            return SendCoinsReturn(AmountExceedsBalance);
         }
 
         // Reject absurdly high fee. (This can never happen because the

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -203,7 +203,7 @@ WalletModel::SendCoinsReturn WalletModel::prepareTransaction(WalletModelTransact
 
     try {
         auto& newTx = transaction.getWtx();
-        const auto& res = m_wallet->createTransaction(vecSend, coinControl, /*sign=*/!wallet().privateKeysDisabled(), /*change_pos=*/std::nullopt);
+        const auto& res = m_wallet->createTransaction(vecSend, coinControl, /*sign=*/false, /*change_pos=*/std::nullopt);
         if (!res) {
             Q_EMIT message(tr("Send Coins"), QString::fromStdString(util::ErrorString(res).translated),
                            CClientUIInterface::MSG_ERROR);


### PR DESCRIPTION
Fixes [#30070](https://github.com/bitcoin/bitcoin/issues/30070)

When creating an unsigned PSBT from the GUI, the transaction was already signed during preparation, causing legacy inputs to have non-empty scriptSig fields. The PSBT parser then rejects them.

This defers signing until the user clicks "Send" instead of signing during preparation. Fee calculation still works since transactions can be created without signing.

Follows the approach suggested by @achow101 in the issue comments.