### PR TITLE
Add "Hide conflicted" checkbox to Transactions tab

### DIFF
--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -23,6 +23,7 @@
 #include <optional>
 
 #include <QApplication>
+#include <QCheckBox>
 #include <QComboBox>
 #include <QDateTimeEdit>
 #include <QDesktopServices>
@@ -88,6 +89,12 @@ TransactionView::TransactionView(const PlatformStyle *platformStyle, QWidget *pa
     typeWidget->addItem(tr("Other"), TransactionFilterProxy::TYPE(TransactionRecord::Other));
 
     hlayout->addWidget(typeWidget);
+
+    hlayout->addSpacing(14);
+    hideConflictedWidget = new QCheckBox(tr("Hide conflicted"), this);
+    hideConflictedWidget->setToolTip(tr("Whether to hide conflicted transactions"));
+    hlayout->addWidget(hideConflictedWidget);
+    hlayout->addSpacing(14);
 
     search_widget = new QLineEdit(this);
     search_widget->setPlaceholderText(tr("Enter address, transaction id, or label to search"));
@@ -173,6 +180,9 @@ TransactionView::TransactionView(const PlatformStyle *platformStyle, QWidget *pa
 
     connect(dateWidget, qOverload<int>(&QComboBox::activated), this, &TransactionView::chooseDate);
     connect(typeWidget, qOverload<int>(&QComboBox::activated), this, &TransactionView::chooseType);
+    connect(hideConflictedWidget, &QCheckBox::toggled, this, [this](bool checked) {
+        if (transactionProxyModel) transactionProxyModel->setShowInactive(!checked);
+    });
     connect(amountWidget, &QLineEdit::textChanged, amount_typing_delay, qOverload<>(&QTimer::start));
     connect(amount_typing_delay, &QTimer::timeout, this, &TransactionView::changedAmount);
     connect(search_widget, &QLineEdit::textChanged, prefix_typing_delay, qOverload<>(&QTimer::start));

--- a/src/qt/transactionview.h
+++ b/src/qt/transactionview.h
@@ -19,6 +19,7 @@ class TransactionFilterProxy;
 class WalletModel;
 
 QT_BEGIN_NAMESPACE
+class QCheckBox;
 class QComboBox;
 class QDateTimeEdit;
 class QFrame;
@@ -71,6 +72,7 @@ private:
 
     QComboBox *dateWidget;
     QComboBox *typeWidget;
+    QCheckBox *hideConflictedWidget;
     QLineEdit *search_widget;
     QLineEdit *amountWidget;
 


### PR DESCRIPTION
Conflicted transactions can accumulate in the wallet over time. These transactions clutter the transaction list and cannot be filtered out.

While the Overview page already hides conflicted transactions using `TransactionFilterProxy::setShowInactive(false)`, the Transactions tab has no equivalent option, forcing users to scroll through potentially many obsolete entries.

This PR adds a "Hide conflicted" checkbox to the Transactions tab filter row, allowing users to toggle visibility of conflicted transactions. The implementation reuses the existing `setShowInactive()` function.

**Before:** 
Users must manually scroll past conflicted transactions with no filtering option. 

**After:** 
A checkbox in the filter row lets users hide conflicted transactions with one click.

<img width="981" height="109" alt="image" src="https://github.com/user-attachments/assets/50596a8c-fb71-452c-bc8a-bc67efc23168" />