### PR TITLE
test: Nudge toward QT_STYLE_OVERRIDE=fusion on macOS

### DIFF
--- a/src/qt/test/test_main.cpp
+++ b/src/qt/test/test_main.cpp
@@ -60,11 +60,11 @@ int main(int argc, char* argv[])
     // Prefer the "minimal" platform for the test instead of the normal default
     // platform ("xcb", "windows", or "cocoa") so tests can't unintentionally
     // interfere with any background GUIs and don't require extra resources.
-    #if defined(WIN32)
-        if (getenv("QT_QPA_PLATFORM") == nullptr) _putenv_s("QT_QPA_PLATFORM", "minimal");
-    #else
-        setenv("QT_QPA_PLATFORM", "minimal", 0 /* overwrite */);
-    #endif
+#if defined(WIN32)
+    if (getenv("QT_QPA_PLATFORM") == nullptr) _putenv_s("QT_QPA_PLATFORM", "minimal");
+#else
+    setenv("QT_QPA_PLATFORM", "minimal", 0 /* overwrite */);
+#endif
 
 
     QCoreApplication::setOrganizationName(QAPP_ORG_NAME);

--- a/src/qt/test/test_main.cpp
+++ b/src/qt/test/test_main.cpp
@@ -66,6 +66,12 @@ int main(int argc, char* argv[])
     setenv("QT_QPA_PLATFORM", "minimal", 0 /* overwrite */);
 #endif
 
+#ifdef Q_OS_MACOS
+    // QMacStyle assumes a Cocoa platform window, which the minimal platform
+    // does not provide. In particular, painting a QGroupBox can make Qt call
+    // addSubview: on an invalid native object (QTBUG-49686).
+    setenv("QT_STYLE_OVERRIDE", "fusion", 0 /* overwrite */);
+#endif
 
     QCoreApplication::setOrganizationName(QAPP_ORG_NAME);
     QCoreApplication::setApplicationName(QAPP_APP_NAME_DEFAULT "-test");


### PR DESCRIPTION
Fixes https://github.com/bitcoin/bitcoin/issues/35771

Using the Fusion style works around QTBUG-49686.

Otherwise, there could be an invalid call under the QMacStyle.

Can be tested via:

```
QT_STYLE_OVERRIDE=macOS  build/bin/test_bitcoin-qt  # fails
QT_STYLE_OVERRIDE=fusion build/bin/test_bitcoin-qt  # passes
```

