### PR TITLE
qt: Preserve headers presync progress

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -1161,9 +1161,21 @@ void BitcoinGUI::setNumBlocks(int count, const QDateTime& blockDate, double nVer
     switch (blockSource) {
         case BlockSource::NETWORK:
             if (synctype == SyncType::HEADER_PRESYNC) {
+                m_headers_presync_active = true;
+                m_headers_presync_height = count;
+                m_headers_presync_block_date = blockDate;
                 updateHeadersPresyncProgressLabel(count, blockDate);
                 return;
-            } else if (synctype == SyncType::HEADER_SYNC) {
+            }
+            if (m_headers_presync_active) {
+                const int64_t headers_height{synctype == SyncType::HEADER_SYNC ? count : clientModel->getHeaderTipHeight()};
+                if (headers_height < m_headers_presync_height) {
+                    updateHeadersPresyncProgressLabel(m_headers_presync_height, m_headers_presync_block_date);
+                    return;
+                }
+                m_headers_presync_active = false;
+            }
+            if (synctype == SyncType::HEADER_SYNC) {
                 updateHeadersSyncProgressLabel();
                 return;
             }

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -183,6 +183,9 @@ private:
     /** Keep track of previous number of blocks, to detect progress */
     int prevBlocks = 0;
     int spinnerFrame = 0;
+    bool m_headers_presync_active{false};
+    int64_t m_headers_presync_height{0};
+    QDateTime m_headers_presync_block_date;
 
     const PlatformStyle *platformStyle;
     const NetworkStyle* const m_network_style;

--- a/src/qt/modaloverlay.cpp
+++ b/src/qt/modaloverlay.cpp
@@ -85,18 +85,36 @@ bool ModalOverlay::event(QEvent* ev) {
 
 void ModalOverlay::setKnownBestHeight(int count, const QDateTime& blockDate, bool presync)
 {
+    if (presync) {
+        m_headers_presync_active = true;
+        m_headers_presync_height = count;
+        m_headers_presync_date = blockDate;
+        UpdateHeaderPresyncLabel(count, blockDate);
+        return;
+    }
+
+    if (m_headers_presync_active) {
+        if (count < m_headers_presync_height) {
+            UpdateHeaderPresyncLabel(m_headers_presync_height, m_headers_presync_date);
+            return;
+        }
+        m_headers_presync_active = false;
+    }
+
     if (!presync && count > bestHeaderHeight) {
         bestHeaderHeight = count;
         bestHeaderDate = blockDate;
         UpdateHeaderSyncLabel();
     }
-    if (presync) {
-        UpdateHeaderPresyncLabel(count, blockDate);
-    }
 }
 
 void ModalOverlay::tipUpdate(int count, const QDateTime& blockDate, double nVerificationProgress)
 {
+    if (m_headers_presync_active) {
+        UpdateHeaderPresyncLabel(m_headers_presync_height, m_headers_presync_date);
+        return;
+    }
+
     QDateTime currentDate = QDateTime::currentDateTime();
 
     // keep a vector of samples of verification progress at height
@@ -163,12 +181,16 @@ void ModalOverlay::tipUpdate(int count, const QDateTime& blockDate, double nVeri
 
 void ModalOverlay::UpdateHeaderSyncLabel() {
     int est_headers_left = bestHeaderDate.secsTo(QDateTime::currentDateTime()) / Params().GetConsensus().nPowTargetSpacing;
+    ui->labelSyncDone->setText(tr("Progress"));
     ui->numberOfBlocksLeft->setText(tr("Unknown. Syncing Headers (%1, %2%)…").arg(bestHeaderHeight).arg(QString::number(100.0 / (bestHeaderHeight + est_headers_left) * bestHeaderHeight, 'f', 1)));
 }
 
 void ModalOverlay::UpdateHeaderPresyncLabel(int height, const QDateTime& blockDate) {
     int est_headers_left = blockDate.secsTo(QDateTime::currentDateTime()) / Params().GetConsensus().nPowTargetSpacing;
-    ui->numberOfBlocksLeft->setText(tr("Unknown. Pre-syncing Headers (%1, %2%)…").arg(height).arg(QString::number(100.0 / (height + est_headers_left) * height, 'f', 1)));
+    const QString progress{QString::number(100.0 / (height + est_headers_left) * height, 'f', 1)};
+    ui->labelSyncDone->setText(tr("Headers pre-sync progress"));
+    ui->percentageProgress->setText(progress + "%");
+    ui->numberOfBlocksLeft->setText(tr("Unknown. Pre-syncing Headers (%1, %2%)…").arg(height).arg(progress));
 }
 
 void ModalOverlay::toggleVisibility()

--- a/src/qt/modaloverlay.h
+++ b/src/qt/modaloverlay.h
@@ -47,6 +47,9 @@ private:
     Ui::ModalOverlay *ui;
     int bestHeaderHeight{0}; // best known height (based on the headers)
     QDateTime bestHeaderDate;
+    bool m_headers_presync_active{false};
+    int m_headers_presync_height{0};
+    QDateTime m_headers_presync_date;
     QVector<QPair<qint64, double> > blockProcessTime;
     bool layerIsVisible{false};
     bool userClosed{false};

--- a/src/qt/test/CMakeLists.txt
+++ b/src/qt/test/CMakeLists.txt
@@ -6,6 +6,7 @@ set(CMAKE_AUTOMOC_MOC_OPTIONS "-p${CMAKE_CURRENT_SOURCE_DIR}")
 
 add_executable(test_bitcoin-qt
   apptests.cpp
+  modaloverlaytests.cpp
   optiontests.cpp
   rpcnestedtests.cpp
   test_main.cpp

--- a/src/qt/test/modaloverlaytests.cpp
+++ b/src/qt/test/modaloverlaytests.cpp
@@ -1,0 +1,46 @@
+// Copyright (c) 2026-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <qt/test/modaloverlaytests.h>
+
+#include <qt/modaloverlay.h>
+
+#include <QDateTime>
+#include <QLabel>
+#include <QTest>
+
+void ModalOverlayTests::headersPresyncProgressStaysVisible()
+{
+    ModalOverlay overlay{/*enable_wallet=*/false, /*parent=*/nullptr};
+    QLabel* blocks_left{overlay.findChild<QLabel*>("numberOfBlocksLeft")};
+    QLabel* progress_label{overlay.findChild<QLabel*>("labelSyncDone")};
+    QLabel* progress_value{overlay.findChild<QLabel*>("percentageProgress")};
+    QVERIFY(blocks_left);
+    QVERIFY(progress_label);
+    QVERIFY(progress_value);
+
+    const QDateTime presync_date{QDateTime::currentDateTime().addSecs(-3600)};
+    overlay.setKnownBestHeight(/*count=*/1000, presync_date, /*presync=*/true);
+
+    QVERIFY(blocks_left->text().contains("Pre-syncing Headers"));
+    QVERIFY(blocks_left->text().contains("1000"));
+    QCOMPARE(progress_label->text(), QString("Headers pre-sync progress"));
+    QVERIFY(!progress_value->text().isEmpty());
+    QVERIFY(progress_value->text() != QString("100.00%"));
+
+    overlay.setKnownBestHeight(/*count=*/100, presync_date.addSecs(-1800), /*presync=*/false);
+    QVERIFY(blocks_left->text().contains("Pre-syncing Headers"));
+    QVERIFY(blocks_left->text().contains("1000"));
+    QCOMPARE(progress_label->text(), QString("Headers pre-sync progress"));
+
+    overlay.tipUpdate(/*count=*/0, presync_date.addSecs(-3600), /*nVerificationProgress=*/1.0);
+    QVERIFY(blocks_left->text().contains("Pre-syncing Headers"));
+    QCOMPARE(progress_label->text(), QString("Headers pre-sync progress"));
+    QVERIFY(progress_value->text() != QString("100.00%"));
+
+    overlay.setKnownBestHeight(/*count=*/1000, presync_date, /*presync=*/false);
+    QVERIFY(blocks_left->text().contains("Syncing Headers"));
+    QVERIFY(!blocks_left->text().contains("Pre-syncing Headers"));
+    QCOMPARE(progress_label->text(), QString("Progress"));
+}

--- a/src/qt/test/modaloverlaytests.h
+++ b/src/qt/test/modaloverlaytests.h
@@ -1,0 +1,18 @@
+// Copyright (c) 2026-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QT_TEST_MODALOVERLAYTESTS_H
+#define BITCOIN_QT_TEST_MODALOVERLAYTESTS_H
+
+#include <QObject>
+
+class ModalOverlayTests : public QObject
+{
+    Q_OBJECT
+
+private Q_SLOTS:
+    void headersPresyncProgressStaysVisible();
+};
+
+#endif // BITCOIN_QT_TEST_MODALOVERLAYTESTS_H

--- a/src/qt/test/test_main.cpp
+++ b/src/qt/test/test_main.cpp
@@ -9,6 +9,7 @@
 #include <qt/bitcoin.h>
 #include <qt/guiconstants.h>
 #include <qt/test/apptests.h>
+#include <qt/test/modaloverlaytests.h>
 #include <qt/test/optiontests.h>
 #include <qt/test/rpcnestedtests.h>
 #include <qt/test/uritests.h>
@@ -78,6 +79,9 @@ int main(int argc, char* argv[])
 
         AppTests app_tests(app);
         num_test_failures += QTest::qExec(&app_tests);
+
+        ModalOverlayTests modal_overlay_tests;
+        num_test_failures += QTest::qExec(&modal_overlay_tests);
 
         OptionTests options_tests(app.node());
         num_test_failures += QTest::qExec(&options_tests);


### PR DESCRIPTION
## Summary

During headers pre-sync, the pre-sync height and the accepted-header height can describe different phases of initial sync. The GUI previously allowed both `HEADER_PRESYNC` and normal header/block sync updates to repaint the same status and modal overlay labels.

As a result, an active `Pre-syncing Headers (...)` display could be replaced by a lower `Syncing Headers (...)` accepted-header progress value while headers pre-sync was still active. The modal overlay could also continue showing normal block verification progress during headers pre-sync.

This PR keeps the headers pre-sync display active until accepted headers catch up, then restores normal header/block sync display behavior. It also labels modal progress as headers pre-sync progress during that phase instead of showing stale block verification progress.

This is a GUI display-only change. It does not change header validation, block validation, peer behavior, block download, or sync state.

## Testing

- `cmake -B build-qt -DCMAKE_BUILD_TYPE=Debug -DBUILD_GUI=ON -DBUILD_TESTS=ON -DBUILD_GUI_TESTS=ON -DBUILD_BENCH=OFF -DBUILD_FUZZ_BINARY=OFF`
- `cmake --build build-qt --target test_bitcoin-qt -j"$(sysctl -n hw.ncpu)"`
- `ulimit -n 10240 && ctest --test-dir build-qt -R test_bitcoin-qt --output-on-failure`

The new regression coverage is `ModalOverlayTests::headersPresyncProgressStaysVisible`.
