### PR TITLE
qt, test: Run GUI tests on macOS with `minimal` QPA plugin

### DIFF
--- a/src/qt/macdockiconhandler.mm
+++ b/src/qt/macdockiconhandler.mm
@@ -20,7 +20,8 @@ bool dockClickHandler(id self, SEL _cmd, ...) {
 }
 
 void setupDockClickHandler() {
-    Class delClass = (Class)[[[NSApplication sharedApplication] delegate] class];
+    if (NSApp == nil) return;
+    Class delClass = (Class)[[NSApp delegate] class];
     SEL shouldHandle = sel_registerName("applicationShouldHandleReopen:hasVisibleWindows:");
     class_replaceMethod(delClass, shouldHandle, (IMP)dockClickHandler, "B@:");
 }
@@ -49,5 +50,6 @@ void MacDockIconHandler::cleanup()
  */
 void ForceActivation()
 {
-    [[NSApplication sharedApplication] activateIgnoringOtherApps:YES];
+    if (NSApp == nil) return;
+    [NSApp activateIgnoringOtherApps:YES];
 }

--- a/src/qt/test/addressbooktests.cpp
+++ b/src/qt/test/addressbooktests.cpp
@@ -212,16 +212,5 @@ void TestAddAddressesToSendBook(interfaces::Node& node)
 
 void AddressBookTests::addressBookTests()
 {
-#ifdef Q_OS_MACOS
-    if (QApplication::platformName() == "minimal") {
-        // Disable for mac on "minimal" platform to avoid crashes inside the Qt
-        // framework when it tries to look up unimplemented cocoa functions,
-        // and fails to handle returned nulls
-        // (https://bugreports.qt.io/browse/QTBUG-49686).
-        qWarning() << "Skipping AddressBookTests on mac build with 'minimal' platform set due to Qt bugs. To run AppTests, invoke "
-                      "with 'QT_QPA_PLATFORM=cocoa test_bitcoin-qt' on mac, or else use a linux or windows build.";
-        return;
-    }
-#endif
     TestAddAddressesToSendBook(m_node);
 }

--- a/src/qt/test/apptests.cpp
+++ b/src/qt/test/apptests.cpp
@@ -54,18 +54,6 @@ void TestRpcCommand(RPCConsole* console)
 //! Entry point for BitcoinApplication tests.
 void AppTests::appTests()
 {
-#ifdef Q_OS_MACOS
-    if (QApplication::platformName() == "minimal") {
-        // Disable for mac on "minimal" platform to avoid crashes inside the Qt
-        // framework when it tries to look up unimplemented cocoa functions,
-        // and fails to handle returned nulls
-        // (https://bugreports.qt.io/browse/QTBUG-49686).
-        qWarning() << "Skipping AppTests on mac build with 'minimal' platform set due to Qt bugs. To run AppTests, invoke "
-                      "with 'QT_QPA_PLATFORM=cocoa test_bitcoin-qt' on mac, or else use a linux or windows build.";
-        return;
-    }
-#endif
-
     qRegisterMetaType<interfaces::BlockAndHeaderTipInfo>("interfaces::BlockAndHeaderTipInfo");
     m_app.parameterSetup();
     QVERIFY(m_app.createOptionsModel(/*resetSettings=*/true));

--- a/src/qt/test/wallettests.cpp
+++ b/src/qt/test/wallettests.cpp
@@ -455,16 +455,5 @@ void TestGUI(interfaces::Node& node)
 
 void WalletTests::walletTests()
 {
-#ifdef Q_OS_MACOS
-    if (QApplication::platformName() == "minimal") {
-        // Disable for mac on "minimal" platform to avoid crashes inside the Qt
-        // framework when it tries to look up unimplemented cocoa functions,
-        // and fails to handle returned nulls
-        // (https://bugreports.qt.io/browse/QTBUG-49686).
-        qWarning() << "Skipping WalletTests on mac build with 'minimal' platform set due to Qt bugs. To run AppTests, invoke "
-                      "with 'QT_QPA_PLATFORM=cocoa test_bitcoin-qt' on mac, or else use a linux or windows build.";
-        return;
-    }
-#endif
     TestGUI(m_node);
 }


### PR DESCRIPTION
On macOS, `test_bitcoin-qt` has skipped `AppTests`, `WalletTests`, and `AddressBookTests` under the `minimal` QPA plugin since https://github.com/bitcoin/bitcoin/commit/a3197c5294df4711bab0ff6dcdd061ceab115c7d (2018, Qt 5.11), pointing to [QTBUG-49686](https://qt-project.atlassian.net/browse/QTBUG-49686).

The recent re-evaluation of the Bitcoin Core codebase showed that the Qt bug report is no longer relevant. The remaining causes were in our own code, and they are fixed in the first commit.