### PR TITLE
gui: show wallet name in progress messages

### DIFF
--- a/src/qt/walletcontroller.cpp
+++ b/src/qt/walletcontroller.cpp
@@ -375,6 +375,8 @@ LoadWalletsActivity::LoadWalletsActivity(WalletController* wallet_controller, QW
 
 void LoadWalletsActivity::load(bool show_loading_minimized)
 {
+    // No specific wallet name is shown here because multiple wallets may be
+    // loaded simultaneously when syncing the GUI with the node's wallet list.
     showProgressDialog(
         //: Title of progress window which is displayed when wallets are being loaded.
         tr("Load Wallets"),

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -283,7 +283,7 @@ std::shared_ptr<CWallet> LoadWalletInternal(WalletContext& context, const std::s
             return nullptr;
         }
 
-        context.chain->initMessage(_("Loading wallet…"));
+        context.chain->initMessage(strprintf("[%s] %s", name.empty() ? std::string{_("default wallet")} : name, _("Loading wallet…")));
         std::shared_ptr<CWallet> wallet = CWallet::LoadExisting(context, name, std::move(database), error, warnings);
         if (!wallet) {
             error = Untranslated("Wallet loading failed.") + Untranslated(" ") + error;
@@ -416,7 +416,7 @@ std::shared_ptr<CWallet> CreateWallet(WalletContext& context, const std::string&
     }
 
     // Make the wallet
-    context.chain->initMessage(_("Creating wallet…"));
+    context.chain->initMessage(strprintf("[%s] %s", name, _("Creating wallet…")));
     std::shared_ptr<CWallet> wallet = CWallet::CreateNew(context, name, std::move(database), wallet_creation_flags, born_encrypted, error, warnings);
     if (!wallet) {
         error = Untranslated("Wallet creation failed.") + Untranslated(" ") + error;
@@ -3288,7 +3288,7 @@ bool CWallet::AttachChain(const std::shared_ptr<CWallet>& walletInstance, interf
             }
         }
 
-        chain.initMessage(_("Rescanning…"));
+        chain.initMessage(strprintf("[%s] %s", walletInstance->DisplayName(), _("Rescanning…")));
         walletInstance->WalletLogPrintf("Rescanning last %i blocks (from block %i)...\n", *tip_height - rescan_height, rescan_height);
 
         {


### PR DESCRIPTION
## What

Include the wallet display name in the `initMessage` calls made during
wallet loading so the splash screen clearly identifies which wallet is
being processed:

- `LoadWalletInternal`: `"Loading wallet…"` → `"[wallet_name] Loading wallet…"`
- `CreateWallet`: `"Creating wallet…"` → `"[wallet_name] Creating wallet…"`
- `CWallet::AttachChain`: `"Rescanning…"` → `"[wallet_name] Rescanning…"` *(primary fix)*

For unnamed (default) wallets, `DisplayName()` already returns the
translated `"default wallet"` string, handling that case correctly.

A comment is added to `LoadWalletsActivity::load()` explaining why no
specific wallet name is shown there — it loads multiple wallets
simultaneously from the node's wallet list.

## Why

When a wallet that has not been synchronized recently is opened — either
via `settings.json` at startup or via File > Open Wallet — the splash
screen shows a bare `"Rescanning…"` with no indication of which wallet
is being scanned. Users with multiple wallets have no way to know which
one is being processed without checking the debug log.

The `ShowProgress` calls inside `ScanForWalletTransactions` already use
`"[wallet_name] Rescanning…"` (lines 1888/1903/2008); this change makes
the preceding `initMessage` consistent with them.

Fixes #259