### PR TITLE
Improve Chinese translations for peer connection types

### DIFF
--- a/src/qt/locale/bitcoin_zh-Hans.ts
+++ b/src/qt/locale/bitcoin_zh-Hans.ts
@@ -357,17 +357,17 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Manual</source>
         <extracomment>Peer connection type established manually through one of several methods.</extracomment>
-        <translation type="unfinished">手册</translation>
+        <translation type="unfinished">手动连接</translation>
     </message>
     <message>
         <source>Feeler</source>
         <extracomment>Short-lived peer connection type that tests the aliveness of known addresses.</extracomment>
-        <translation type="unfinished">触须</translation>
+        <translation type="unfinished">探测连接</translation>
     </message>
     <message>
         <source>Address Fetch</source>
         <extracomment>Short-lived peer connection type that solicits known addresses from a peer.</extracomment>
-        <translation type="unfinished">地址取回</translation>
+        <translation type="unfinished">地址获取</translation>
     </message>
     <message>
         <source>%1 d</source>

--- a/src/qt/locale/bitcoin_zh-Hant.ts
+++ b/src/qt/locale/bitcoin_zh-Hant.ts
@@ -324,7 +324,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Inbound</source>
         <extracomment>An inbound connection from a peer. An inbound connection is a connection initiated by a peer.</extracomment>
-        <translation type="unfinished">進來</translation>
+        <translation type="unfinished">传入</translation>
     </message>
     <message>
         <source>Block Relay</source>
@@ -334,7 +334,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Manual</source>
         <extracomment>Peer connection type established manually through one of several methods.</extracomment>
-        <translation type="unfinished">手册</translation>
+        <translation type="unfinished">手动连接</translation>
     </message>
     <message>
         <source>%1 h</source>

--- a/src/qt/locale/bitcoin_zh_HK.ts
+++ b/src/qt/locale/bitcoin_zh_HK.ts
@@ -332,7 +332,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Inbound</source>
         <extracomment>An inbound connection from a peer. An inbound connection is a connection initiated by a peer.</extracomment>
-        <translation type="unfinished">進來</translation>
+        <translation type="unfinished">传入</translation>
     </message>
     <message>
         <source>Block Relay</source>
@@ -342,7 +342,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Manual</source>
         <extracomment>Peer connection type established manually through one of several methods.</extracomment>
-        <translation type="unfinished">手册</translation>
+        <translation type="unfinished">手动连接</translation>
     </message>
     <message>
         <source>%1 d</source>

--- a/src/qt/locale/bitcoin_zh_TW.ts
+++ b/src/qt/locale/bitcoin_zh_TW.ts
@@ -332,12 +332,12 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Inbound</source>
         <extracomment>An inbound connection from a peer. An inbound connection is a connection initiated by a peer.</extracomment>
-        <translation type="unfinished">進來</translation>
+        <translation type="unfinished">传入</translation>
     </message>
     <message>
         <source>Outbound</source>
         <extracomment>An outbound connection to a peer. An outbound connection is a connection initiated by us.</extracomment>
-        <translation type="unfinished">出去</translation>
+        <translation type="unfinished">传出</translation>
     </message>
     <message>
         <source>Block Relay</source>
@@ -347,7 +347,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Manual</source>
         <extracomment>Peer connection type established manually through one of several methods.</extracomment>
-        <translation type="unfinished">手册</translation>
+        <translation type="unfinished">手动连接</translation>
     </message>
     <message>
         <source>%1 d</source>


### PR DESCRIPTION
This PR improves several Chinese translations related to peer connection types in the
Bitcoin Core Qt GUI. The existing translations contain a mix of literal interpretations
and colloquial wording that can be misleading or unclear in a technical networking UI.

Specifically:

- "Manual" was translated as "手册", which commonly refers to documentation in Chinese.
  In Bitcoin Core, "Manual" indicates a peer connection that was manually established.
  This PR updates the translation to "手动连接" to accurately reflect its meaning.

- "Feeler" was translated as "触须", a literal but biological metaphor that does not
  clearly convey its function. Feeler connections are short-lived probes used to test
  peer reachability. The translation is updated to "探测连接", which is a commonly
  understood networking term.

- "Address Fetch" was translated as "地址取回", which implies retrieving previously
  owned data. In reality, this connection type requests known addresses from a peer.
  The translation is updated to "地址获取" for accuracy and clarity.

- "Inbound" was translated as "進來", a colloquial verb that is not suitable as a UI
  label. "Inbound" describes a peer-initiated connection direction and is commonly
  represented as "传入" in Chinese networking terminology (paired with "传出" for
  outbound connections). This change also aligns with terminology used in other locale
  files.

These updates improve clarity, technical accuracy, and consistency across the Chinese
UI, reducing potential user confusion without affecting any consensus or networking
logic.
