### PR TITLE
Replace three dots with ellipsis

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -496,7 +496,7 @@ void BitcoinGUI::createActions()
                 action->setEnabled(false);
             }
             m_migrate_wallet_menu->addSeparator();
-            QAction* restore_migrate_file_action = m_migrate_wallet_menu->addAction(tr("Restore and Migrate Wallet File..."));
+            QAction* restore_migrate_file_action = m_migrate_wallet_menu->addAction(tr("Restore and Migrate Wallet File…"));
             restore_migrate_file_action->setEnabled(true);
 
             connect(restore_migrate_file_action, &QAction::triggered, [this] {


### PR DESCRIPTION
From the translator's [comment](https://app.transifex.com/bitcoin/bitcoin/translate/#pl/qt-translation-031x/611215465/) on Transifex:
> Source text has 3 dots, instead of 3-dot character. Most commonly used form is the 3-dot character: …
You could consider updating it.