### PR TITLE
bugfix: truncate header sync percentage

### DIFF
--- a/src/qt/modaloverlay.cpp
+++ b/src/qt/modaloverlay.cpp
@@ -163,12 +163,14 @@ void ModalOverlay::tipUpdate(int count, const QDateTime& blockDate, double nVeri
 
 void ModalOverlay::UpdateHeaderSyncLabel() {
     int est_headers_left = bestHeaderDate.secsTo(QDateTime::currentDateTime()) / Params().GetConsensus().nPowTargetSpacing;
-    ui->numberOfBlocksLeft->setText(tr("Unknown. Syncing Headers (%1, %2%)…").arg(bestHeaderHeight).arg(QString::number(100.0 / (bestHeaderHeight + est_headers_left) * bestHeaderHeight, 'f', 1)));
+    const int pct = bestHeaderHeight ? static_cast<int>(1000LL * bestHeaderHeight / (bestHeaderHeight + est_headers_left)) : 0;
+    ui->numberOfBlocksLeft->setText(tr("Unknown. Syncing Headers (%1, %2%)…").arg(bestHeaderHeight).arg(QStringLiteral("%1.%2").arg(pct / 10).arg(pct % 10)));
 }
 
 void ModalOverlay::UpdateHeaderPresyncLabel(int height, const QDateTime& blockDate) {
     int est_headers_left = blockDate.secsTo(QDateTime::currentDateTime()) / Params().GetConsensus().nPowTargetSpacing;
-    ui->numberOfBlocksLeft->setText(tr("Unknown. Pre-syncing Headers (%1, %2%)…").arg(height).arg(QString::number(100.0 / (height + est_headers_left) * height, 'f', 1)));
+    const int pct = height ? static_cast<int>(1000LL * height / (height + est_headers_left)) : 0;
+    ui->numberOfBlocksLeft->setText(tr("Unknown. Pre-syncing Headers (%1, %2%)…").arg(height).arg(QStringLiteral("%1.%2").arg(pct / 10).arg(pct % 10)));
 }
 
 void ModalOverlay::toggleVisibility()


### PR DESCRIPTION
<!--
*** Please remove the following help text before submitting: ***

Pull requests without a rationale and clear improvement may be closed
immediately.

GUI-related pull requests should be opened against
https://github.com/bitcoin-core/gui
first. See CONTRIBUTING.md
-->

<!--
Please provide clear motivation for your patch and explain how it improves
Bitcoin Core user experience or Bitcoin Core developer experience
significantly:

* Any test improvements or new tests that improve coverage are always welcome.
* All other changes should have accompanying unit tests (see `src/test/`) or
  functional tests (see `test/`). Contributors should note which tests cover
  modified code. If no tests exist for a region of modified code, new tests
  should accompany the change.
* Bug fixes are most welcome when they come with steps to reproduce or an
  explanation of the potential issue as well as reasoning for the way the bug
  was fixed.
* Features are welcome, but might be rejected due to design or scope issues.
  If a feature is based on a lot of dependencies, contributors should first
  consider building the system outside of Bitcoin Core, if possible.
* Refactoring changes are only accepted if they are required for a feature or
  bug fix or otherwise improve developer experience significantly. For example,
  most "code style" refactoring changes require a thorough explanation why they
  are useful, what downsides they have and why they *significantly* improve
  developer experience or avoid serious programming bugs. Note that code style
  is often a subjective matter. Unless they are explicitly mentioned to be
  preferred in the [developer notes](/doc/developer-notes.md), stylistic code
  changes are usually rejected.
-->


During IBD, if `LoadingBlocks()` is true (e.g. during a chainstate rebuild after a crash), the node rejects incoming headers from peers. The GUI has headers loaded from the block index on disk, but `bestHeaderDate` becomes stale over time.

After ~4 hours (`HEADER_HEIGHT_DELTA_SYNC * nPowTargetSpacing`), the time-based heuristic in `modaloverlay.cpp` considers headers as "not synced" and falls into the `else` branch, displaying "Unknown" for both blocks remaining and estimated time. Meanwhile, `UpdateHeaderSyncLabel()` computes a percentage that rounds up to 100.0%, creating a contradictory display: `"Unknown. Syncing Headers (942188, 100.0%)"`. Please read issue #65 for more context.

 This patch truncates the percentage to one decimal place instead of rounding, so it only shows 100.0% when headers are truly up to date. The same fix is applied to
  `UpdateHeaderPresyncLabel()` for consistency.

Fixes https://github.com/bitcoin-core/gui/issues/65 .
<!--
Bitcoin Core has a thorough review process and even the most trivial change
needs to pass a lot of eyes and requires non-zero or even substantial time
effort to review. There is a huge lack of active reviewers on the project, so
patches often sit for a long time.
-->
