### PR TITLE
Fix issues with new create wallet dialogue

### DIFF
--- a/src/qt/createwalletdialog.cpp
+++ b/src/qt/createwalletdialog.cpp
@@ -77,7 +77,7 @@ CreateWalletDialog::CreateWalletDialog(QWidget* parent) :
     connect(ui->blank_wallet_checkbox, &QCheckBox::toggled, [this](bool checked) {
         // Disable the disable_privkeys_checkbox when blank_wallet_checkbox is checked
         // as blank-ness only pertains to wallets with private keys.
-        ui->disable_privkeys_checkbox->setEnabled(!checked);
+        ui->disable_privkeys_checkbox->setEnabled(!checked && !ui->encrypt_wallet_checkbox->isChecked());
         if (checked) {
             ui->disable_privkeys_checkbox->setChecked(false);
         }

--- a/src/qt/forms/createwalletdialog.ui
+++ b/src/qt/forms/createwalletdialog.ui
@@ -86,7 +86,7 @@
    <item>
     <widget class="QCheckBox" name="encrypt_wallet_checkbox">
      <property name="toolTip">
-      <string>Encrypt the wallet. The wallet will be encrypted with a passphrase of your choice.</string>
+      <string>Encrypt the wallet's private key with a passphrase of your choice. Other wallet data such as transaction history will not be encrypted.</string>
      </property>
      <property name="text">
       <string>Encrypt Wallet</string>


### PR DESCRIPTION
With this PR, I aim to fix #151.

As @Rspigler noted in [the issue](https://github.com/bitcoin-core/gui/issues/151#issue-766874552):
1. When creating a new wallet, the UI offers an option to "encrypt wallet", which is misleading, because only private keys are encrypted and not other wallet data.
2. There are issues with the options for Disable Private Keys and Make Blank Wallet being disabled/enabled in ways that don't make sense.

Point number one is still an issue. However, as @vasild mentioned [here](https://github.com/bitcoin-core/gui/issues/151#issuecomment-3569746495), point number 2 is no longer happening as of 17072f7. They [point out another inconsistency](https://github.com/bitcoin-core/gui/issues/151#issuecomment-3569746495) where:
- User chooses "Encrypt Wallet"
	- This disables "Disable Private Keys" in an unchecked state
- User chooses "Make Blank Wallet"
- Uses unchecks "Make Blank Wallet"
	- This enables "Disable Private Keys", allowing it to be checked

This PR fixes @Rspigler's point number one by changing the "Encrypt Wallet" tooltip to clarify that it encrypts the private key rather than the wallet. It also fixes @vasild's noted inconsistency where the checkbox becomes re-enabled.

### Rationale
I considered for a moment that it might be more technically accurately to say "encrypt private key" instead of "encrypt wallet". However, I counted 27 instances of user-facing strings that describe encrypting the wallet. Users might be accustomed to the feature being called "encrypt wallet", so changing the text all across the app felt drastic, IMHO. Therefore, I thought we could simply provide some clarification in the tooltip that encrypting the wallet specifically means encrypting the private keys, but not other wallet metadata.

### Testing
I successfully built the application with each commit of this PR, and I ran `ctest --test-dir build` to verify all the tests passed.
### First PR
This is my first time opening a PR to Bitcoin Core. I've done my research on best practices, but I probably made errors. Happy to correct anything I may have missed.