### PR TITLE
Fix transactions disable problem

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -737,6 +737,8 @@ void BitcoinGUI::enableHistoryAction(bool privacy)
     if (walletFrame->currentWalletModel()) {
         historyAction->setEnabled(!privacy);
         if (historyAction->isChecked()) gotoOverviewPage();
+    } else if (privacy) {
+        historyAction->setEnabled(false);
     }
 }
 


### PR DESCRIPTION
- In bitcoin-qt, there is under Settings the "Mask values" option
- When a wallet is open and the "Mask values" checkbox is checked, the "Transactions" tab is disabled
- When no wallet was open and the "Mask values" checkbox was checked and a wallet was opened, the "Transactions" tab was enabled
- This fix changes this, so that there is always the same behavior
- The "Transactions" tab is now always disabled when the "Mask values" checkbox is checked
- This fix is manually tested on the fork
