### PR TITLE
gui: Update RPC console wallet when the active wallet changes

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -826,6 +826,7 @@ void BitcoinGUI::setCurrentWallet(WalletModel* wallet_model)
 {
     if (!walletFrame || !m_wallet_controller) return;
     walletFrame->setCurrentWallet(wallet_model);
+    rpcConsole->setCurrentWallet(wallet_model);
     for (int index = 0; index < m_wallet_selector->count(); ++index) {
         if (m_wallet_selector->itemData(index).value<WalletModel*>() == wallet_model) {
             m_wallet_selector->setCurrentIndex(index);


### PR DESCRIPTION
When multiple wallets are loaded, switching the active wallet via the main window's wallet selector doesn't update the wallet used by the RPC console. Console commands keep running against the previously selected wallet, so a wallet RPC can be sent to a different wallet than the one shown as active.

The open/create/restore/migrate paths already call `RPCConsole::setCurrentWallet()`, but the main window selector was missed. Add the call to the central `setCurrentWallet()`.

To reproduce: load two wallets, switch the active wallet in the toolbar, then run a wallet command such as `getwalletinfo` in the console.
