### PR TITLE
Use plurals where necessary

### DIFF
--- a/src/qt/psbtoperationsdialog.cpp
+++ b/src/qt/psbtoperationsdialog.cpp
@@ -98,7 +98,7 @@ void PSBTOperationsDialog::signTransaction()
     } else if (!complete && n_signed < 1) {
         showStatus(tr("Could not sign any more inputs."), StatusLevel::WARN);
     } else if (!complete) {
-        showStatus(tr("Signed %1 inputs, but more signatures are still required.").arg(n_signed),
+        showStatus(tr("Signed %n input(s), but more signatures are still required.", "", n_signed),
             StatusLevel::INFO);
     } else {
         showStatus(tr("Signed transaction successfully. Transaction is ready to broadcast."),
@@ -219,7 +219,7 @@ QString PSBTOperationsDialog::renderTransaction(const PartiallySignedTransaction
     size_t num_unsigned = CountPSBTUnsignedInputs(psbtx);
     if (num_unsigned > 0) {
         tx_description.append("<br><br>");
-        tx_description.append(tr("Transaction has %1 unsigned inputs.").arg(QString::number(num_unsigned)));
+        tx_description.append(tr("Transaction has %n unsigned input(s).", "", num_unsigned));
     }
 
     return tx_description;


### PR DESCRIPTION
This PR fixes pluralization strings in the GUI. These issues were identified during the translation process on Transifex:

- https://app.transifex.com/bitcoin/bitcoin/translate/#pl/qt-translation-031x/611215775

- https://app.transifex.com/bitcoin/bitcoin/translate/#pl/qt-translation-031x/611215760 