### PR TITLE
qt: warn about rescan in wallet migration dialogs

### DIFF
--- a/src/qt/walletcontroller.cpp
+++ b/src/qt/walletcontroller.cpp
@@ -448,7 +448,10 @@ void MigrateWalletActivity::do_migrate(const std::string& name)
         if (dlg.exec() == QDialog::Rejected) return;
     }
 
-    showProgressDialog(tr("Migrate Wallet"), tr("Migrating Wallet <b>%1</b>…").arg(GUIUtil::HtmlEscape(name)));
+    showProgressDialog(tr("Migrate Wallet"),
+        tr("Migrating Wallet <b>%1</b>…<br><br>"
+           "A blockchain rescan will follow and may take a significant amount of time.")
+            .arg(GUIUtil::HtmlEscape(name)));
 
     QTimer::singleShot(0, worker(), [this, name, passphrase] {
         auto res{node().walletLoader().migrateWallet(name, passphrase)};
@@ -481,7 +484,9 @@ void MigrateWalletActivity::migrate(const std::string& name)
                 "If this wallet contains any solvable but not watched scripts, a different and new wallet will be created which contains those scripts.\n\n"
                 "The migration process will create a backup of the wallet before migrating. This backup file will be named "
                 "<wallet name>-<timestamp>.legacy.bak and can be found in the directory for this wallet. In the event of "
-                "an incorrect migration, the backup can be restored with the \"Restore Wallet\" functionality."));
+                "an incorrect migration, the backup can be restored with the \"Restore Wallet\" functionality.\n\n"
+                "After migration, the wallet will be rescanned for transactions. Depending on the size of the blockchain "
+                "and whether block filter indexes are available, this rescan may take a significant amount of time."));
     box.setStandardButtons(QMessageBox::Yes|QMessageBox::Cancel);
     box.setDefaultButton(QMessageBox::Yes);
     if (box.exec() != QMessageBox::Yes) return;
@@ -502,7 +507,9 @@ void MigrateWalletActivity::restore_and_migrate(const fs::path& path, const std:
                 "If this wallet contains any solvable but not watched scripts, a different and new wallet will be created which contains those scripts.\n\n"
                 "The migration process will create a backup of the wallet before migrating. This backup file will be named "
                 "<wallet name>-<timestamp>.legacy.bak and can be found in the directory for this wallet. In the event of "
-                "an incorrect migration, the backup can be restored with the \"Restore Wallet\" functionality."));
+                "an incorrect migration, the backup can be restored with the \"Restore Wallet\" functionality.\n\n"
+                "After migration, the wallet will be rescanned for transactions. Depending on the size of the blockchain "
+                "and whether block filter indexes are available, this rescan may take a significant amount of time."));
     box.setStandardButtons(QMessageBox::Yes|QMessageBox::Cancel);
     box.setDefaultButton(QMessageBox::Yes);
     if (box.exec() != QMessageBox::Yes) return;


### PR DESCRIPTION
## Problem

Fixes #930.

Migrating a legacy wallet triggers an automatic blockchain rescan
immediately after the conversion completes. Depending on chain size
and whether `-blockfilterindex` is enabled, this rescan can take
anywhere from minutes to hours. During this time the progress dialog
shows "Migrating Wallet…" with no indication that a rescan is
happening — only the debug log reveals what is going on.

## Fix

Three changes, all in `MigrateWalletActivity`:

**1 & 2 — Confirmation dialogs** (`migrate()` and
`restore_and_migrate()`): append a rescan warning to the informative
text so users know what to expect before clicking Confirm:

> After migration, the wallet will be rescanned for transactions.
> Depending on the size of the blockchain and whether block filter
> indexes are available, this rescan may take a significant amount of
> time.

**3 — Progress dialog** (`do_migrate()`): update the label from the
bare "Migrating Wallet…" to also mention the rescan, so users who are
already in the waiting phase have context:

> Migrating Wallet **name**…
>
> A blockchain rescan will follow and may take a significant amount of
> time.

## Notes

- All changes are confined to `src/qt/walletcontroller.cpp`.
- No behaviour or logic is changed — this is purely informational UI
  text.
- The rescan itself is performed inside `migrateWallet()` as a single
  blocking call; separating migration from rescan would require wallet
  backend changes and is out of scope here.