### PR TITLE
Adds non-mempool wallet balance to overview

### DIFF
--- a/doc/release-notes-911.md
+++ b/doc/release-notes-911.md
@@ -1,0 +1,4 @@
+GUI Changes
+---
+
+The Overview page now displays a "On hold:" balance row showing funds that would be spent if wallet transactions currently outside the mempool were to confirm. This row is only shown when non-mempool wallet transactions are present.

--- a/src/qt/bitcoinunits.cpp
+++ b/src/qt/bitcoinunits.cpp
@@ -146,7 +146,6 @@ QString BitcoinUnits::formatHtmlWithUnit(Unit unit, const CAmount& amount, bool 
 
 QString BitcoinUnits::formatWithPrivacy(Unit unit, const CAmount& amount, SeparatorStyle separators, bool privacy)
 {
-    assert(amount >= 0);
     QString value;
     if (privacy) {
         value = format(unit, 0, false, separators, true).replace('0', '#');

--- a/src/qt/bitcoinunits.cpp
+++ b/src/qt/bitcoinunits.cpp
@@ -93,9 +93,6 @@ QString BitcoinUnits::format(Unit unit, const CAmount& nIn, bool fPlus, Separato
     qint64 n_abs = (n > 0 ? n : -n);
     qint64 quotient = n_abs / coin;
     QString quotient_str = QString::number(quotient);
-    if (justify) {
-        quotient_str = quotient_str.rightJustified(MAX_DIGITS_BTC - num_decimals, ' ');
-    }
 
     // Use SI-style thin space separators as these are locale independent and can't be
     // confused with the decimal marker.
@@ -109,6 +106,13 @@ QString BitcoinUnits::format(Unit unit, const CAmount& nIn, bool fPlus, Separato
         quotient_str.insert(0, '-');
     else if (fPlus && n > 0)
         quotient_str.insert(0, '+');
+
+    // Right-justify after the sign is prepended, so that the sign stays
+    // adjacent to the most significant digit rather than being separated
+    // from it by the justification padding.
+    if (justify) {
+        quotient_str = quotient_str.rightJustified(MAX_DIGITS_BTC - num_decimals, ' ');
+    }
 
     if (num_decimals > 0) {
         qint64 remainder = n_abs % coin;

--- a/src/qt/forms/overviewpage.ui
+++ b/src/qt/forms/overviewpage.ui
@@ -130,14 +130,14 @@
               </property>
              </widget>
             </item>
-            <item row="3" column="0" colspan="2">
+            <item row="4" column="0" colspan="2">
              <widget class="Line" name="line">
               <property name="orientation">
                <enum>Qt::Horizontal</enum>
               </property>
              </widget>
             </item>
-            <item row="4" column="0">
+            <item row="5" column="0">
              <widget class="QLabel" name="labelTotalText">
               <property name="text">
                <string>Total:</string>
@@ -183,7 +183,33 @@
               </property>
              </widget>
             </item>
-            <item row="4" column="1">
+            <item row="3" column="1">
+             <widget class="QLabel" name="labelNonMempool">
+              <property name="cursor">
+               <cursorShape>IBeamCursor</cursorShape>
+              </property>
+              <property name="toolTip">
+               <string>Wallet transactions not currently in the mempool — due to policy rejection or deliberate delay.</string>
+              </property>
+              <property name="text">
+               <string notr="true">0.00000000 BTC</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+              </property>
+              <property name="textInteractionFlags">
+               <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+              </property>
+             </widget>
+            </item>
+            <item row="3" column="0">
+             <widget class="QLabel" name="labelNonMempoolText">
+              <property name="text">
+               <string>On hold:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="5" column="1">
              <widget class="QLabel" name="labelTotal">
               <property name="cursor">
                <cursorShape>IBeamCursor</cursorShape>

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -190,13 +190,22 @@ void OverviewPage::setBalance(const interfaces::WalletBalances& balances)
     ui->labelBalance->setText(BitcoinUnits::formatWithPrivacy(unit, balances.balance, BitcoinUnits::SeparatorStyle::ALWAYS, m_privacy));
     ui->labelUnconfirmed->setText(BitcoinUnits::formatWithPrivacy(unit, balances.unconfirmed_balance, BitcoinUnits::SeparatorStyle::ALWAYS, m_privacy));
     ui->labelImmature->setText(BitcoinUnits::formatWithPrivacy(unit, balances.immature_balance, BitcoinUnits::SeparatorStyle::ALWAYS, m_privacy));
-    ui->labelTotal->setText(BitcoinUnits::formatWithPrivacy(unit, balances.balance + balances.unconfirmed_balance + balances.immature_balance, BitcoinUnits::SeparatorStyle::ALWAYS, m_privacy));
+    ui->labelNonMempool->setText(BitcoinUnits::formatWithPrivacy(unit, balances.nonmempool_balance, BitcoinUnits::SeparatorStyle::ALWAYS, m_privacy));
+    ui->labelNonMempool->setStyleSheet("QLabel { color: " + COLOR_NEGATIVE.name() + "; }");
+    ui->labelTotal->setText(BitcoinUnits::formatWithPrivacy(unit, balances.balance + balances.unconfirmed_balance + balances.immature_balance + balances.nonmempool_balance, BitcoinUnits::SeparatorStyle::ALWAYS, m_privacy));
     // only show immature (newly mined) balance if it's non-zero, so as not to complicate things
     // for the non-mining users
     bool showImmature = balances.immature_balance != 0;
 
     ui->labelImmature->setVisible(showImmature);
     ui->labelImmatureText->setVisible(showImmature);
+
+    // likewise for non-mempool balances
+    Assert(balances.nonmempool_balance <= 0);
+    bool showNonMempool = balances.nonmempool_balance < 0;
+
+    ui->labelNonMempool->setVisible(showNonMempool);
+    ui->labelNonMempoolText->setVisible(showNonMempool);
 }
 
 void OverviewPage::setClientModel(ClientModel *model)
@@ -296,5 +305,6 @@ void OverviewPage::setMonospacedFont(const QFont& f)
     ui->labelBalance->setFont(f);
     ui->labelUnconfirmed->setFont(f);
     ui->labelImmature->setFont(f);
+    ui->labelNonMempool->setFont(f);
     ui->labelTotal->setFont(f);
 }

--- a/src/qt/test/wallettests.cpp
+++ b/src/qt/test/wallettests.cpp
@@ -297,7 +297,7 @@ void TestGUI(interfaces::Node& node, const std::shared_ptr<CWallet>& wallet)
     OverviewPage overviewPage(platformStyle.get());
     overviewPage.setWalletModel(&walletModel);
     walletModel.pollBalanceChanged(); // Manual balance polling update
-    CompareBalance(walletModel, walletModel.wallet().getBalance(), overviewPage.findChild<QLabel*>("labelBalance"));
+    CompareBalance(walletModel, walletModel.wallet().getBalances().balance, overviewPage.findChild<QLabel*>("labelBalance"));
 
     // Check Request Payment button
     ReceiveCoinsDialog receiveCoinsDialog(platformStyle.get());

--- a/src/qt/test/wallettests.cpp
+++ b/src/qt/test/wallettests.cpp
@@ -299,6 +299,20 @@ void TestGUI(interfaces::Node& node, const std::shared_ptr<CWallet>& wallet)
     walletModel.pollBalanceChanged(); // Manual balance polling update
     CompareBalance(walletModel, walletModel.wallet().getBalances().balance, overviewPage.findChild<QLabel*>("labelBalance"));
 
+    // Test non-mempool balance display
+    overviewPage.show();
+    interfaces::WalletBalances nonmempool_balances;
+    nonmempool_balances.balance = walletModel.wallet().getBalances().balance;
+    nonmempool_balances.nonmempool_balance = -50000;
+    overviewPage.setBalance(nonmempool_balances);
+    QVERIFY(overviewPage.findChild<QLabel*>("labelNonMempool")->isVisible());
+    QVERIFY(overviewPage.findChild<QLabel*>("labelNonMempoolText")->isVisible());
+    CompareBalance(walletModel, -50000, overviewPage.findChild<QLabel*>("labelNonMempool"));
+    nonmempool_balances.nonmempool_balance = 0;
+    overviewPage.setBalance(nonmempool_balances);
+    QVERIFY(!overviewPage.findChild<QLabel*>("labelNonMempool")->isVisible());
+    QVERIFY(!overviewPage.findChild<QLabel*>("labelNonMempoolText")->isVisible());
+
     // Check Request Payment button
     ReceiveCoinsDialog receiveCoinsDialog(platformStyle.get());
     receiveCoinsDialog.setModel(&walletModel);

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -374,7 +374,7 @@ public:
     }
     WalletBalances getBalances() override
     {
-        const auto bal = GetBalance(*m_wallet);
+        const auto bal = GetBalance(*m_wallet, /*min_depth=*/0, /*avoid_reuse=*/true, /*include_nonmempool=*/true);
         WalletBalances result;
         result.balance = bal.m_mine_trusted;
         result.unconfirmed_balance = bal.m_mine_untrusted_pending;


### PR DESCRIPTION
Just grabbing #911

Copying the motivation from AJ's description:

The wallet can contain transactions that are not accepted into the node's mempool (eg due to containing a too large OP_RETURN output, due to too low a feerate, or due to too many unconfirmed ancestors). In the event you end up in this situation, it can appear as if funds have gone missing from your wallet due to the non-mempool balance not being reported. Correct this by reporting the non-mempool balance.

See https://github.com/bitcoin/bitcoin/pull/33671 for further context.


The changes look like:

<img width="372" height="239" alt="imagen" src="https://github.com/user-attachments/assets/2adab476-0db1-4354-9e51-ddddca26c61a" />



### How to test

To test, start with `-datacarriersize=10`, and run

```
send '{"data": "4368616e63656c6c6f72206f6e206272696e6b206f66207365636f6e64206261696c6f757420666f722062616e6b73"}' null "unset" 1
```

from the console. "Non-mempool: <change amount>" should appear in the Balances pane on the Overview window with the change from the transaction. Restarting with `-datacarriersize=100000` should allow the tx to enter the mempool, and move the amount into the Available balance. (Presumably, do this on -regtest after generating 100 blocks; or perhaps signet after grabbing some funds from a faucet)