### PR TITLE
Remove deprecated "Starting Block" from Peer Detail

### DIFF
--- a/src/qt/forms/debugwindow.ui
+++ b/src/qt/forms/debugwindow.ui
@@ -1397,36 +1397,13 @@
                 </widget>
                </item>
                <item row="10" column="0">
-                <widget class="QLabel" name="label_29">
-                 <property name="text">
-                  <string>Starting Block</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="10" column="1">
-                <widget class="QLabel" name="peerHeight">
-                 <property name="cursor">
-                  <cursorShape>IBeamCursor</cursorShape>
-                 </property>
-                 <property name="text">
-                  <string>N/A</string>
-                 </property>
-                 <property name="textFormat">
-                  <enum>Qt::PlainText</enum>
-                 </property>
-                 <property name="textInteractionFlags">
-                  <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-                 </property>
-                </widget>
-               </item>
-               <item row="11" column="0">
                 <widget class="QLabel" name="label_27">
                  <property name="text">
                   <string>Synced Headers</string>
                  </property>
                 </widget>
                </item>
-               <item row="11" column="1">
+               <item row="10" column="1">
                 <widget class="QLabel" name="peerSyncHeight">
                  <property name="cursor">
                   <cursorShape>IBeamCursor</cursorShape>
@@ -1442,14 +1419,14 @@
                  </property>
                 </widget>
                </item>
-               <item row="12" column="0">
+               <item row="11" column="0">
                 <widget class="QLabel" name="label_25">
                  <property name="text">
                   <string>Synced Blocks</string>
                  </property>
                 </widget>
                </item>
-               <item row="12" column="1">
+               <item row="11" column="1">
                 <widget class="QLabel" name="peerCommonHeight">
                  <property name="cursor">
                   <cursorShape>IBeamCursor</cursorShape>
@@ -1465,14 +1442,14 @@
                  </property>
                 </widget>
                </item>
-               <item row="13" column="0">
+               <item row="12" column="0">
                 <widget class="QLabel" name="label_22">
                  <property name="text">
                   <string>Connection Time</string>
                  </property>
                 </widget>
                </item>
-               <item row="13" column="1">
+               <item row="12" column="1">
                 <widget class="QLabel" name="peerConnTime">
                  <property name="cursor">
                   <cursorShape>IBeamCursor</cursorShape>
@@ -1488,7 +1465,7 @@
                  </property>
                 </widget>
                </item>
-               <item row="14" column="0">
+               <item row="13" column="0">
                 <widget class="QLabel" name="peerLastBlockLabel">
                  <property name="toolTip">
                   <string>Elapsed time since a novel block passing initial validity checks was received from this peer.</string>
@@ -1498,7 +1475,7 @@
                  </property>
                 </widget>
                </item>
-               <item row="14" column="1">
+               <item row="13" column="1">
                 <widget class="QLabel" name="peerLastBlock">
                  <property name="cursor">
                   <cursorShape>IBeamCursor</cursorShape>
@@ -1514,7 +1491,7 @@
                  </property>
                 </widget>
                </item>
-               <item row="15" column="0">
+               <item row="14" column="0">
                 <widget class="QLabel" name="peerLastTxLabel">
                  <property name="toolTip">
                   <string extracomment="Tooltip text for the Last Transaction field in the peer details area.">Elapsed time since a novel transaction accepted into our mempool was received from this peer.</string>
@@ -1524,7 +1501,7 @@
                  </property>
                 </widget>
                </item>
-               <item row="15" column="1">
+               <item row="14" column="1">
                 <widget class="QLabel" name="peerLastTx">
                  <property name="cursor">
                   <cursorShape>IBeamCursor</cursorShape>
@@ -1540,14 +1517,14 @@
                  </property>
                 </widget>
                </item>
-               <item row="16" column="0">
+               <item row="15" column="0">
                 <widget class="QLabel" name="label_15">
                  <property name="text">
                   <string>Last Send</string>
                  </property>
                 </widget>
                </item>
