### PR TITLE
qt: prevent console hang on large RPC responses

### DIFF
--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -414,6 +414,18 @@ void RPCExecutor::request(const QString &command, const QString& wallet_name)
             return;
         }
 
+        // Avoid passing a very large string to the Qt text widget. Appending
+        // many megabytes of HTML to QTextEdit causes the UI thread to hang
+        // while the document is re-laid-out. Direct the user to bitcoin-cli
+        // for commands whose output exceeds the display limit.
+        if (result.size() > 1_MiB) {
+            Q_EMIT reply(RPCConsole::CMD_REPLY,
+                QString("Response too large to display (%1 bytes). "
+                        "Use bitcoin-cli to retrieve the full result.")
+                    .arg(result.size()));
+            return;
+        }
+
         Q_EMIT reply(RPCConsole::CMD_REPLY, QString::fromStdString(result));
     }
     catch (UniValue& objError)

--- a/src/qt/test/rpcnestedtests.cpp
+++ b/src/qt/test/rpcnestedtests.cpp
@@ -9,6 +9,7 @@
 #include <qt/rpcconsole.h>
 #include <rpc/server.h>
 #include <test/util/setup_common.h>
+#include <util/byte_units.h>
 #include <univalue.h>
 
 #include <QTest>
@@ -34,8 +35,27 @@ static RPCMethod rpcNestedTest_rpc()
     };
 }
 
+// Returns a hex string larger than the RPCExecutor display limit (1 MiB) to
+// exercise the large-output path. RPCExecuteCommandLine returns the full
+// result; the truncation for display is enforced by RPCExecutor::request().
+static RPCMethod rpcLargeOutput_rpc()
+{
+    return RPCMethod{
+        "rpcLargeOutput",
+        "return a string larger than 1 MiB",
+        {},
+        RPCResult{RPCResult::Type::STR_HEX, "", ""},
+        RPCExamples{""},
+        [](const RPCMethod& self, const JSONRPCRequest& request) -> UniValue {
+            // 1 MiB + 1 byte of hex characters
+            return UniValue{std::string(1_MiB + 1, 'a')};
+        },
+    };
+}
+
 static const CRPCCommand vRPCCommands[] = {
     {"rpcNestedTest", &rpcNestedTest_rpc},
+    {"rpcLargeOutput", &rpcLargeOutput_rpc},
 };
 
 void RPCNestedTests::rpcNestedTests()
@@ -139,4 +159,10 @@ void RPCNestedTests::rpcNestedTests()
     QVERIFY_EXCEPTION_THROWN(RPCConsole::RPCExecuteCommandLine(m_node, result, "rpcNestedTest abc,,abc"), std::runtime_error); //don't tolerate empty arguments when using ,
     QVERIFY_EXCEPTION_THROWN(RPCConsole::RPCExecuteCommandLine(m_node, result, "rpcNestedTest(abc,,abc)"), std::runtime_error); //don't tolerate empty arguments when using ,
     QVERIFY_EXCEPTION_THROWN(RPCConsole::RPCExecuteCommandLine(m_node, result, "rpcNestedTest(abc,,)"), std::runtime_error); //don't tolerate empty arguments when using ,
+
+    // Verify that RPCExecuteCommandLine returns the full result for large
+    // outputs. The size guard lives in RPCExecutor::request() and only affects
+    // what is rendered in the console widget, not the underlying RPC call.
+    RPCConsole::RPCExecuteCommandLine(m_node, result, "rpcLargeOutput");
+    QVERIFY(result.size() > 1_MiB);
 }


### PR DESCRIPTION
## Problem

Fixes #932.

Running `getrawtransaction` on a very large non-standard transaction in the bitcoin-qt console causes the GUI to become completely unresponsive.

Reproduction:

getrawtransaction 30794005e228089a56cca58b6ad85e8cc0667cdc06b0ee6f9fe72aa19f50acd2


The transaction is ~3.98 MB and sits in block 938523. Entering the command above leaves the node window frozen until the process is killed. Reported in #932.

## Root cause

The hang is not in the node or the RPC execution path. It occurs in the Qt UI thread after the result is delivered to the console widget.

Two operations in `RPCConsole::message()` scale badly with payload size:

1. `GUIUtil::HtmlEscape()` processes the result string character-by-character. A 3.98 MB transaction encodes to ~7.96 MB of  hex, all of which this function walks before returning.

2. `QTextEdit::append()` is then called with an HTML string of the same magnitude. Qt re-lays-out the entire text document on each call; for a payload this size the layout pass does not complete in any practical amount of time, stalling the event loop indefinitely.

## Fix

Add a 1 MiB size guard in `RPCExecutor::request()`, immediately after `RPCExecuteCommandLine()` returns and before `QString::fromStdString()` is called. When the result exceeds the limit the widget receives a short notice instead of the raw output:

Response too large to display (7962624 bytes). Use bitcoin-cli to retrieve the full result.


Because the guard fires before `QString` conversion, the oversized string is never converted to UTF-16, never HTML-escaped, and never handed to the text widget.

The 1 MiB threshold:
- reuses the `_MiB` literal already present in this file (`ui->lineEdit->setMaxLength(16_MiB)`)
- is well above any realistic interactive debugging output
- is well below the ~7.96 MiB that triggers the hang

## Tests

A mock RPC command `rpcLargeOutput` is registered in `src/qt/test/rpcnestedtests.cpp`. It returns a string of `1_MiB + 1` bytes. The test asserts that `RPCExecuteCommandLine` returns the complete result unmodified, confirming the size guard in
`RPCExecutor::request()` does not affect the underlying RPC call, only what is rendered in the console widget.