### PR TITLE
qt: filter addhdkey from RPC console history

### DIFF
--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -73,6 +73,7 @@ namespace {
 
 // don't add private key handling cmd's to the history
 const QStringList historyFilter = QStringList()
+    << "addhdkey"
     << "createwallet"
     << "createwalletdescriptor"
     << "migratewallet"

--- a/src/qt/test/rpcnestedtests.cpp
+++ b/src/qt/test/rpcnestedtests.cpp
@@ -85,6 +85,8 @@ void RPCNestedTests::rpcNestedTests()
     QVERIFY(result == "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
     QVERIFY(filtered == "getblock(getbestblockhash())[tx][0]");
 
+    RPCConsole::RPCParseCommandLine(nullptr, result, "addhdkey abc", /*fExecute=*/false, &filtered);
+    QVERIFY(filtered == "addhdkey(…)");
     RPCConsole::RPCParseCommandLine(nullptr, result, "createwallet test true", false, &filtered);
     QVERIFY(filtered == "createwallet(…)");
     RPCConsole::RPCParseCommandLine(nullptr, result, "createwalletdescriptor abc", false, &filtered);


### PR DESCRIPTION
Filters `addhdkey` arguments from RPC console history, consistent with other RPCs that handle private key material.

This prevents extended private keys from being retained in history. It also covers the mnemonic and passphrase inputs proposed in bitcoin/bitcoin#35857.

Adds a parser test verifying that the arguments are redacted.

## Motivation

`addhdkey` accepts a BIP 32 extended private key, but its arguments are currently retained in RPC console history, unlike other RPCs that handle private key material.

The same filter would also protect the mnemonic and passphrase inputs proposed in bitcoin/bitcoin#35857.

## Changes

- Add `addhdkey` to the RPC console sensitive-command filter.
- Add a parser test verifying that its arguments are redacted as `addhdkey(…)`.

## Tests

- `./build_gui/bin/test_bitcoin-qt` — all tests passed, including `RPCNestedTests::rpcNestedTests()`.