-               <item row="16" column="1">
+               <item row="15" column="1">
                 <widget class="QLabel" name="peerLastSend">
                  <property name="cursor">
                   <cursorShape>IBeamCursor</cursorShape>
@@ -1563,14 +1540,14 @@
                  </property>
                 </widget>
                </item>
-               <item row="17" column="0">
+               <item row="16" column="0">
                 <widget class="QLabel" name="label_19">
                  <property name="text">
                   <string>Last Receive</string>
                  </property>
                 </widget>
                </item>
-               <item row="17" column="1">
+               <item row="16" column="1">
                 <widget class="QLabel" name="peerLastRecv">
                  <property name="cursor">
                   <cursorShape>IBeamCursor</cursorShape>
@@ -1586,14 +1563,14 @@
                  </property>
                 </widget>
                </item>
-               <item row="18" column="0">
+               <item row="17" column="0">
                 <widget class="QLabel" name="label_18">
                  <property name="text">
                   <string>Sent</string>
                  </property>
                 </widget>
                </item>
-               <item row="18" column="1">
+               <item row="17" column="1">
                 <widget class="QLabel" name="peerBytesSent">
                  <property name="cursor">
                   <cursorShape>IBeamCursor</cursorShape>
@@ -1609,14 +1586,14 @@
                  </property>
                 </widget>
                </item>
-               <item row="19" column="0">
+               <item row="18" column="0">
                 <widget class="QLabel" name="label_20">
                  <property name="text">
                   <string>Received</string>
                  </property>
                 </widget>
                </item>
-               <item row="19" column="1">
+               <item row="18" column="1">
                 <widget class="QLabel" name="peerBytesRecv">
                  <property name="cursor">
                   <cursorShape>IBeamCursor</cursorShape>
@@ -1632,14 +1609,14 @@
                  </property>
                 </widget>
                </item>
-               <item row="20" column="0">
+               <item row="19" column="0">
                 <widget class="QLabel" name="label_26">
                  <property name="text">
                   <string>Ping Time</string>
                  </property>
                 </widget>
                </item>
-               <item row="20" column="1">
+               <item row="19" column="1">
                 <widget class="QLabel" name="peerPingTime">
                  <property name="cursor">
                   <cursorShape>IBeamCursor</cursorShape>
@@ -1655,7 +1632,7 @@
                  </property>
                 </widget>
                </item>
-               <item row="21" column="0">
+               <item row="20" column="0">
                 <widget class="QLabel" name="peerPingWaitLabel">
                  <property name="toolTip">
                   <string>The duration of a currently outstanding ping.</string>
@@ -1665,7 +1642,7 @@
                  </property>
                 </widget>
                </item>
-               <item row="21" column="1">
+               <item row="20" column="1">
                 <widget class="QLabel" name="peerPingWait">
                  <property name="cursor">
                   <cursorShape>IBeamCursor</cursorShape>
@@ -1681,14 +1658,14 @@
                  </property>
                 </widget>
                </item>
-               <item row="22" column="0">
+               <item row="21" column="0">
                 <widget class="QLabel" name="peerMinPingLabel">
                  <property name="text">
                   <string>Min Ping</string>
                  </property>
                 </widget>
                </item>
-               <item row="22" column="1">
+               <item row="21" column="1">
                 <widget class="QLabel" name="peerMinPing">
                  <property name="cursor">
                   <cursorShape>IBeamCursor</cursorShape>
@@ -1704,14 +1681,14 @@
                  </property>
                 </widget>
                </item>
-               <item row="23" column="0">
+               <item row="22" column="0">
                 <widget class="QLabel" name="label_timeoffset">
                  <property name="text">
                   <string>Time Offset</string>
                  </property>
                 </widget>
                </item>
-               <item row="23" column="1">
+               <item row="22" column="1">
                 <widget class="QLabel" name="timeoffset">
                  <property name="cursor">
                   <cursorShape>IBeamCursor</cursorShape>
