### PR TITLE
bugfix: Close transaction detail windows when switching wallets

### DIFF
--- a/src/qt/test/wallettests.cpp
+++ b/src/qt/test/wallettests.cpp
@@ -245,6 +245,37 @@ public:
 
 };
 
+void TestCloseTransactionDialogs(TransactionView& transactionView, const Txid& txid)
+{
+    // Select a transaction row in the view.
+    QTableView* table = transactionView.findChild<QTableView*>("transactionView");
+    QModelIndex index = FindTx(*table->selectionModel()->model(), txid);
+    QVERIFY2(index.isValid(), "Could not find txid for dialog test");
+    table->selectionModel()->select(index, QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows);
+
+    // Open the transaction details dialog.
+    bool invoked = QMetaObject::invokeMethod(&transactionView, "showDetails");
+    QVERIFY(invoked);
+
+    // Verify a TransactionDescDialog is now open.
+    int open_count = 0;
+    for (QWidget* widget : QApplication::topLevelWidgets()) {
+        if (widget->inherits("TransactionDescDialog")) ++open_count;
+    }
+    QCOMPARE(open_count, 1);
+
+    // Simulate wallet switch: close open dialogs.
+    transactionView.closeOpenedDialogs();
+    qApp->processEvents();
+
+    // Verify the dialog is gone.
+    int closed_count = 0;
+    for (QWidget* widget : QApplication::topLevelWidgets()) {
+        if (widget->inherits("TransactionDescDialog")) ++closed_count;
+    }
+    QCOMPARE(closed_count, 0);
+}
+
 //! Simple qt wallet tests.
 //
 // Test widgets can be debugged interactively calling show() on them and
@@ -292,6 +323,9 @@ void TestGUI(interfaces::Node& node, const std::shared_ptr<CWallet>& wallet)
     BumpFee(transactionView, txid2, /*expectDisabled=*/false, /*expectError=*/{}, /*cancel=*/true);
     BumpFee(transactionView, txid2, /*expectDisabled=*/false, /*expectError=*/{}, /*cancel=*/false);
     BumpFee(transactionView, txid2, /*expectDisabled=*/true, /*expectError=*/"already bumped", /*cancel=*/false);
+
+    // Verify transaction detail dialogs are closed when the wallet view is hidden (e.g. on wallet switch).
+    TestCloseTransactionDialogs(transactionView, txid1);
 
     // Check current balance on OverviewPage
     OverviewPage overviewPage(platformStyle.get());

--- a/src/qt/walletframe.cpp
+++ b/src/qt/walletframe.cpp
@@ -98,6 +98,7 @@ void WalletFrame::setCurrentWallet(WalletModel* wallet_model)
         QSizePolicy sp = view_about_to_hide->sizePolicy();
         sp.setHorizontalPolicy(QSizePolicy::Ignored);
         view_about_to_hide->setSizePolicy(sp);
+        view_about_to_hide->closeTransactionDialogs();
     }
 
     WalletView *walletView = mapWalletViews.value(wallet_model);

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -284,3 +284,8 @@ void WalletView::disableTransactionView(bool disable)
 {
     transactionView->setDisabled(disable);
 }
+
+void WalletView::closeTransactionDialogs()
+{
+    transactionView->closeOpenedDialogs();
+}

--- a/src/qt/walletview.h
+++ b/src/qt/walletview.h
@@ -107,6 +107,9 @@ public Q_SLOTS:
     /** Show progress dialog e.g. for rescan */
     void showProgress(const QString &title, int nProgress);
 
+    /** Close all open transaction detail dialogs for this wallet view. */
+    void closeTransactionDialogs();
+
 private Q_SLOTS:
     void disableTransactionView(bool disable);
 


### PR DESCRIPTION
<details>
<summary>When the user switches to a different wallet, any open transaction detail windows (<code>TransactionDescDialog</code>) from the previous wallet's view remain visible. The dialogs are backed by the outgoing wallet's data but stay on screen, which is confusing.</summary>
<img width="1017" height="646" alt="before" src="https://github.com/user-attachments/assets/6d183d77-1cee-4bf1-9271-2c2cc6b76d92" />
</details>
<details>
<summary>Fix by adding <code>WalletView::closeTransactionDialogs()</code> (delegating to the existing <code>TransactionView::closeOpenedDialogs()</code>) and calling it from <code>WalletFrame::setCurrentWallet()</code> when hiding the outgoing view.</summary>
<img width="1017" height="646" alt="after" src="https://github.com/user-attachments/assets/2774aa08-c912-40c8-8ca6-64b8469c0364" />
</details>

A Qt test was added to verify that open transaction detail dialogs are closed when `closeOpenedDialogs()` is called.


_Possible follow-up_: remembering which transaction detail windows were open per wallet and restore them when switching back to that wallet.