### PR TITLE
fix: add .dat file extension automatically when exporting watchonly

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -444,7 +444,7 @@ void BitcoinGUI::createActions()
             //: The title for Restore Wallet File Windows
             QString title_windows = tr("Load Wallet Backup");
 
-            QString backup_file = GUIUtil::getOpenFileName(this, title_windows, QString(), name_data_file + QLatin1String(" (*.dat)"), nullptr);
+            QString backup_file = GUIUtil::getOpenFileName(this, title_windows, QString(), name_data_file +  QLatin1String(" (*.dat *.wallet);;") + tr("All Files") + QLatin1String(" (*)"), nullptr);
             if (backup_file.isEmpty()) return;
 
             bool wallet_name_ok;

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -529,7 +529,11 @@ void BitcoinGUI::createActions()
         connect(m_mask_values_action, &QAction::toggled, this, &BitcoinGUI::setPrivacy);
         connect(m_mask_values_action, &QAction::toggled, this, &BitcoinGUI::enableHistoryAction);
         GUIUtil::ExceptionSafeConnect(m_export_watchonly_action, &QAction::triggered, [this](bool) {
-            QString destination = GUIUtil::getSaveFileName(this, tr("Save Watch-only Wallet Export"), QString(), QString(), nullptr);
+            QString destination = GUIUtil::getSaveFileName(this,
+                tr("Save Watch-only Wallet Export"), QString(),
+                //: Name of the wallet data file format.
+                tr("Wallet Data") + QLatin1String(" (*.dat)"), nullptr);
+
             if (destination.isEmpty()) return;
             WalletModel* model = walletFrame->currentWalletModel();
             if (!Assume(model)) return;


### PR DESCRIPTION
fixes https://github.com/bitcoin-core/gui/issues/956

Unlike `backup wallet`, `export watch-only wallet` was not automatically adding the file extension to the exported file, making restoring difficult if the user doesn't manually add the file extension after exporting.

Allows also to restore a wallet from a non specified `.dat` file extension. This is achieved by removing the filter in the select file screen, matching the RPC behavior.