@@ -1727,7 +1704,7 @@
                  </property>
                 </widget>
                </item>
-               <item row="24" column="0">
+               <item row="23" column="0">
                 <widget class="QLabel" name="peerMappedASLabel">
                  <property name="toolTip">
                   <string>The mapped Autonomous System used for diversifying peer selection.</string>
@@ -1737,7 +1714,7 @@
                  </property>
                 </widget>
                </item>
-               <item row="24" column="1">
+               <item row="23" column="1">
                 <widget class="QLabel" name="peerMappedAS">
                  <property name="cursor">
                   <cursorShape>IBeamCursor</cursorShape>
@@ -1753,7 +1730,7 @@
                  </property>
                 </widget>
                </item>
-               <item row="25" column="0">
+               <item row="24" column="0">
                 <widget class="QLabel" name="peerAddrRelayEnabledLabel">
                  <property name="toolTip">
                   <string extracomment="Tooltip text for the Address Relay field in the peer details area, which displays whether we relay addresses to this peer (Yes/No).">Whether we relay addresses to this peer.</string>
@@ -1763,7 +1740,7 @@
                  </property>
                 </widget>
                </item>
-               <item row="25" column="1">
+               <item row="24" column="1">
                 <widget class="QLabel" name="peerAddrRelayEnabled">
                  <property name="cursor">
                   <cursorShape>IBeamCursor</cursorShape>
@@ -1779,7 +1756,7 @@
                  </property>
                 </widget>
                </item>
-               <item row="26" column="0">
+               <item row="25" column="0">
                 <widget class="QLabel" name="peerAddrProcessedLabel">
                  <property name="toolTip">
                   <string extracomment="Tooltip text for the Addresses Processed field in the peer details area, which displays the total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).">The total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</string>
@@ -1789,7 +1766,7 @@
                  </property>
                 </widget>
                </item>
-               <item row="26" column="1">
+               <item row="25" column="1">
                 <widget class="QLabel" name="peerAddrProcessed">
                  <property name="cursor">
                   <cursorShape>IBeamCursor</cursorShape>
@@ -1805,7 +1782,7 @@
                  </property>
                 </widget>
                </item>
-               <item row="27" column="0">
+               <item row="26" column="0">
                 <widget class="QLabel" name="peerAddrRateLimitedLabel">
                  <property name="toolTip">
                   <string extracomment="Tooltip text for the Addresses Rate-Limited field in the peer details area, which displays the total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.">The total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</string>
@@ -1815,7 +1792,7 @@
                  </property>
                 </widget>
                </item>
-               <item row="27" column="1">
+               <item row="26" column="1">
                 <widget class="QLabel" name="peerAddrRateLimited">
                  <property name="cursor">
                   <cursorShape>IBeamCursor</cursorShape>
@@ -1831,7 +1808,7 @@
                  </property>
                 </widget>
                </item>
-               <item row="28" column="0">
+               <item row="27" column="0">
                 <spacer name="verticalSpacer_3">
                  <property name="orientation">
                   <enum>Qt::Vertical</enum>

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -1217,7 +1217,6 @@ void RPCConsole::updateDetailWidget()
         } else {
             ui->peerCommonHeight->setText(ts.unknown);
         }
-        ui->peerHeight->setText(QString::number(stats->nodeStateStats.m_starting_height));
         ui->peerPingWait->setText(GUIUtil::formatPingTime(stats->nodeStateStats.m_ping_wait));
         ui->peerAddrRelayEnabled->setText(stats->nodeStateStats.m_addr_relay_enabled ? ts.yes : ts.no);
         ui->peerAddrProcessed->setText(QString::number(stats->nodeStateStats.m_addr_processed));


### PR DESCRIPTION
the `startingheight` rpc field got deprecated in https://github.com/bitcoin/bitcoin/pull/34197
this pr removes it from peer detail
